### PR TITLE
CID lookup GraphQL method

### DIFF
--- a/cmd/vsc-node/main.go
+++ b/cmd/vsc-node/main.go
@@ -135,6 +135,7 @@ func main() {
 		txpool,
 		balanceDb,
 		se,
+		da,
 	}}), "0.0.0.0:8080")
 
 	plugins := make([]aggregate.Plugin, 0)

--- a/modules/gql/gql_test.go
+++ b/modules/gql/gql_test.go
@@ -69,6 +69,7 @@ func TestQueryAndMutation(t *testing.T) {
 		txPool,
 		balances,
 		se,
+		da,
 	}
 	schema := gqlgen.NewExecutableSchema(gqlgen.Config{Resolvers: resolver})
 

--- a/modules/gql/gqlgen/resolver.go
+++ b/modules/gql/gqlgen/resolver.go
@@ -1,6 +1,7 @@
 package gqlgen
 
 import (
+	"vsc-node/lib/datalayer"
 	ledgerDb "vsc-node/modules/db/vsc/ledger"
 	"vsc-node/modules/db/vsc/witnesses"
 	stateEngine "vsc-node/modules/state-processing"
@@ -16,4 +17,5 @@ type Resolver struct {
 	TxPool      *transactionpool.TransactionPool
 	Balances    ledgerDb.Balances
 	StateEngine *stateEngine.StateEngine
+	Da          *datalayer.DataLayer
 }

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -205,8 +205,8 @@ func (r *queryResolver) WitnessStake(ctx context.Context, account string) (model
 	return model.Uint64(res.HIVE_CONSENSUS), nil
 }
 
-// FindCid is the resolver for the findCID field.
-func (r *queryResolver) FindCid(ctx context.Context, cidString string) (string, error) {
+// GetDagByCid is the resolver for the getDagByCID field.
+func (r *queryResolver) GetDagByCid(ctx context.Context, cidString string) (string, error) {
 	blockCid, parseErr := cid.Parse(cidString)
 	if parseErr != nil {
 		return "", parseErr

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -14,6 +14,8 @@ import (
 	"vsc-node/modules/gql/model"
 	stateEngine "vsc-node/modules/state-processing"
 	transactionpool "vsc-node/modules/transaction-pool"
+
+	"github.com/ipfs/go-cid"
 )
 
 // AnchoredBlock is the resolver for the anchored_block field.
@@ -201,6 +203,23 @@ func (r *queryResolver) WitnessStake(ctx context.Context, account string) (model
 		return 0, nil
 	}
 	return model.Uint64(res.HIVE_CONSENSUS), nil
+}
+
+// FindCid is the resolver for the findCID field.
+func (r *queryResolver) FindCid(ctx context.Context, cidString string) (string, error) {
+	blockCid, parseErr := cid.Parse(cidString)
+	if parseErr != nil {
+		return "", parseErr
+	}
+	node, nodeErr := r.Da.GetDag(blockCid)
+	if nodeErr != nil {
+		return "", nodeErr
+	}
+	jsonBytes, jsonErr := node.MarshalJSON()
+	if jsonErr != nil {
+		return "", jsonErr
+	}
+	return string(jsonBytes), nil
 }
 
 // IpfsPeerID is the resolver for the ipfs_peer_id field.

--- a/modules/gql/schema.graphql
+++ b/modules/gql/schema.graphql
@@ -265,7 +265,7 @@ type Query {
   anchorProducer: AnchorProducer
   getCurrentNumber: TestResult # TESTING QUERY
   witnessStake(account: String!): Uint64!
-  findCID(cidString: String!): JSON!
+  getDagByCID(cidString: String!): JSON!
 }
 
 scalar Uint64

--- a/modules/gql/schema.graphql
+++ b/modules/gql/schema.graphql
@@ -265,6 +265,7 @@ type Query {
   anchorProducer: AnchorProducer
   getCurrentNumber: TestResult # TESTING QUERY
   witnessStake(account: String!): Uint64!
+  findCID(cidString: String!): JSON!
 }
 
 scalar Uint64


### PR DESCRIPTION
This will be very helpful for retrieving block transactions/output/oplog data for VSC Blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new GraphQL query that allows clients to fetch node data by providing a content identifier. The query returns the corresponding information in a JSON format, enhancing data retrieval capabilities through the API.
	- Added support for a data layer instance in the GraphQL resolver, expanding its functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->