### PR TITLE
Fix wrong asset in tx oplog for consensus_stake and consensus_unstake

### DIFF
--- a/modules/state-processing/ledger_system.go
+++ b/modules/state-processing/ledger_system.go
@@ -878,7 +878,7 @@ func (le *LedgerExecutor) ConsensusStake(params ledgerSystem.ConsensusParams, le
 		BlockHeight: params.BlockHeight,
 
 		Amount: params.Amount,
-		Asset:  "hbd",
+		Asset:  "hive",
 		Type:   "consensus_stake",
 	})
 
@@ -896,7 +896,7 @@ func (le *LedgerExecutor) ConsensusUnstake(params ledgerSystem.ConsensusParams, 
 		BlockHeight: params.BlockHeight,
 
 		Amount: params.Amount,
-		Asset:  "hbd",
+		Asset:  "hive",
 		Type:   "consensus_unstake",
 
 		Params: map[string]interface{}{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated staking and unstaking ledger entries to display HIVE assets instead of HBD, ensuring that transaction records accurately reflect the correct asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->