### PR TITLE
Fixes issue of `db_test.go`'s database growing to unbounded size during tests.

### DIFF
--- a/modules/db/db.go
+++ b/modules/db/db.go
@@ -28,7 +28,7 @@ func New() *db {
 }
 
 func (db *db) Init() error {
-	err := os.MkdirAll("data/", os.ModeDir)
+	err := os.MkdirAll("data/", 0755)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Changes

- Before, `db_test.go`'s database grew without bounds. Now, after each test it clears itself.
- Before, database `data/` file was created in a way that when someone else cloned the repository, they wouldn't have permissions for it, causing them to `chmod` it to solve a mysterious "out of memory" error SQLite threw. Now, it has enough perms.