### PR TITLE
Account balance, election, witness nodes GraphQL query

### DIFF
--- a/cmd/vsc-node/main.go
+++ b/cmd/vsc-node/main.go
@@ -134,6 +134,7 @@ func main() {
 		witnessDb,
 		txpool,
 		balanceDb,
+		hiveBlocks,
 		se,
 		da,
 	}}), "0.0.0.0:8080")

--- a/cmd/vsc-node/main.go
+++ b/cmd/vsc-node/main.go
@@ -134,6 +134,7 @@ func main() {
 		witnessDb,
 		txpool,
 		balanceDb,
+		electionDb,
 		hiveBlocks,
 		se,
 		da,

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -33,8 +33,14 @@ models:
   Uint64:
     model:
       - vsc-node/modules/gql/model.Uint64
+  Int64:
+    model:
+      - vsc-node/modules/gql/model.Int64
   WitnessSlot:
     model:
       - vsc-node/modules/state-processing.WitnessSlot
+  BalanceRecord:
+    model:
+      - vsc-node/modules/db/vsc/ledger.BalanceRecord
 
 call_argument_directives_with_null: true

--- a/modules/db/reindex.go
+++ b/modules/db/reindex.go
@@ -9,7 +9,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-var REINDEX_ID = 3
+var REINDEX_ID = 4
 
 var IMMUTABLE_COLLECTIONS = []string{
 	"hive_blocks",

--- a/modules/db/vsc/elections/elections_test.go
+++ b/modules/db/vsc/elections/elections_test.go
@@ -66,6 +66,7 @@ func TestGetElectionByHeight(t *testing.T) {
 	electionMock.Weights = []uint64{
 		42069,
 	}
+	electionMock.TxId = "0123456789abcdef0123456789abcdef01234567"
 
 	err = e.StoreElection(electionMock)
 	assert.NoError(t, err)

--- a/modules/db/vsc/elections/schema.go
+++ b/modules/db/vsc/elections/schema.go
@@ -33,6 +33,7 @@ type ElectionResult struct {
 	TotalWeight uint64 `json:"total_weight" refmt:"total_weight" bson:"total_weight"`
 	BlockHeight uint64 `json:"block_height" refmt:"block_height" bson:"block_height"`
 	Proposer    string `json:"proposer" refmt:"proposer" bson:"proposer"`
+	TxId        string `json:"tx_id" refmt:"tx_id" bson:"tx_id"`
 }
 
 type ElectionResultRecord struct {
@@ -46,6 +47,7 @@ type ElectionResultRecord struct {
 	BlockHeight     uint64           `json:"block_height" refmt:"block_height" bson:"block_height"`
 	Proposer        string           `json:"proposer" refmt:"proposer" bson:"proposer"`
 	Type            string           `json:"type" refmt:"type" bson:"type"`
+	TxId            string           `json:"tx_id" refmt:"tx_id" bson:"tx_id"`
 }
 
 type ElectionMember struct {

--- a/modules/db/vsc/ledger/types.go
+++ b/modules/db/vsc/ledger/types.go
@@ -43,15 +43,15 @@ type ClaimRecord struct {
 }
 
 type BalanceRecord struct {
-	Account           string `bson:"account"`
-	BlockHeight       uint64 `bson:"block_height"`
-	Hive              int64  `bson:"hive"`
-	HIVE_CONSENSUS    int64  `bson:"hive_consensus"`
-	HBD               int64  `bson:"hbd"`
-	HBD_SAVINGS       int64  `bson:"hbd_savings"`
-	HBD_AVG           int64  `bson:"hbd_avg"`
-	HBD_CLAIM_HEIGHT  uint64 `bson:"hbd_claim,omitempty"`
-	HBD_MODIFY_HEIGHT uint64 `bson:"hbd_modify,omitempty"`
+	Account           string `json:"account" bson:"account"`
+	BlockHeight       uint64 `json:"block_height" bson:"block_height"`
+	Hive              int64  `json:"hive" bson:"hive"`
+	HIVE_CONSENSUS    int64  `json:"hive_consensus" bson:"hive_consensus"`
+	HBD               int64  `json:"hbd" bson:"hbd"`
+	HBD_SAVINGS       int64  `json:"hbd_savings" bson:"hbd_savings"`
+	HBD_AVG           int64  `json:"hbd_avg" bson:"hbd_avg"`
+	HBD_CLAIM_HEIGHT  uint64 `json:"hbd_claim" bson:"hbd_claim,omitempty"`
+	HBD_MODIFY_HEIGHT uint64 `json:"hbd_modify" bson:"hbd_modify,omitempty"`
 }
 
 // {

--- a/modules/db/vsc/ledger/types.go
+++ b/modules/db/vsc/ledger/types.go
@@ -50,8 +50,8 @@ type BalanceRecord struct {
 	HBD               int64  `json:"hbd" bson:"hbd"`
 	HBD_SAVINGS       int64  `json:"hbd_savings" bson:"hbd_savings"`
 	HBD_AVG           int64  `json:"hbd_avg" bson:"hbd_avg"`
-	HBD_CLAIM_HEIGHT  uint64 `json:"hbd_claim" bson:"hbd_claim,omitempty"`
-	HBD_MODIFY_HEIGHT uint64 `json:"hbd_modify" bson:"hbd_modify,omitempty"`
+	HBD_CLAIM_HEIGHT  uint64 `json:"hbd_claim,omitempty" bson:"hbd_claim,omitempty"`
+	HBD_MODIFY_HEIGHT uint64 `json:"hbd_modify,omitempty" bson:"hbd_modify,omitempty"`
 }
 
 // {

--- a/modules/db/vsc/witnesses/schema.go
+++ b/modules/db/vsc/witnesses/schema.go
@@ -10,6 +10,7 @@ type Witness struct {
 	PeerId          string            `json:"peer_id" bson:"peer_id"`
 	ProtocolVersion uint64            `json:"protocol_version" bson:"protocol_version"`
 	Ts              string            `json:"ts" bson:"ts"`
+	TxId            string            `json:"tx_id" bson:"tx_id"`
 	VersionId       string            `json:"version_id" bson:"version_id"`
 	GatewayKey      string            `json:"gateway_key" bson:"gateway_key"`
 }

--- a/modules/db/vsc/witnesses/witnesses.go
+++ b/modules/db/vsc/witnesses/witnesses.go
@@ -53,6 +53,7 @@ func (w *witnesses) SetWitnessUpdate(requestIn SetWitnessUpdateType) error {
 			"peer_addrs": request.Metadata.VscNode.PeerAddrs,
 			//timestamp
 			"ts":               request.Metadata.VscNode.Ts,
+			"tx_id":            request.TxId,
 			"version_id":       request.Metadata.VscNode.VersionId,
 			"git_commit":       request.Metadata.VscNode.GitCommit,
 			"net_id":           request.Metadata.VscNode.NetId,

--- a/modules/gql/gql_test.go
+++ b/modules/gql/gql_test.go
@@ -68,6 +68,7 @@ func TestQueryAndMutation(t *testing.T) {
 		witnesses,
 		txPool,
 		balances,
+		electionDb,
 		hiveBlocks,
 		se,
 		da,

--- a/modules/gql/gql_test.go
+++ b/modules/gql/gql_test.go
@@ -68,6 +68,7 @@ func TestQueryAndMutation(t *testing.T) {
 		witnesses,
 		txPool,
 		balances,
+		hiveBlocks,
 		se,
 		da,
 	}

--- a/modules/gql/gqlgen/generated.go
+++ b/modules/gql/gqlgen/generated.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"vsc-node/modules/db/vsc/contracts"
+	"vsc-node/modules/db/vsc/elections"
 	ledgerDb "vsc-node/modules/db/vsc/ledger"
 	"vsc-node/modules/db/vsc/witnesses"
 	"vsc-node/modules/gql/model"
@@ -45,6 +46,7 @@ type ResolverRoot interface {
 	BalanceRecord() BalanceRecordResolver
 	ContractOutput() ContractOutputResolver
 	ContractState() ContractStateResolver
+	ElectionResult() ElectionResultResolver
 	Mutation() MutationResolver
 	Query() QueryResolver
 	Witness() WitnessResolver
@@ -115,6 +117,25 @@ type ComplexityRoot struct {
 		StateKeys   func(childComplexity int, key *string) int
 		StateMerkle func(childComplexity int) int
 		StateQuery  func(childComplexity int, key *string, query *string) int
+	}
+
+	ElectionMember struct {
+		Account func(childComplexity int) int
+		Key     func(childComplexity int) int
+	}
+
+	ElectionResult struct {
+		BlockHeight     func(childComplexity int) int
+		Data            func(childComplexity int) int
+		Epoch           func(childComplexity int) int
+		Members         func(childComplexity int) int
+		NetId           func(childComplexity int) int
+		Proposer        func(childComplexity int) int
+		ProtocolVersion func(childComplexity int) int
+		TotalWeight     func(childComplexity int) int
+		TxId            func(childComplexity int) int
+		Type            func(childComplexity int) int
+		Weights         func(childComplexity int) int
 	}
 
 	FindContractOutputResult struct {
@@ -188,6 +209,7 @@ type ComplexityRoot struct {
 		GetAccountNonce      func(childComplexity int, keyGroup []*string) int
 		GetCurrentNumber     func(childComplexity int) int
 		GetDagByCid          func(childComplexity int, cidString string) int
+		GetElection          func(childComplexity int, epoch model.Uint64) int
 		LocalNodeInfo        func(childComplexity int) int
 		MockGenerateElection func(childComplexity int) int
 		NextWitnessSlot      func(childComplexity int, self *bool) int
@@ -280,6 +302,14 @@ type ContractStateResolver interface {
 	StateKeys(ctx context.Context, obj contracts.ContractState, key *string) (*string, error)
 	StateMerkle(ctx context.Context, obj contracts.ContractState) (*string, error)
 }
+type ElectionResultResolver interface {
+	Epoch(ctx context.Context, obj *elections.ElectionResult) (model.Uint64, error)
+
+	Weights(ctx context.Context, obj *elections.ElectionResult) ([]model.Uint64, error)
+	ProtocolVersion(ctx context.Context, obj *elections.ElectionResult) (model.Uint64, error)
+	TotalWeight(ctx context.Context, obj *elections.ElectionResult) (model.Uint64, error)
+	BlockHeight(ctx context.Context, obj *elections.ElectionResult) (model.Uint64, error)
+}
 type MutationResolver interface {
 	IncrementNumber(ctx context.Context) (*TestResult, error)
 }
@@ -304,6 +334,7 @@ type QueryResolver interface {
 	GetCurrentNumber(ctx context.Context) (*TestResult, error)
 	WitnessStake(ctx context.Context, account string) (model.Uint64, error)
 	GetDagByCid(ctx context.Context, cidString string) (string, error)
+	GetElection(ctx context.Context, epoch model.Uint64) (*elections.ElectionResult, error)
 }
 type WitnessResolver interface {
 	IpfsPeerID(ctx context.Context, obj *witnesses.Witness) (*string, error)
@@ -598,6 +629,97 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ContractState.StateQuery(childComplexity, args["key"].(*string), args["query"].(*string)), true
+
+	case "ElectionMember.account":
+		if e.complexity.ElectionMember.Account == nil {
+			break
+		}
+
+		return e.complexity.ElectionMember.Account(childComplexity), true
+
+	case "ElectionMember.key":
+		if e.complexity.ElectionMember.Key == nil {
+			break
+		}
+
+		return e.complexity.ElectionMember.Key(childComplexity), true
+
+	case "ElectionResult.block_height":
+		if e.complexity.ElectionResult.BlockHeight == nil {
+			break
+		}
+
+		return e.complexity.ElectionResult.BlockHeight(childComplexity), true
+
+	case "ElectionResult.data":
+		if e.complexity.ElectionResult.Data == nil {
+			break
+		}
+
+		return e.complexity.ElectionResult.Data(childComplexity), true
+
+	case "ElectionResult.epoch":
+		if e.complexity.ElectionResult.Epoch == nil {
+			break
+		}
+
+		return e.complexity.ElectionResult.Epoch(childComplexity), true
+
+	case "ElectionResult.members":
+		if e.complexity.ElectionResult.Members == nil {
+			break
+		}
+
+		return e.complexity.ElectionResult.Members(childComplexity), true
+
+	case "ElectionResult.net_id":
+		if e.complexity.ElectionResult.NetId == nil {
+			break
+		}
+
+		return e.complexity.ElectionResult.NetId(childComplexity), true
+
+	case "ElectionResult.proposer":
+		if e.complexity.ElectionResult.Proposer == nil {
+			break
+		}
+
+		return e.complexity.ElectionResult.Proposer(childComplexity), true
+
+	case "ElectionResult.protocol_version":
+		if e.complexity.ElectionResult.ProtocolVersion == nil {
+			break
+		}
+
+		return e.complexity.ElectionResult.ProtocolVersion(childComplexity), true
+
+	case "ElectionResult.total_weight":
+		if e.complexity.ElectionResult.TotalWeight == nil {
+			break
+		}
+
+		return e.complexity.ElectionResult.TotalWeight(childComplexity), true
+
+	case "ElectionResult.tx_id":
+		if e.complexity.ElectionResult.TxId == nil {
+			break
+		}
+
+		return e.complexity.ElectionResult.TxId(childComplexity), true
+
+	case "ElectionResult.type":
+		if e.complexity.ElectionResult.Type == nil {
+			break
+		}
+
+		return e.complexity.ElectionResult.Type(childComplexity), true
+
+	case "ElectionResult.weights":
+		if e.complexity.ElectionResult.Weights == nil {
+			break
+		}
+
+		return e.complexity.ElectionResult.Weights(childComplexity), true
 
 	case "FindContractOutputResult.outputs":
 		if e.complexity.FindContractOutputResult.Outputs == nil {
@@ -902,6 +1024,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.GetDagByCid(childComplexity, args["cidString"].(string)), true
+
+	case "Query.getElection":
+		if e.complexity.Query.GetElection == nil {
+			break
+		}
+
+		args, err := ec.field_Query_getElection_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.GetElection(childComplexity, args["epoch"].(model.Uint64)), true
 
 	case "Query.localNodeInfo":
 		if e.complexity.Query.LocalNodeInfo == nil {
@@ -1539,6 +1673,25 @@ type LedgerResults {
   txs: [LedgerOp!]
 }
 
+type ElectionMember {
+  key: String!
+  account: String!
+}
+
+type ElectionResult {
+  epoch: Uint64!
+  net_id: String!
+  type: String!
+  data: String!
+  members: [ElectionMember!]!
+  weights: [Uint64!]!
+  protocol_version: Uint64!
+  total_weight: Uint64!
+  block_height: Uint64!
+  proposer: String!
+  tx_id: String!
+}
+
 input LedgerTxFilter {
   byToFrom: String
   byTxId: String
@@ -1590,6 +1743,7 @@ type Query {
   getCurrentNumber: TestResult # TESTING QUERY
   witnessStake(account: String!): Uint64!
   getDagByCID(cidString: String!): JSON!
+  getElection(epoch: Uint64!): ElectionResult
 }
 
 scalar Uint64
@@ -2002,6 +2156,29 @@ func (ec *executionContext) field_Query_getDagByCID_argsCidString(
 	}
 
 	var zeroVal string
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_getElection_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query_getElection_argsEpoch(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["epoch"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query_getElection_argsEpoch(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.Uint64, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("epoch"))
+	if tmp, ok := rawArgs["epoch"]; ok {
+		return ec.unmarshalNUint642vscᚑnodeᚋmodulesᚋgqlᚋmodelᚐUint64(ctx, tmp)
+	}
+
+	var zeroVal model.Uint64
 	return zeroVal, nil
 }
 
@@ -3776,6 +3953,584 @@ func (ec *executionContext) fieldContext_ContractState_state_merkle(_ context.Co
 		Field:      field,
 		IsMethod:   true,
 		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ElectionMember_key(ctx context.Context, field graphql.CollectedField, obj *elections.ElectionMember) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ElectionMember_key(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Key, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ElectionMember_key(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ElectionMember",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ElectionMember_account(ctx context.Context, field graphql.CollectedField, obj *elections.ElectionMember) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ElectionMember_account(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Account, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ElectionMember_account(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ElectionMember",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ElectionResult_epoch(ctx context.Context, field graphql.CollectedField, obj *elections.ElectionResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ElectionResult_epoch(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ElectionResult().Epoch(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.Uint64)
+	fc.Result = res
+	return ec.marshalNUint642vscᚑnodeᚋmodulesᚋgqlᚋmodelᚐUint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ElectionResult_epoch(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ElectionResult",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Uint64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ElectionResult_net_id(ctx context.Context, field graphql.CollectedField, obj *elections.ElectionResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ElectionResult_net_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NetId, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ElectionResult_net_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ElectionResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ElectionResult_type(ctx context.Context, field graphql.CollectedField, obj *elections.ElectionResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ElectionResult_type(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Type, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ElectionResult_type(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ElectionResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ElectionResult_data(ctx context.Context, field graphql.CollectedField, obj *elections.ElectionResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ElectionResult_data(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Data, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ElectionResult_data(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ElectionResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ElectionResult_members(ctx context.Context, field graphql.CollectedField, obj *elections.ElectionResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ElectionResult_members(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Members, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]elections.ElectionMember)
+	fc.Result = res
+	return ec.marshalNElectionMember2ᚕvscᚑnodeᚋmodulesᚋdbᚋvscᚋelectionsᚐElectionMemberᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ElectionResult_members(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ElectionResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "key":
+				return ec.fieldContext_ElectionMember_key(ctx, field)
+			case "account":
+				return ec.fieldContext_ElectionMember_account(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ElectionMember", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ElectionResult_weights(ctx context.Context, field graphql.CollectedField, obj *elections.ElectionResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ElectionResult_weights(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ElectionResult().Weights(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]model.Uint64)
+	fc.Result = res
+	return ec.marshalNUint642ᚕvscᚑnodeᚋmodulesᚋgqlᚋmodelᚐUint64ᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ElectionResult_weights(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ElectionResult",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Uint64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ElectionResult_protocol_version(ctx context.Context, field graphql.CollectedField, obj *elections.ElectionResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ElectionResult_protocol_version(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ElectionResult().ProtocolVersion(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.Uint64)
+	fc.Result = res
+	return ec.marshalNUint642vscᚑnodeᚋmodulesᚋgqlᚋmodelᚐUint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ElectionResult_protocol_version(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ElectionResult",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Uint64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ElectionResult_total_weight(ctx context.Context, field graphql.CollectedField, obj *elections.ElectionResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ElectionResult_total_weight(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ElectionResult().TotalWeight(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.Uint64)
+	fc.Result = res
+	return ec.marshalNUint642vscᚑnodeᚋmodulesᚋgqlᚋmodelᚐUint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ElectionResult_total_weight(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ElectionResult",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Uint64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ElectionResult_block_height(ctx context.Context, field graphql.CollectedField, obj *elections.ElectionResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ElectionResult_block_height(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ElectionResult().BlockHeight(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.Uint64)
+	fc.Result = res
+	return ec.marshalNUint642vscᚑnodeᚋmodulesᚋgqlᚋmodelᚐUint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ElectionResult_block_height(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ElectionResult",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Uint64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ElectionResult_proposer(ctx context.Context, field graphql.CollectedField, obj *elections.ElectionResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ElectionResult_proposer(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Proposer, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ElectionResult_proposer(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ElectionResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ElectionResult_tx_id(ctx context.Context, field graphql.CollectedField, obj *elections.ElectionResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ElectionResult_tx_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TxId, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ElectionResult_tx_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ElectionResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
 		},
@@ -6003,6 +6758,82 @@ func (ec *executionContext) fieldContext_Query_getDagByCID(ctx context.Context, 
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_getDagByCID_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_getElection(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_getElection(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().GetElection(rctx, fc.Args["epoch"].(model.Uint64))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*elections.ElectionResult)
+	fc.Result = res
+	return ec.marshalOElectionResult2ᚖvscᚑnodeᚋmodulesᚋdbᚋvscᚋelectionsᚐElectionResult(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_getElection(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "epoch":
+				return ec.fieldContext_ElectionResult_epoch(ctx, field)
+			case "net_id":
+				return ec.fieldContext_ElectionResult_net_id(ctx, field)
+			case "type":
+				return ec.fieldContext_ElectionResult_type(ctx, field)
+			case "data":
+				return ec.fieldContext_ElectionResult_data(ctx, field)
+			case "members":
+				return ec.fieldContext_ElectionResult_members(ctx, field)
+			case "weights":
+				return ec.fieldContext_ElectionResult_weights(ctx, field)
+			case "protocol_version":
+				return ec.fieldContext_ElectionResult_protocol_version(ctx, field)
+			case "total_weight":
+				return ec.fieldContext_ElectionResult_total_weight(ctx, field)
+			case "block_height":
+				return ec.fieldContext_ElectionResult_block_height(ctx, field)
+			case "proposer":
+				return ec.fieldContext_ElectionResult_proposer(ctx, field)
+			case "tx_id":
+				return ec.fieldContext_ElectionResult_tx_id(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ElectionResult", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_getElection_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -10691,6 +11522,294 @@ func (ec *executionContext) _ContractState(ctx context.Context, sel ast.Selectio
 	return out
 }
 
+var electionMemberImplementors = []string{"ElectionMember"}
+
+func (ec *executionContext) _ElectionMember(ctx context.Context, sel ast.SelectionSet, obj *elections.ElectionMember) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, electionMemberImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ElectionMember")
+		case "key":
+			out.Values[i] = ec._ElectionMember_key(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "account":
+			out.Values[i] = ec._ElectionMember_account(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var electionResultImplementors = []string{"ElectionResult"}
+
+func (ec *executionContext) _ElectionResult(ctx context.Context, sel ast.SelectionSet, obj *elections.ElectionResult) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, electionResultImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ElectionResult")
+		case "epoch":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ElectionResult_epoch(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "net_id":
+			out.Values[i] = ec._ElectionResult_net_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "type":
+			out.Values[i] = ec._ElectionResult_type(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "data":
+			out.Values[i] = ec._ElectionResult_data(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "members":
+			out.Values[i] = ec._ElectionResult_members(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "weights":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ElectionResult_weights(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "protocol_version":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ElectionResult_protocol_version(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "total_weight":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ElectionResult_total_weight(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "block_height":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ElectionResult_block_height(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "proposer":
+			out.Values[i] = ec._ElectionResult_proposer(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "tx_id":
+			out.Values[i] = ec._ElectionResult_tx_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var findContractOutputResultImplementors = []string{"FindContractOutputResult"}
 
 func (ec *executionContext) _FindContractOutputResult(ctx context.Context, sel ast.SelectionSet, obj *FindContractOutputResult) graphql.Marshaler {
@@ -11560,6 +12679,25 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "getElection":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_getElection(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "__type":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Query___type(ctx, field)
@@ -12383,6 +13521,54 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
+func (ec *executionContext) marshalNElectionMember2vscᚑnodeᚋmodulesᚋdbᚋvscᚋelectionsᚐElectionMember(ctx context.Context, sel ast.SelectionSet, v elections.ElectionMember) graphql.Marshaler {
+	return ec._ElectionMember(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNElectionMember2ᚕvscᚑnodeᚋmodulesᚋdbᚋvscᚋelectionsᚐElectionMemberᚄ(ctx context.Context, sel ast.SelectionSet, v []elections.ElectionMember) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNElectionMember2vscᚑnodeᚋmodulesᚋdbᚋvscᚋelectionsᚐElectionMember(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) unmarshalNFloat2float64(ctx context.Context, v any) (float64, error) {
 	res, err := graphql.UnmarshalFloatContext(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -12543,6 +13729,36 @@ func (ec *executionContext) unmarshalNUint642vscᚑnodeᚋmodulesᚋgqlᚋmodel�
 
 func (ec *executionContext) marshalNUint642vscᚑnodeᚋmodulesᚋgqlᚋmodelᚐUint64(ctx context.Context, sel ast.SelectionSet, v model.Uint64) graphql.Marshaler {
 	return v
+}
+
+func (ec *executionContext) unmarshalNUint642ᚕvscᚑnodeᚋmodulesᚋgqlᚋmodelᚐUint64ᚄ(ctx context.Context, v any) ([]model.Uint64, error) {
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]model.Uint64, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNUint642vscᚑnodeᚋmodulesᚋgqlᚋmodelᚐUint64(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNUint642ᚕvscᚑnodeᚋmodulesᚋgqlᚋmodelᚐUint64ᚄ(ctx context.Context, sel ast.SelectionSet, v []model.Uint64) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNUint642vscᚑnodeᚋmodulesᚋgqlᚋmodelᚐUint64(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalNWitness2vscᚑnodeᚋmodulesᚋdbᚋvscᚋwitnessesᚐWitness(ctx context.Context, sel ast.SelectionSet, v witnesses.Witness) graphql.Marshaler {
@@ -13046,6 +14262,13 @@ func (ec *executionContext) marshalOContractState2vscᚑnodeᚋmodulesᚋdbᚋvs
 		return graphql.Null
 	}
 	return ec._ContractState(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOElectionResult2ᚖvscᚑnodeᚋmodulesᚋdbᚋvscᚋelectionsᚐElectionResult(ctx context.Context, sel ast.SelectionSet, v *elections.ElectionResult) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._ElectionResult(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOFindContractOutputFilter2ᚖvscᚑnodeᚋmodulesᚋgqlᚋgqlgenᚐFindContractOutputFilter(ctx context.Context, v any) (*FindContractOutputFilter, error) {

--- a/modules/gql/gqlgen/generated.go
+++ b/modules/gql/gqlgen/generated.go
@@ -48,6 +48,7 @@ type ResolverRoot interface {
 	ContractState() ContractStateResolver
 	ElectionResult() ElectionResultResolver
 	Mutation() MutationResolver
+	PostingJsonKeys() PostingJsonKeysResolver
 	Query() QueryResolver
 	Witness() WitnessResolver
 	WitnessSlot() WitnessSlotResolver
@@ -158,12 +159,6 @@ type ComplexityRoot struct {
 		Nonce func(childComplexity int) int
 	}
 
-	HiveKeys struct {
-		Active  func(childComplexity int) int
-		Owner   func(childComplexity int) int
-		Posting func(childComplexity int) int
-	}
-
 	JsonPatchOp struct {
 		Op    func(childComplexity int) int
 		Path  func(childComplexity int) int
@@ -194,6 +189,12 @@ type ComplexityRoot struct {
 
 	Mutation struct {
 		IncrementNumber func(childComplexity int) int
+	}
+
+	PostingJsonKeys struct {
+		Ct  func(childComplexity int) int
+		Key func(childComplexity int) int
+		T   func(childComplexity int) int
 	}
 
 	Query struct {
@@ -260,12 +261,18 @@ type ComplexityRoot struct {
 	}
 
 	Witness struct {
-		Account     func(childComplexity int) int
-		IpfsPeerID  func(childComplexity int) int
-		LastSigned  func(childComplexity int) int
-		NetId       func(childComplexity int) int
-		SigningKeys func(childComplexity int) int
-		VersionId   func(childComplexity int) int
+		Account         func(childComplexity int) int
+		DidKeys         func(childComplexity int) int
+		Enabled         func(childComplexity int) int
+		GatewayKey      func(childComplexity int) int
+		GitCommit       func(childComplexity int) int
+		Height          func(childComplexity int) int
+		NetId           func(childComplexity int) int
+		PeerId          func(childComplexity int) int
+		ProtocolVersion func(childComplexity int) int
+		Ts              func(childComplexity int) int
+		TxId            func(childComplexity int) int
+		VersionId       func(childComplexity int) int
 	}
 
 	WitnessSlot struct {
@@ -313,6 +320,10 @@ type ElectionResultResolver interface {
 type MutationResolver interface {
 	IncrementNumber(ctx context.Context) (*TestResult, error)
 }
+type PostingJsonKeysResolver interface {
+	Ct(ctx context.Context, obj *witnesses.PostingJsonKeys) (*string, error)
+	T(ctx context.Context, obj *witnesses.PostingJsonKeys) (*string, error)
+}
 type QueryResolver interface {
 	ContractStateDiff(ctx context.Context, id *string) (*ContractDiff, error)
 	ContractState(ctx context.Context, id *string) (contracts.ContractState, error)
@@ -337,10 +348,9 @@ type QueryResolver interface {
 	GetElection(ctx context.Context, epoch model.Uint64) (*elections.ElectionResult, error)
 }
 type WitnessResolver interface {
-	IpfsPeerID(ctx context.Context, obj *witnesses.Witness) (*string, error)
-	LastSigned(ctx context.Context, obj *witnesses.Witness) (*int, error)
+	Height(ctx context.Context, obj *witnesses.Witness) (model.Uint64, error)
 
-	SigningKeys(ctx context.Context, obj *witnesses.Witness) (*HiveKeys, error)
+	ProtocolVersion(ctx context.Context, obj *witnesses.Witness) (model.Uint64, error)
 }
 type WitnessSlotResolver interface {
 	Bn(ctx context.Context, obj *stateEngine.WitnessSlot) (model.Uint64, error)
@@ -756,27 +766,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Headers.Nonce(childComplexity), true
 
-	case "HiveKeys.active":
-		if e.complexity.HiveKeys.Active == nil {
-			break
-		}
-
-		return e.complexity.HiveKeys.Active(childComplexity), true
-
-	case "HiveKeys.owner":
-		if e.complexity.HiveKeys.Owner == nil {
-			break
-		}
-
-		return e.complexity.HiveKeys.Owner(childComplexity), true
-
-	case "HiveKeys.posting":
-		if e.complexity.HiveKeys.Posting == nil {
-			break
-		}
-
-		return e.complexity.HiveKeys.Posting(childComplexity), true
-
 	case "JsonPatchOp.op":
 		if e.complexity.JsonPatchOp.Op == nil {
 			break
@@ -895,6 +884,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.IncrementNumber(childComplexity), true
+
+	case "PostingJsonKeys.ct":
+		if e.complexity.PostingJsonKeys.Ct == nil {
+			break
+		}
+
+		return e.complexity.PostingJsonKeys.Ct(childComplexity), true
+
+	case "PostingJsonKeys.key":
+		if e.complexity.PostingJsonKeys.Key == nil {
+			break
+		}
+
+		return e.complexity.PostingJsonKeys.Key(childComplexity), true
+
+	case "PostingJsonKeys.t":
+		if e.complexity.PostingJsonKeys.T == nil {
+			break
+		}
+
+		return e.complexity.PostingJsonKeys.T(childComplexity), true
 
 	case "Query.activeWitnessNodes":
 		if e.complexity.Query.ActiveWitnessNodes == nil {
@@ -1298,19 +1308,40 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Witness.Account(childComplexity), true
 
-	case "Witness.ipfs_peer_id":
-		if e.complexity.Witness.IpfsPeerID == nil {
+	case "Witness.did_keys":
+		if e.complexity.Witness.DidKeys == nil {
 			break
 		}
 
-		return e.complexity.Witness.IpfsPeerID(childComplexity), true
+		return e.complexity.Witness.DidKeys(childComplexity), true
 
-	case "Witness.last_signed":
-		if e.complexity.Witness.LastSigned == nil {
+	case "Witness.enabled":
+		if e.complexity.Witness.Enabled == nil {
 			break
 		}
 
-		return e.complexity.Witness.LastSigned(childComplexity), true
+		return e.complexity.Witness.Enabled(childComplexity), true
+
+	case "Witness.gateway_key":
+		if e.complexity.Witness.GatewayKey == nil {
+			break
+		}
+
+		return e.complexity.Witness.GatewayKey(childComplexity), true
+
+	case "Witness.git_commit":
+		if e.complexity.Witness.GitCommit == nil {
+			break
+		}
+
+		return e.complexity.Witness.GitCommit(childComplexity), true
+
+	case "Witness.height":
+		if e.complexity.Witness.Height == nil {
+			break
+		}
+
+		return e.complexity.Witness.Height(childComplexity), true
 
 	case "Witness.net_id":
 		if e.complexity.Witness.NetId == nil {
@@ -1319,12 +1350,33 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Witness.NetId(childComplexity), true
 
-	case "Witness.signing_keys":
-		if e.complexity.Witness.SigningKeys == nil {
+	case "Witness.peer_id":
+		if e.complexity.Witness.PeerId == nil {
 			break
 		}
 
-		return e.complexity.Witness.SigningKeys(childComplexity), true
+		return e.complexity.Witness.PeerId(childComplexity), true
+
+	case "Witness.protocol_version":
+		if e.complexity.Witness.ProtocolVersion == nil {
+			break
+		}
+
+		return e.complexity.Witness.ProtocolVersion(childComplexity), true
+
+	case "Witness.ts":
+		if e.complexity.Witness.Ts == nil {
+			break
+		}
+
+		return e.complexity.Witness.Ts(childComplexity), true
+
+	case "Witness.tx_id":
+		if e.complexity.Witness.TxId == nil {
+			break
+		}
+
+		return e.complexity.Witness.TxId(childComplexity), true
 
 	case "Witness.version_id":
 		if e.complexity.Witness.VersionId == nil {
@@ -1577,19 +1629,25 @@ type LocalNodeInfo {
   did: String
 }
 
-type HiveKeys {
-  posting: String
-  active: String
-  owner: String
+type PostingJsonKeys {
+  ct: String
+  t: String
+  key: String
 }
 
 type Witness {
   account: String
-  ipfs_peer_id: String
-  last_signed: Int
+  height: Uint64!
+  did_keys: [PostingJsonKeys!]!
+  enabled: Boolean
+  git_commit: String
   net_id: String
+  peer_id: String
+  protocol_version: Uint64!
+  ts: String
+  tx_id: String
   version_id: String
-  signing_keys: HiveKeys
+  gateway_key: String
 }
 
 type WitnessSlot {
@@ -4801,129 +4859,6 @@ func (ec *executionContext) fieldContext_Headers_nonce(_ context.Context, field 
 	return fc, nil
 }
 
-func (ec *executionContext) _HiveKeys_posting(ctx context.Context, field graphql.CollectedField, obj *HiveKeys) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_HiveKeys_posting(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Posting, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_HiveKeys_posting(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "HiveKeys",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _HiveKeys_active(ctx context.Context, field graphql.CollectedField, obj *HiveKeys) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_HiveKeys_active(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Active, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_HiveKeys_active(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "HiveKeys",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _HiveKeys_owner(ctx context.Context, field graphql.CollectedField, obj *HiveKeys) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_HiveKeys_owner(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Owner, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_HiveKeys_owner(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "HiveKeys",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _JsonPatchOp_op(ctx context.Context, field graphql.CollectedField, obj *JSONPatchOp) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_JsonPatchOp_op(ctx, field)
 	if err != nil {
@@ -5671,6 +5606,129 @@ func (ec *executionContext) fieldContext_Mutation_incrementNumber(_ context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _PostingJsonKeys_ct(ctx context.Context, field graphql.CollectedField, obj *witnesses.PostingJsonKeys) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PostingJsonKeys_ct(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.PostingJsonKeys().Ct(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PostingJsonKeys_ct(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PostingJsonKeys",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PostingJsonKeys_t(ctx context.Context, field graphql.CollectedField, obj *witnesses.PostingJsonKeys) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PostingJsonKeys_t(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.PostingJsonKeys().T(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PostingJsonKeys_t(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PostingJsonKeys",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PostingJsonKeys_key(ctx context.Context, field graphql.CollectedField, obj *witnesses.PostingJsonKeys) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PostingJsonKeys_key(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Key, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PostingJsonKeys_key(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PostingJsonKeys",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_contractStateDiff(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_contractStateDiff(ctx, field)
 	if err != nil {
@@ -6289,16 +6347,28 @@ func (ec *executionContext) fieldContext_Query_witnessNodes(ctx context.Context,
 			switch field.Name {
 			case "account":
 				return ec.fieldContext_Witness_account(ctx, field)
-			case "ipfs_peer_id":
-				return ec.fieldContext_Witness_ipfs_peer_id(ctx, field)
-			case "last_signed":
-				return ec.fieldContext_Witness_last_signed(ctx, field)
+			case "height":
+				return ec.fieldContext_Witness_height(ctx, field)
+			case "did_keys":
+				return ec.fieldContext_Witness_did_keys(ctx, field)
+			case "enabled":
+				return ec.fieldContext_Witness_enabled(ctx, field)
+			case "git_commit":
+				return ec.fieldContext_Witness_git_commit(ctx, field)
 			case "net_id":
 				return ec.fieldContext_Witness_net_id(ctx, field)
+			case "peer_id":
+				return ec.fieldContext_Witness_peer_id(ctx, field)
+			case "protocol_version":
+				return ec.fieldContext_Witness_protocol_version(ctx, field)
+			case "ts":
+				return ec.fieldContext_Witness_ts(ctx, field)
+			case "tx_id":
+				return ec.fieldContext_Witness_tx_id(ctx, field)
 			case "version_id":
 				return ec.fieldContext_Witness_version_id(ctx, field)
-			case "signing_keys":
-				return ec.fieldContext_Witness_signing_keys(ctx, field)
+			case "gateway_key":
+				return ec.fieldContext_Witness_gateway_key(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Witness", field.Name)
 		},
@@ -8029,8 +8099,8 @@ func (ec *executionContext) fieldContext_Witness_account(_ context.Context, fiel
 	return fc, nil
 }
 
-func (ec *executionContext) _Witness_ipfs_peer_id(ctx context.Context, field graphql.CollectedField, obj *witnesses.Witness) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Witness_ipfs_peer_id(ctx, field)
+func (ec *executionContext) _Witness_height(ctx context.Context, field graphql.CollectedField, obj *witnesses.Witness) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Witness_height(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -8043,35 +8113,38 @@ func (ec *executionContext) _Witness_ipfs_peer_id(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Witness().IpfsPeerID(rctx, obj)
+		return ec.resolvers.Witness().Height(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(model.Uint64)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNUint642vscᚑnodeᚋmodulesᚋgqlᚋmodelᚐUint64(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Witness_ipfs_peer_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Witness_height(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Witness",
 		Field:      field,
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type Uint64 does not have child fields")
 		},
 	}
 	return fc, nil
 }
 
-func (ec *executionContext) _Witness_last_signed(ctx context.Context, field graphql.CollectedField, obj *witnesses.Witness) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Witness_last_signed(ctx, field)
+func (ec *executionContext) _Witness_did_keys(ctx context.Context, field graphql.CollectedField, obj *witnesses.Witness) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Witness_did_keys(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -8084,7 +8157,59 @@ func (ec *executionContext) _Witness_last_signed(ctx context.Context, field grap
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Witness().LastSigned(rctx, obj)
+		return obj.DidKeys, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]witnesses.PostingJsonKeys)
+	fc.Result = res
+	return ec.marshalNPostingJsonKeys2ᚕvscᚑnodeᚋmodulesᚋdbᚋvscᚋwitnessesᚐPostingJsonKeysᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Witness_did_keys(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Witness",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "ct":
+				return ec.fieldContext_PostingJsonKeys_ct(ctx, field)
+			case "t":
+				return ec.fieldContext_PostingJsonKeys_t(ctx, field)
+			case "key":
+				return ec.fieldContext_PostingJsonKeys_key(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PostingJsonKeys", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Witness_enabled(ctx context.Context, field graphql.CollectedField, obj *witnesses.Witness) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Witness_enabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Enabled, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -8093,19 +8218,60 @@ func (ec *executionContext) _Witness_last_signed(ctx context.Context, field grap
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*int)
+	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Witness_last_signed(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Witness_enabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Witness",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Witness_git_commit(ctx context.Context, field graphql.CollectedField, obj *witnesses.Witness) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Witness_git_commit(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.GitCommit, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Witness_git_commit(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Witness",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -8140,6 +8306,173 @@ func (ec *executionContext) _Witness_net_id(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_Witness_net_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Witness",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Witness_peer_id(ctx context.Context, field graphql.CollectedField, obj *witnesses.Witness) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Witness_peer_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PeerId, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Witness_peer_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Witness",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Witness_protocol_version(ctx context.Context, field graphql.CollectedField, obj *witnesses.Witness) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Witness_protocol_version(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Witness().ProtocolVersion(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.Uint64)
+	fc.Result = res
+	return ec.marshalNUint642vscᚑnodeᚋmodulesᚋgqlᚋmodelᚐUint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Witness_protocol_version(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Witness",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Uint64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Witness_ts(ctx context.Context, field graphql.CollectedField, obj *witnesses.Witness) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Witness_ts(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Ts, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Witness_ts(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Witness",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Witness_tx_id(ctx context.Context, field graphql.CollectedField, obj *witnesses.Witness) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Witness_tx_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TxId, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Witness_tx_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Witness",
 		Field:      field,
@@ -8193,8 +8526,8 @@ func (ec *executionContext) fieldContext_Witness_version_id(_ context.Context, f
 	return fc, nil
 }
 
-func (ec *executionContext) _Witness_signing_keys(ctx context.Context, field graphql.CollectedField, obj *witnesses.Witness) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Witness_signing_keys(ctx, field)
+func (ec *executionContext) _Witness_gateway_key(ctx context.Context, field graphql.CollectedField, obj *witnesses.Witness) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Witness_gateway_key(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -8207,7 +8540,7 @@ func (ec *executionContext) _Witness_signing_keys(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Witness().SigningKeys(rctx, obj)
+		return obj.GatewayKey, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -8216,27 +8549,19 @@ func (ec *executionContext) _Witness_signing_keys(ctx context.Context, field gra
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*HiveKeys)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOHiveKeys2ᚖvscᚑnodeᚋmodulesᚋgqlᚋgqlgenᚐHiveKeys(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Witness_signing_keys(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Witness_gateway_key(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Witness",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "posting":
-				return ec.fieldContext_HiveKeys_posting(ctx, field)
-			case "active":
-				return ec.fieldContext_HiveKeys_active(ctx, field)
-			case "owner":
-				return ec.fieldContext_HiveKeys_owner(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type HiveKeys", field.Name)
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -11990,46 +12315,6 @@ func (ec *executionContext) _Headers(ctx context.Context, sel ast.SelectionSet, 
 	return out
 }
 
-var hiveKeysImplementors = []string{"HiveKeys"}
-
-func (ec *executionContext) _HiveKeys(ctx context.Context, sel ast.SelectionSet, obj *HiveKeys) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, hiveKeysImplementors)
-
-	out := graphql.NewFieldSet(fields)
-	deferred := make(map[string]*graphql.FieldSet)
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("HiveKeys")
-		case "posting":
-			out.Values[i] = ec._HiveKeys_posting(ctx, field, obj)
-		case "active":
-			out.Values[i] = ec._HiveKeys_active(ctx, field, obj)
-		case "owner":
-			out.Values[i] = ec._HiveKeys_owner(ctx, field, obj)
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch(ctx)
-	if out.Invalids > 0 {
-		return graphql.Null
-	}
-
-	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
-
-	for label, dfs := range deferred {
-		ec.processDeferredGroup(graphql.DeferredGroup{
-			Label:    label,
-			Path:     graphql.GetPath(ctx),
-			FieldSet: dfs,
-			Context:  ctx,
-		})
-	}
-
-	return out
-}
-
 var jsonPatchOpImplementors = []string{"JsonPatchOp"}
 
 func (ec *executionContext) _JsonPatchOp(ctx context.Context, sel ast.SelectionSet, obj *JSONPatchOp) graphql.Marshaler {
@@ -12245,6 +12530,108 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_incrementNumber(ctx, field)
 			})
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var postingJsonKeysImplementors = []string{"PostingJsonKeys"}
+
+func (ec *executionContext) _PostingJsonKeys(ctx context.Context, sel ast.SelectionSet, obj *witnesses.PostingJsonKeys) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, postingJsonKeysImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("PostingJsonKeys")
+		case "ct":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._PostingJsonKeys_ct(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "t":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._PostingJsonKeys_t(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "key":
+			out.Values[i] = ec._PostingJsonKeys_key(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -12969,16 +13356,19 @@ func (ec *executionContext) _Witness(ctx context.Context, sel ast.SelectionSet, 
 			out.Values[i] = graphql.MarshalString("Witness")
 		case "account":
 			out.Values[i] = ec._Witness_account(ctx, field, obj)
-		case "ipfs_peer_id":
+		case "height":
 			field := field
 
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Witness_ipfs_peer_id(ctx, field, obj)
+				res = ec._Witness_height(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -13002,53 +13392,32 @@ func (ec *executionContext) _Witness(ctx context.Context, sel ast.SelectionSet, 
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "last_signed":
-			field := field
-
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Witness_last_signed(ctx, field, obj)
-				return res
+		case "did_keys":
+			out.Values[i] = ec._Witness_did_keys(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
 			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "enabled":
+			out.Values[i] = ec._Witness_enabled(ctx, field, obj)
+		case "git_commit":
+			out.Values[i] = ec._Witness_git_commit(ctx, field, obj)
 		case "net_id":
 			out.Values[i] = ec._Witness_net_id(ctx, field, obj)
-		case "version_id":
-			out.Values[i] = ec._Witness_version_id(ctx, field, obj)
-		case "signing_keys":
+		case "peer_id":
+			out.Values[i] = ec._Witness_peer_id(ctx, field, obj)
+		case "protocol_version":
 			field := field
 
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Witness_signing_keys(ctx, field, obj)
+				res = ec._Witness_protocol_version(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -13072,6 +13441,14 @@ func (ec *executionContext) _Witness(ctx context.Context, sel ast.SelectionSet, 
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "ts":
+			out.Values[i] = ec._Witness_ts(ctx, field, obj)
+		case "tx_id":
+			out.Values[i] = ec._Witness_tx_id(ctx, field, obj)
+		case "version_id":
+			out.Values[i] = ec._Witness_version_id(ctx, field, obj)
+		case "gateway_key":
+			out.Values[i] = ec._Witness_gateway_key(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -13650,6 +14027,54 @@ func (ec *executionContext) marshalNJSON2ᚕᚖstring(ctx context.Context, sel a
 
 func (ec *executionContext) marshalNLedgerOp2vscᚑnodeᚋmodulesᚋgqlᚋgqlgenᚐLedgerOp(ctx context.Context, sel ast.SelectionSet, v LedgerOp) graphql.Marshaler {
 	return ec._LedgerOp(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNPostingJsonKeys2vscᚑnodeᚋmodulesᚋdbᚋvscᚋwitnessesᚐPostingJsonKeys(ctx context.Context, sel ast.SelectionSet, v witnesses.PostingJsonKeys) graphql.Marshaler {
+	return ec._PostingJsonKeys(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNPostingJsonKeys2ᚕvscᚑnodeᚋmodulesᚋdbᚋvscᚋwitnessesᚐPostingJsonKeysᚄ(ctx context.Context, sel ast.SelectionSet, v []witnesses.PostingJsonKeys) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNPostingJsonKeys2vscᚑnodeᚋmodulesᚋdbᚋvscᚋwitnessesᚐPostingJsonKeys(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v any) (string, error) {
@@ -14320,13 +14745,6 @@ func (ec *executionContext) marshalOHeaders2ᚖvscᚑnodeᚋmodulesᚋgqlᚋgqlg
 		return graphql.Null
 	}
 	return ec._Headers(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOHiveKeys2ᚖvscᚑnodeᚋmodulesᚋgqlᚋgqlgenᚐHiveKeys(ctx context.Context, sel ast.SelectionSet, v *HiveKeys) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._HiveKeys(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOInt2ᚖint(ctx context.Context, v any) (*int, error) {

--- a/modules/gql/gqlgen/models.go
+++ b/modules/gql/gqlgen/models.go
@@ -101,12 +101,6 @@ type Headers struct {
 	Nonce *int `json:"nonce,omitempty"`
 }
 
-type HiveKeys struct {
-	Posting *string `json:"posting,omitempty"`
-	Active  *string `json:"active,omitempty"`
-	Owner   *string `json:"owner,omitempty"`
-}
-
 type JSONPatchOp struct {
 	Op    *string `json:"op,omitempty"`
 	Path  *string `json:"path,omitempty"`

--- a/modules/gql/gqlgen/models.go
+++ b/modules/gql/gqlgen/models.go
@@ -97,17 +97,6 @@ type Gas struct {
 	Io *int `json:"IO,omitempty"`
 }
 
-type GetBalanceResult struct {
-	Account     *string           `json:"account,omitempty"`
-	BlockHeight *int              `json:"block_height,omitempty"`
-	Tokens      *GetBalanceTokens `json:"tokens,omitempty"`
-}
-
-type GetBalanceTokens struct {
-	Hbd  *float64 `json:"HBD,omitempty"`
-	Hive *float64 `json:"HIVE,omitempty"`
-}
-
 type Headers struct {
 	Nonce *int `json:"nonce,omitempty"`
 }

--- a/modules/gql/gqlgen/resolver.go
+++ b/modules/gql/gqlgen/resolver.go
@@ -2,6 +2,7 @@ package gqlgen
 
 import (
 	"vsc-node/lib/datalayer"
+	"vsc-node/modules/db/vsc/elections"
 	"vsc-node/modules/db/vsc/hive_blocks"
 	ledgerDb "vsc-node/modules/db/vsc/ledger"
 	"vsc-node/modules/db/vsc/witnesses"
@@ -17,6 +18,7 @@ type Resolver struct {
 	Witnesses   witnesses.Witnesses
 	TxPool      *transactionpool.TransactionPool
 	Balances    ledgerDb.Balances
+	Elections   elections.Elections
 	HiveBlocks  hive_blocks.HiveBlocks
 	StateEngine *stateEngine.StateEngine
 	Da          *datalayer.DataLayer

--- a/modules/gql/gqlgen/resolver.go
+++ b/modules/gql/gqlgen/resolver.go
@@ -2,6 +2,7 @@ package gqlgen
 
 import (
 	"vsc-node/lib/datalayer"
+	"vsc-node/modules/db/vsc/hive_blocks"
 	ledgerDb "vsc-node/modules/db/vsc/ledger"
 	"vsc-node/modules/db/vsc/witnesses"
 	stateEngine "vsc-node/modules/state-processing"
@@ -16,6 +17,7 @@ type Resolver struct {
 	Witnesses   witnesses.Witnesses
 	TxPool      *transactionpool.TransactionPool
 	Balances    ledgerDb.Balances
+	HiveBlocks  hive_blocks.HiveBlocks
 	StateEngine *stateEngine.StateEngine
 	Da          *datalayer.DataLayer
 }

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -318,7 +318,11 @@ func (r *queryResolver) GetDagByCid(ctx context.Context, cidString string) (stri
 
 // GetElection is the resolver for the getElection field.
 func (r *queryResolver) GetElection(ctx context.Context, epoch model.Uint64) (*elections.ElectionResult, error) {
-	return r.Elections.GetElection(uint64(epoch)), nil
+	result := r.Elections.GetElection(uint64(epoch))
+	if result == nil {
+		return nil, fmt.Errorf("election not found or error occurred for epoch %d", uint64(epoch))
+	}
+	return result, nil
 }
 
 // Height is the resolver for the height field.

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -191,6 +191,9 @@ func (r *queryResolver) FindLedgerTXs(ctx context.Context, filterOptions *Ledger
 
 // GetAccountBalance is the resolver for the getAccountBalance field.
 func (r *queryResolver) GetAccountBalance(ctx context.Context, account string, height *model.Uint64) (*ledgerDb.BalanceRecord, error) {
+	if account == "" {
+		return nil, fmt.Errorf("Account parameter cannot be empty")
+	}
 	var blockHeight uint64
 	if height != nil {
 		blockHeight = uint64(*height)

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math"
 	"vsc-node/modules/db/vsc/contracts"
+	"vsc-node/modules/db/vsc/elections"
 	ledgerDb "vsc-node/modules/db/vsc/ledger"
 	"vsc-node/modules/db/vsc/witnesses"
 	"vsc-node/modules/gql/model"
@@ -117,6 +118,35 @@ func (r *contractStateResolver) StateKeys(ctx context.Context, obj contracts.Con
 // StateMerkle is the resolver for the state_merkle field.
 func (r *contractStateResolver) StateMerkle(ctx context.Context, obj contracts.ContractState) (*string, error) {
 	panic(fmt.Errorf("not implemented: StateMerkle - state_merkle"))
+}
+
+// Epoch is the resolver for the epoch field.
+func (r *electionResultResolver) Epoch(ctx context.Context, obj *elections.ElectionResult) (model.Uint64, error) {
+	return model.Uint64(obj.Epoch), nil
+}
+
+// Weights is the resolver for the weights field.
+func (r *electionResultResolver) Weights(ctx context.Context, obj *elections.ElectionResult) ([]model.Uint64, error) {
+	converted := make([]model.Uint64, len(obj.Weights))
+	for i, v := range obj.Weights {
+		converted[i] = model.Uint64(v)
+	}
+	return converted, nil
+}
+
+// ProtocolVersion is the resolver for the protocol_version field.
+func (r *electionResultResolver) ProtocolVersion(ctx context.Context, obj *elections.ElectionResult) (model.Uint64, error) {
+	return model.Uint64(obj.ProtocolVersion), nil
+}
+
+// TotalWeight is the resolver for the total_weight field.
+func (r *electionResultResolver) TotalWeight(ctx context.Context, obj *elections.ElectionResult) (model.Uint64, error) {
+	return model.Uint64(obj.TotalWeight), nil
+}
+
+// BlockHeight is the resolver for the block_height field.
+func (r *electionResultResolver) BlockHeight(ctx context.Context, obj *elections.ElectionResult) (model.Uint64, error) {
+	return model.Uint64(obj.BlockHeight), nil
 }
 
 // IncrementNumber is the resolver for the incrementNumber field.
@@ -273,6 +303,11 @@ func (r *queryResolver) GetDagByCid(ctx context.Context, cidString string) (stri
 	return string(jsonBytes), nil
 }
 
+// GetElection is the resolver for the getElection field.
+func (r *queryResolver) GetElection(ctx context.Context, epoch model.Uint64) (*elections.ElectionResult, error) {
+	return r.Elections.GetElection(uint64(epoch)), nil
+}
+
 // IpfsPeerID is the resolver for the ipfs_peer_id field.
 func (r *witnessResolver) IpfsPeerID(ctx context.Context, obj *witnesses.Witness) (*string, error) {
 	panic(fmt.Errorf("not implemented: IpfsPeerID - ipfs_peer_id"))
@@ -302,6 +337,9 @@ func (r *Resolver) ContractOutput() ContractOutputResolver { return &contractOut
 // ContractState returns ContractStateResolver implementation.
 func (r *Resolver) ContractState() ContractStateResolver { return &contractStateResolver{r} }
 
+// ElectionResult returns ElectionResultResolver implementation.
+func (r *Resolver) ElectionResult() ElectionResultResolver { return &electionResultResolver{r} }
+
 // Mutation returns MutationResolver implementation.
 func (r *Resolver) Mutation() MutationResolver { return &mutationResolver{r} }
 
@@ -317,6 +355,7 @@ func (r *Resolver) WitnessSlot() WitnessSlotResolver { return &witnessSlotResolv
 type balanceRecordResolver struct{ *Resolver }
 type contractOutputResolver struct{ *Resolver }
 type contractStateResolver struct{ *Resolver }
+type electionResultResolver struct{ *Resolver }
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type witnessResolver struct{ *Resolver }

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -154,6 +154,16 @@ func (r *mutationResolver) IncrementNumber(ctx context.Context) (*TestResult, er
 	panic(fmt.Errorf("not implemented"))
 }
 
+// Ct is the resolver for the ct field.
+func (r *postingJsonKeysResolver) Ct(ctx context.Context, obj *witnesses.PostingJsonKeys) (*string, error) {
+	return &obj.CryptoType, nil
+}
+
+// T is the resolver for the t field.
+func (r *postingJsonKeysResolver) T(ctx context.Context, obj *witnesses.PostingJsonKeys) (*string, error) {
+	return &obj.Type, nil
+}
+
 // ContractStateDiff is the resolver for the contractStateDiff field.
 func (r *queryResolver) ContractStateDiff(ctx context.Context, id *string) (*ContractDiff, error) {
 	panic(fmt.Errorf("not implemented"))
@@ -308,19 +318,14 @@ func (r *queryResolver) GetElection(ctx context.Context, epoch model.Uint64) (*e
 	return r.Elections.GetElection(uint64(epoch)), nil
 }
 
-// IpfsPeerID is the resolver for the ipfs_peer_id field.
-func (r *witnessResolver) IpfsPeerID(ctx context.Context, obj *witnesses.Witness) (*string, error) {
-	panic(fmt.Errorf("not implemented: IpfsPeerID - ipfs_peer_id"))
+// Height is the resolver for the height field.
+func (r *witnessResolver) Height(ctx context.Context, obj *witnesses.Witness) (model.Uint64, error) {
+	return model.Uint64(obj.Height), nil
 }
 
-// LastSigned is the resolver for the last_signed field.
-func (r *witnessResolver) LastSigned(ctx context.Context, obj *witnesses.Witness) (*int, error) {
-	panic(fmt.Errorf("not implemented: LastSigned - last_signed"))
-}
-
-// SigningKeys is the resolver for the signing_keys field.
-func (r *witnessResolver) SigningKeys(ctx context.Context, obj *witnesses.Witness) (*HiveKeys, error) {
-	panic(fmt.Errorf("not implemented: SigningKeys - signing_keys"))
+// ProtocolVersion is the resolver for the protocol_version field.
+func (r *witnessResolver) ProtocolVersion(ctx context.Context, obj *witnesses.Witness) (model.Uint64, error) {
+	return model.Uint64(obj.ProtocolVersion), nil
 }
 
 // Bn is the resolver for the bn field.
@@ -343,6 +348,9 @@ func (r *Resolver) ElectionResult() ElectionResultResolver { return &electionRes
 // Mutation returns MutationResolver implementation.
 func (r *Resolver) Mutation() MutationResolver { return &mutationResolver{r} }
 
+// PostingJsonKeys returns PostingJsonKeysResolver implementation.
+func (r *Resolver) PostingJsonKeys() PostingJsonKeysResolver { return &postingJsonKeysResolver{r} }
+
 // Query returns QueryResolver implementation.
 func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
 
@@ -357,6 +365,7 @@ type contractOutputResolver struct{ *Resolver }
 type contractStateResolver struct{ *Resolver }
 type electionResultResolver struct{ *Resolver }
 type mutationResolver struct{ *Resolver }
+type postingJsonKeysResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type witnessResolver struct{ *Resolver }
 type witnessSlotResolver struct{ *Resolver }

--- a/modules/gql/model/Int64.go
+++ b/modules/gql/model/Int64.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+)
+
+type Int64 int64
+
+func (b Int64) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, int64(b))
+}
+
+func (b *Int64) UnmarshalGQL(v any) (err error) {
+	var u int64
+	switch v := v.(type) {
+	case string:
+		u, err = strconv.ParseInt(v, 10, 64)
+	case int64:
+		u = v
+	case uint64:
+		u = int64(v)
+	default:
+		err = fmt.Errorf("%T is not an Int64", v)
+	}
+	*b = Int64(u)
+	return
+}

--- a/modules/gql/schema.graphql
+++ b/modules/gql/schema.graphql
@@ -216,6 +216,25 @@ type LedgerResults {
   txs: [LedgerOp!]
 }
 
+type ElectionMember {
+  key: String!
+  account: String!
+}
+
+type ElectionResult {
+  epoch: Uint64!
+  net_id: String!
+  type: String!
+  data: String!
+  members: [ElectionMember!]!
+  weights: [Uint64!]!
+  protocol_version: Uint64!
+  total_weight: Uint64!
+  block_height: Uint64!
+  proposer: String!
+  tx_id: String!
+}
+
 input LedgerTxFilter {
   byToFrom: String
   byTxId: String
@@ -267,6 +286,7 @@ type Query {
   getCurrentNumber: TestResult # TESTING QUERY
   witnessStake(account: String!): Uint64!
   getDagByCID(cidString: String!): JSON!
+  getElection(epoch: Uint64!): ElectionResult
 }
 
 scalar Uint64

--- a/modules/gql/schema.graphql
+++ b/modules/gql/schema.graphql
@@ -120,19 +120,25 @@ type LocalNodeInfo {
   did: String
 }
 
-type HiveKeys {
-  posting: String
-  active: String
-  owner: String
+type PostingJsonKeys {
+  ct: String
+  t: String
+  key: String
 }
 
 type Witness {
   account: String
-  ipfs_peer_id: String
-  last_signed: Int
+  height: Uint64!
+  did_keys: [PostingJsonKeys!]!
+  enabled: Boolean
+  git_commit: String
   net_id: String
+  peer_id: String
+  protocol_version: Uint64!
+  ts: String
+  tx_id: String
   version_id: String
-  signing_keys: HiveKeys
+  gateway_key: String
 }
 
 type WitnessSlot {

--- a/modules/gql/schema.graphql
+++ b/modules/gql/schema.graphql
@@ -175,15 +175,16 @@ interface BlockRef {
   included_block: Int
 }
 
-type GetBalanceTokens {
-  HBD: Float
-  HIVE: Float
-}
-
-type GetBalanceResult {
+type BalanceRecord {
   account: String
-  block_height: Int
-  tokens: GetBalanceTokens
+  block_height: Uint64!
+  hbd: Int64!
+  hbd_avg: Int64!
+  hbd_modify: Uint64!
+  hbd_claim: Uint64!
+  hbd_savings: Int64!
+  hive: Int64!
+  hive_consensus: Int64!
 }
 
 type FindTransactionResult {
@@ -251,7 +252,7 @@ type Query {
     decodedFilter: JSON
   ): FindContractOutputResult
   findLedgerTXs(filterOptions: LedgerTxFilter): LedgerResults
-  getAccountBalance(account: String): GetBalanceResult
+  getAccountBalance(account: String!, height: Uint64): BalanceRecord
   findContract(id: String): FindContractResult
   submitTransactionV1(tx: String!, sig: String!): TransactionSubmitResult
   getAccountNonce(keyGroup: [String]!): AccountNonceResult
@@ -269,6 +270,7 @@ type Query {
 }
 
 scalar Uint64
+scalar Int64
 
 type Mutation {
   incrementNumber: TestResult # TESTING MUTATION

--- a/modules/state-processing/system_txs.go
+++ b/modules/state-processing/system_txs.go
@@ -287,6 +287,7 @@ func (tx *TxElectionResult) ExecuteTx(se *StateEngine, ledgerSession *LedgerSess
 
 			elecResult.Proposer = tx.Self.RequiredAuths[0]
 			elecResult.BlockHeight = tx.Self.BlockHeight
+			elecResult.TxId = tx.Self.TxId
 			elecResult.Epoch = tx.Epoch
 			elecResult.NetId = tx.NetId
 			elecResult.Data = tx.Data
@@ -392,6 +393,7 @@ func (tx *TxElectionResult) ExecuteTx(se *StateEngine, ledgerSession *LedgerSess
 			elecResult := elections.ElectionResult{
 				Proposer:    tx.Self.RequiredAuths[0],
 				BlockHeight: tx.Self.BlockHeight,
+				TxId:        tx.Self.TxId,
 			}
 			elecResult.Epoch = tx.Epoch
 			elecResult.NetId = tx.NetId


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the GraphQL API to support detailed balance queries, including historical data retrieval by block height.
  - Introduced a new query for fetching election results by epoch, with enriched data that now includes transaction identifiers.
  - Updated data responses for witness and election-related endpoints to provide better transaction traceability.
  - Added support for new data models, including `Int64`, `BalanceRecord`, and `ElectionResult`.
  - Expanded resolver capabilities to include new databases for elections and hive blocks.

- **Refactor**
  - Streamlined and reorganized the API schema by removing outdated models and improving field serialization for increased consistency and efficiency.
  - Updated existing methods to accommodate new parameters and enhance functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->