### PR TITLE
Ledger actions, account RC GraphQL query

### DIFF
--- a/cmd/vsc-node/main.go
+++ b/cmd/vsc-node/main.go
@@ -139,6 +139,7 @@ func main() {
 		electionDb,
 		txDb,
 		nonceDb,
+		rcDb,
 		hiveBlocks,
 		se,
 		da,

--- a/cmd/vsc-node/main.go
+++ b/cmd/vsc-node/main.go
@@ -135,6 +135,7 @@ func main() {
 		txpool,
 		balanceDb,
 		ledgerDbImpl,
+		actionsDb,
 		electionDb,
 		txDb,
 		nonceDb,

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -51,6 +51,9 @@ models:
   NonceRecord:
     model:
       - vsc-node/modules/db/vsc/nonces.NonceRecord
+  RcRecord:
+    model:
+      - vsc-node/modules/db/vsc/rcs.RcRecord
   OpLogEvent:
     model:
       - vsc-node/modules/ledger-system.OpLogEvent

--- a/modules/db/reindex.go
+++ b/modules/db/reindex.go
@@ -9,7 +9,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-var REINDEX_ID = 5
+var REINDEX_ID = 6
 
 var IMMUTABLE_COLLECTIONS = []string{
 	"hive_blocks",

--- a/modules/db/vsc/ledger/ledger.go
+++ b/modules/db/vsc/ledger/ledger.go
@@ -268,18 +268,22 @@ func (actionsDb *actionsDb) StoreAction(withdraw ActionRecord) {
 	}, findUpdateOpts)
 }
 
-func (actionsDb *actionsDb) ExecuteComplete(ids ...string) {
+func (actionsDb *actionsDb) ExecuteComplete(actionId *string, ids ...string) {
 	if len(ids) == 0 {
 		return
+	}
+	updated := bson.M{
+		"status": "complete",
+	}
+	if actionId != nil {
+		updated["action_id"] = *actionId
 	}
 	actionsDb.UpdateMany(context.Background(), bson.M{
 		"id": bson.M{
 			"$in": ids,
 		},
 	}, bson.M{
-		"$set": bson.M{
-			"status": "complete",
-		},
+		"$set": updated,
 	})
 }
 

--- a/modules/db/vsc/ledger/ledger.go
+++ b/modules/db/vsc/ledger/ledger.go
@@ -6,9 +6,9 @@ import (
 	"vsc-node/modules/common"
 	"vsc-node/modules/db"
 	"vsc-node/modules/db/vsc"
+	"vsc-node/modules/db/vsc/hive_blocks"
 
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -117,31 +117,7 @@ func (ledger *ledger) GetLedgersTsRange(account *string, txId *string, txTypes [
 	if len(txTypes) > 0 {
 		filters = append(filters, bson.E{Key: "t", Value: bson.D{{Key: "$in", Value: txTypes}}})
 	}
-	pipe := mongo.Pipeline{
-		{{Key: "$match", Value: filters}},
-		// Join with hive_blocks
-		{{Key: "$lookup", Value: bson.D{
-			{Key: "from", Value: "hive_blocks"},
-			{Key: "localField", Value: "block_height"},
-			{Key: "foreignField", Value: "block.block_number"},
-			{Key: "as", Value: "block_info"},
-		}}},
-		// Unwind the joined array
-		{{Key: "$unwind", Value: "$block_info"}},
-		// Add timestamp field
-		{{Key: "$addFields", Value: bson.D{
-			{Key: "timestamp", Value: "$block_info.block.timestamp"},
-		}}},
-		// Remove temporary field
-		{{Key: "$project", Value: bson.D{
-			{Key: "block_info", Value: 0},
-		}}},
-		// Sorting
-		{{Key: "$sort", Value: bson.D{{Key: "block_height", Value: -1}}}},
-		// Pagination
-		{{Key: "$skip", Value: offset}},
-		{{Key: "$limit", Value: limit}},
-	}
+	pipe := hive_blocks.GetAggTimestampPipeline(filters, "block_height", "timestamp", offset, limit)
 	cursor, err := ledger.Aggregate(context.TODO(), pipe)
 	if err != nil {
 		return []LedgerRecord{}, err
@@ -407,31 +383,7 @@ func (actions *actionsDb) GetActionsRange(txId *string, actionId *string, accoun
 	if toBlock != nil {
 		filters = append(filters, bson.E{Key: "block_height", Value: bson.D{{Key: "$lte", Value: *toBlock}}})
 	}
-	pipe := mongo.Pipeline{
-		{{Key: "$match", Value: filters}},
-		// Join with hive_blocks
-		{{Key: "$lookup", Value: bson.D{
-			{Key: "from", Value: "hive_blocks"},
-			{Key: "localField", Value: "block_height"},
-			{Key: "foreignField", Value: "block.block_number"},
-			{Key: "as", Value: "block_info"},
-		}}},
-		// Unwind the joined array
-		{{Key: "$unwind", Value: "$block_info"}},
-		// Add timestamp field
-		{{Key: "$addFields", Value: bson.D{
-			{Key: "timestamp", Value: "$block_info.block.timestamp"},
-		}}},
-		// Remove temporary field
-		{{Key: "$project", Value: bson.D{
-			{Key: "block_info", Value: 0},
-		}}},
-		// Sorting
-		{{Key: "$sort", Value: bson.D{{Key: "block_height", Value: -1}}}},
-		// Pagination
-		{{Key: "$skip", Value: offset}},
-		{{Key: "$limit", Value: limit}},
-	}
+	pipe := hive_blocks.GetAggTimestampPipeline(filters, "block_height", "timestamp", offset, limit)
 	cursor, err := actions.Aggregate(context.TODO(), pipe)
 	if err != nil {
 		return []ActionRecord{}, err

--- a/modules/db/vsc/ledger/types.go
+++ b/modules/db/vsc/ledger/types.go
@@ -91,6 +91,7 @@ type BridgeActions interface {
 	SetStatus(id string, status string)
 	GetPendingActions(bh uint64, t ...string) ([]ActionRecord, error)
 	GetPendingActionsByEpoch(epoch uint64, t ...string) ([]ActionRecord, error)
+	GetActionsRange(txId *string, actionId *string, account *string, byTypes []string, status *string, fromBlock *uint64, toBlock *uint64, offset int, limit int) ([]ActionRecord, error)
 }
 
 type ILedgerExecutor interface {
@@ -119,6 +120,9 @@ type ActionRecord struct {
 	//Extra stored data
 	Params      map[string]interface{} `bson:"data"`
 	BlockHeight uint64                 `bson:"block_height"`
+
+	//For api query
+	Timestamp *string `json:"timestamp" bson:"timestamp"`
 }
 
 type WithdrawalSideEffect struct {

--- a/modules/db/vsc/ledger/types.go
+++ b/modules/db/vsc/ledger/types.go
@@ -86,7 +86,7 @@ type LedgerRecord struct {
 type BridgeActions interface {
 	aggregate.Plugin
 	StoreAction(withdraw ActionRecord)
-	ExecuteComplete(ids ...string)
+	ExecuteComplete(actionId *string, ids ...string)
 	Get(id string) (*ActionRecord, error)
 	SetStatus(id string, status string)
 	GetPendingActions(bh uint64, t ...string) ([]ActionRecord, error)
@@ -113,7 +113,7 @@ type ActionRecord struct {
 	Asset  string `bson:"asset"`
 	To     string `bson:"to"`
 	Memo   string `bson:"memo"`
-	TxId   string `bson:"withdraw_id"`
+	TxId   string `bson:"action_id"`
 	Type   string `bson:"type"`
 
 	//Extra stored data

--- a/modules/db/vsc/rcs/rc.go
+++ b/modules/db/vsc/rcs/rc.go
@@ -32,8 +32,9 @@ func (e *rcDb) GetRecord(account string, blockHeight uint64) (RcRecord, error) {
 		"account":      account,
 		"block_height": bson.M{"$lte": blockHeight},
 	}
+	opts := options.FindOne().SetSort(bson.D{{Key: "block_height", Value: -1}})
 
-	findResult := e.Collection.FindOne(context.Background(), query)
+	findResult := e.Collection.FindOne(context.Background(), query, opts)
 
 	var record RcRecord
 	err := findResult.Decode(&record)

--- a/modules/db/vsc/rcs/types.go
+++ b/modules/db/vsc/rcs/types.go
@@ -9,7 +9,7 @@ type RcDb interface {
 }
 
 type RcRecord struct {
-	Account     string
-	Amount      int64
-	BlockHeight uint64
+	Account     string `json:"account" bson:"account"`
+	Amount      int64  `json:"amount" bson:"amount"`
+	BlockHeight uint64 `json:"block_height" bson:"block_height"`
 }

--- a/modules/gql/gql_test.go
+++ b/modules/gql/gql_test.go
@@ -73,6 +73,7 @@ func TestQueryAndMutation(t *testing.T) {
 		electionDb,
 		txDb,
 		nonceDb,
+		rcDb,
 		hiveBlocks,
 		se,
 		da,

--- a/modules/gql/gql_test.go
+++ b/modules/gql/gql_test.go
@@ -69,6 +69,7 @@ func TestQueryAndMutation(t *testing.T) {
 		txPool,
 		balances,
 		ledgerDbImpl,
+		actionsDb,
 		electionDb,
 		txDb,
 		nonceDb,

--- a/modules/gql/gqlgen/models.go
+++ b/modules/gql/gqlgen/models.go
@@ -90,6 +90,18 @@ type JSONPatchOp struct {
 	Value *string `json:"value,omitempty"`
 }
 
+type LedgerActionsFilter struct {
+	ByTxID     *string       `json:"byTxId,omitempty"`
+	ByActionID *string       `json:"byActionId,omitempty"`
+	ByAccount  *string       `json:"byAccount,omitempty"`
+	ByTypes    []string      `json:"byTypes,omitempty"`
+	ByStatus   *string       `json:"byStatus,omitempty"`
+	FromBlock  *model.Uint64 `json:"fromBlock,omitempty"`
+	ToBlock    *model.Uint64 `json:"toBlock,omitempty"`
+	Offset     *int          `json:"offset,omitempty"`
+	Limit      *int          `json:"limit,omitempty"`
+}
+
 type LedgerTxFilter struct {
 	ByToFrom  *string       `json:"byToFrom,omitempty"`
 	ByTxID    *string       `json:"byTxId,omitempty"`

--- a/modules/gql/gqlgen/resolver.go
+++ b/modules/gql/gqlgen/resolver.go
@@ -6,6 +6,7 @@ import (
 	"vsc-node/modules/db/vsc/hive_blocks"
 	ledgerDb "vsc-node/modules/db/vsc/ledger"
 	"vsc-node/modules/db/vsc/nonces"
+	rcDb "vsc-node/modules/db/vsc/rcs"
 	"vsc-node/modules/db/vsc/transactions"
 	"vsc-node/modules/db/vsc/witnesses"
 	stateEngine "vsc-node/modules/state-processing"
@@ -25,6 +26,7 @@ type Resolver struct {
 	Elections    elections.Elections
 	Transactions transactions.Transactions
 	Nonces       nonces.Nonces
+	Rc           rcDb.RcDb
 	HiveBlocks   hive_blocks.HiveBlocks
 	StateEngine  *stateEngine.StateEngine
 	Da           *datalayer.DataLayer

--- a/modules/gql/gqlgen/resolver.go
+++ b/modules/gql/gqlgen/resolver.go
@@ -21,6 +21,7 @@ type Resolver struct {
 	TxPool       *transactionpool.TransactionPool
 	Balances     ledgerDb.Balances
 	Ledger       ledgerDb.Ledger
+	Actions      ledgerDb.BridgeActions
 	Elections    elections.Elections
 	Transactions transactions.Transactions
 	Nonces       nonces.Nonces

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -24,6 +24,26 @@ import (
 	"github.com/ipfs/go-cid"
 )
 
+// Amount is the resolver for the amount field.
+func (r *actionRecordResolver) Amount(ctx context.Context, obj *ledgerDb.ActionRecord) (model.Int64, error) {
+	return model.Int64(obj.Amount), nil
+}
+
+// ActionID is the resolver for the action_id field.
+func (r *actionRecordResolver) ActionID(ctx context.Context, obj *ledgerDb.ActionRecord) (string, error) {
+	return obj.TxId, nil
+}
+
+// Params is the resolver for the params field.
+func (r *actionRecordResolver) Params(ctx context.Context, obj *ledgerDb.ActionRecord) (model.Map, error) {
+	return model.Map(obj.Params), nil
+}
+
+// BlockHeight is the resolver for the block_height field.
+func (r *actionRecordResolver) BlockHeight(ctx context.Context, obj *ledgerDb.ActionRecord) (model.Uint64, error) {
+	return model.Uint64(obj.BlockHeight), nil
+}
+
 // BlockHeight is the resolver for the block_height field.
 func (r *balanceRecordResolver) BlockHeight(ctx context.Context, obj *ledgerDb.BalanceRecord) (model.Uint64, error) {
 	return model.Uint64(obj.BlockHeight), nil
@@ -230,6 +250,15 @@ func (r *queryResolver) FindLedgerTXs(ctx context.Context, filterOptions *Ledger
 	return r.Ledger.GetLedgersTsRange(filterOptions.ByToFrom, filterOptions.ByTxID, filterOptions.ByTypes, (*uint64)(filterOptions.FromBlock), (*uint64)(filterOptions.ToBlock), offset, limit)
 }
 
+// FindLedgerActions is the resolver for the findLedgerActions field.
+func (r *queryResolver) FindLedgerActions(ctx context.Context, filterOptions *LedgerActionsFilter) ([]ledgerDb.ActionRecord, error) {
+	offset, limit, paginateErr := Paginate(filterOptions.Offset, filterOptions.Limit)
+	if paginateErr != nil {
+		return nil, paginateErr
+	}
+	return r.Actions.GetActionsRange(filterOptions.ByTxID, filterOptions.ByActionID, filterOptions.ByAccount, filterOptions.ByTypes, filterOptions.ByStatus, (*uint64)(filterOptions.FromBlock), (*uint64)(filterOptions.ToBlock), offset, limit)
+}
+
 // GetAccountBalance is the resolver for the getAccountBalance field.
 func (r *queryResolver) GetAccountBalance(ctx context.Context, account string, height *model.Uint64) (*ledgerDb.BalanceRecord, error) {
 	if account == "" {
@@ -417,6 +446,9 @@ func (r *witnessSlotResolver) Bn(ctx context.Context, obj *stateEngine.WitnessSl
 	return model.Uint64(obj.SlotHeight), nil
 }
 
+// ActionRecord returns ActionRecordResolver implementation.
+func (r *Resolver) ActionRecord() ActionRecordResolver { return &actionRecordResolver{r} }
+
 // BalanceRecord returns BalanceRecordResolver implementation.
 func (r *Resolver) BalanceRecord() BalanceRecordResolver { return &balanceRecordResolver{r} }
 
@@ -458,6 +490,7 @@ func (r *Resolver) Witness() WitnessResolver { return &witnessResolver{r} }
 // WitnessSlot returns WitnessSlotResolver implementation.
 func (r *Resolver) WitnessSlot() WitnessSlotResolver { return &witnessSlotResolver{r} }
 
+type actionRecordResolver struct{ *Resolver }
 type balanceRecordResolver struct{ *Resolver }
 type contractOutputResolver struct{ *Resolver }
 type contractStateResolver struct{ *Resolver }

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -257,6 +257,9 @@ func (r *queryResolver) FindLedgerActions(ctx context.Context, filterOptions *Le
 	if paginateErr != nil {
 		return nil, paginateErr
 	}
+	if filterOptions.ByTxID != nil && utf8.RuneCountInString(*filterOptions.ByTxID) < 40 {
+		return nil, fmt.Errorf("invalid tx id")
+	}
 	return r.Actions.GetActionsRange(filterOptions.ByTxID, filterOptions.ByActionID, filterOptions.ByAccount, filterOptions.ByTypes, filterOptions.ByStatus, (*uint64)(filterOptions.FromBlock), (*uint64)(filterOptions.ToBlock), offset, limit)
 }
 

--- a/modules/gql/schema.graphql
+++ b/modules/gql/schema.graphql
@@ -221,6 +221,20 @@ type LedgerRecord {
   tx_id: String!
 }
 
+type ActionRecord {
+  id: String!
+  status: String!
+  amount: Int64!
+  asset: String!
+  to: String!
+  memo: String!
+  action_id: String!
+  type: String!
+  params: Map
+  block_height: Uint64!
+  timestamp: String!
+}
+
 type ElectionMember {
   key: String!
   account: String!
@@ -244,6 +258,18 @@ input LedgerTxFilter {
   byToFrom: String
   byTxId: String
   byTypes: [String!]
+  fromBlock: Uint64
+  toBlock: Uint64
+  offset: Int
+  limit: Int
+}
+
+input LedgerActionsFilter {
+  byTxId: String
+  byActionId: String
+  byAccount: String
+  byTypes: [String!]
+  byStatus: String
   fromBlock: Uint64
   toBlock: Uint64
   offset: Int
@@ -278,6 +304,7 @@ type Query {
     decodedFilter: JSON
   ): FindContractOutputResult
   findLedgerTXs(filterOptions: LedgerTxFilter): [LedgerRecord!]
+  findLedgerActions(filterOptions: LedgerActionsFilter): [ActionRecord!]
   getAccountBalance(account: String!, height: Uint64): BalanceRecord
   findContract(id: String): FindContractResult
   submitTransactionV1(tx: String!, sig: String!): TransactionSubmitResult

--- a/modules/gql/schema.graphql
+++ b/modules/gql/schema.graphql
@@ -201,6 +201,12 @@ type BalanceRecord {
   hive_consensus: Int64!
 }
 
+type RcRecord {
+  account: String!
+  amount: Int64!
+  block_height: Uint64!
+}
+
 type FindContractOutputResult {
   outputs: [ContractOutput]
 }
@@ -306,6 +312,7 @@ type Query {
   findLedgerTXs(filterOptions: LedgerTxFilter): [LedgerRecord!]
   findLedgerActions(filterOptions: LedgerActionsFilter): [ActionRecord!]
   getAccountBalance(account: String!, height: Uint64): BalanceRecord
+  getAccountRC(account: String!, height: Uint64): RcRecord
   findContract(id: String): FindContractResult
   submitTransactionV1(tx: String!, sig: String!): TransactionSubmitResult
   getAccountNonce(account: String!): NonceRecord

--- a/modules/state-processing/ledger_system.go
+++ b/modules/state-processing/ledger_system.go
@@ -401,6 +401,7 @@ func (ls *LedgerSystem) ExecuteOplog(oplog []ledgerSystem.OpLogEvent, startHeigh
 
 type ExtraInfo struct {
 	BlockHeight uint64
+	ActionId    string
 }
 
 func (ls *LedgerSystem) IndexActions(actionUpdate map[string]interface{}, extraInfo ExtraInfo) {
@@ -422,7 +423,7 @@ func (ls *LedgerSystem) IndexActions(actionUpdate map[string]interface{}, extraI
 		if record == nil {
 			continue
 		}
-		ls.ActionsDb.ExecuteComplete(id)
+		ls.ActionsDb.ExecuteComplete(&extraInfo.ActionId, id)
 
 		if record.Type == "stake" {
 			ls.log.Debug("Indexxing stake Ledger")

--- a/modules/state-processing/ledger_system_test.go
+++ b/modules/state-processing/ledger_system_test.go
@@ -155,7 +155,7 @@ func (m *MockWithdrawsDb) MarkComplete(id string) {
 	m.Withdraws[id] = withdraw
 }
 
-func (m *MockWithdrawsDb) ExecuteComplete(id string) {
+func (m *MockWithdrawsDb) ExecuteComplete(actionId *string, id string) {
 
 }
 

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -301,6 +301,7 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 
 				se.LedgerExecutor.Ls.IndexActions(actionUpdate, ExtraInfo{
 					block.BlockNumber,
+					tx.TransactionID,
 				})
 
 				// if tx.Operations[1].Type == "transfer" {
@@ -784,7 +785,7 @@ func (se *StateEngine) UpdateBalances(startBlock, endBlock uint64) {
 		})
 	}
 	se.LedgerExecutor.Ls.LedgerDb.StoreLedger(ledgerRecords...)
-	se.LedgerExecutor.Ls.ActionsDb.ExecuteComplete(completeIds...)
+	se.LedgerExecutor.Ls.ActionsDb.ExecuteComplete(nil, completeIds...)
 
 	//se.log.Debug("stBlock, endBlock", stBlock, endBlock)
 	distinctAccounts, _ := se.LedgerExecutor.Ls.LedgerDb.GetDistinctAccountsRange(stBlock, endBlock)


### PR DESCRIPTION
`withdraw_id` has been renamed to `action_id` in `ledger_actions` collection to index tx id of action fulfilment hence reindex is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new GraphQL queries to retrieve detailed ledger action records and account resource credit (RC) balances, with advanced filtering and pagination options.
  - Added new types to the GraphQL schema: `ActionRecord` and `RcRecord`, exposing additional fields such as status, amount, block height, and timestamp.
- **Enhancements**
  - Improved filtering, sorting, and pagination capabilities for ledger actions and RC records in API responses.
  - Included additional database modules in GraphQL resolver dependencies for expanded data access.
  - Enhanced action completion processing with contextual action ID support.
  - Refined MongoDB aggregation pipelines for consistent timestamp handling and sorting.
- **Bug Fixes**
  - Ensured correct retrieval of the latest RC record by sorting query results by block height.
- **Chores**
  - Updated internal version identifier for database reindexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->