### PR TITLE
Support for filtering findTransaction with a list of IDs

### DIFF
--- a/modules/db/vsc/hive_blocks/hive_blocks.go
+++ b/modules/db/vsc/hive_blocks/hive_blocks.go
@@ -561,10 +561,7 @@ func GetAggTimestampPipeline(filters bson.D, localField string, timestampField s
 			{Key: "as", Value: "block_info"},
 		}}},
 		// Unwind the joined array, saving the operation index into opId
-		{{Key: "$unwind", Value: bson.D{
-			{Key: "path", Value: "$block_info"},
-			{Key: "includeArrayIndex", Value: "op_id"},
-		}}},
+		{{Key: "$unwind", Value: "$block_info"}},
 		{{Key: "$addFields", Value: bson.D{
 			{Key: "tx_id", Value: "$id"},
 		}}},

--- a/modules/db/vsc/hive_blocks/hive_blocks.go
+++ b/modules/db/vsc/hive_blocks/hive_blocks.go
@@ -574,8 +574,8 @@ func GetAggTimestampPipeline(filters bson.D, localField string, timestampField s
 					Key: "$concat",
 					Value: bson.A{
 						"$id",
-						"#",
-						bson.D{{Key: "$toString", Value: "$op_id"}},
+						"-",
+						bson.D{{Key: "$toString", Value: "$anchr_opidx"}},
 					},
 				},
 			}},

--- a/modules/db/vsc/hive_blocks/hive_blocks.go
+++ b/modules/db/vsc/hive_blocks/hive_blocks.go
@@ -560,8 +560,26 @@ func GetAggTimestampPipeline(filters bson.D, localField string, timestampField s
 			{Key: "foreignField", Value: "block.block_number"},
 			{Key: "as", Value: "block_info"},
 		}}},
-		// Unwind the joined array
-		{{Key: "$unwind", Value: "$block_info"}},
+		// Unwind the joined array, saving the operation index into opId
+		{{Key: "$unwind", Value: bson.D{
+			{Key: "path", Value: "$block_info"},
+			{Key: "includeArrayIndex", Value: "op_id"},
+		}}},
+		{{Key: "$addFields", Value: bson.D{
+			{Key: "tx_id", Value: "$id"},
+		}}},
+		{{Key: "$set", Value: bson.D{
+			{Key: "id", Value: bson.D{
+				{
+					Key: "$concat",
+					Value: bson.A{
+						"$id",
+						"#",
+						bson.D{{Key: "$toString", Value: "$op_id"}},
+					},
+				},
+			}},
+		}}},
 		// Add timestamp field
 		{{Key: "$addFields", Value: bson.D{
 			{Key: timestampField, Value: "$block_info.block.timestamp"},

--- a/modules/db/vsc/transactions/interface.go
+++ b/modules/db/vsc/transactions/interface.go
@@ -7,7 +7,7 @@ type Transactions interface {
 	Ingest(offTx IngestTransactionUpdate) error
 	SetOutput(sOut SetResultUpdate)
 	GetTransaction(id string) *TransactionRecord
-	FindTransactions(id *string, account *string, contract *string, status *TransactionStatus, byType *string, ledgerToFrom *string, ledgerTypes []string, offset int, limit int) ([]TransactionRecord, error)
+	FindTransactions(ids []string, id *string, account *string, contract *string, status *TransactionStatus, byType *string, ledgerToFrom *string, ledgerTypes []string, offset int, limit int) ([]TransactionRecord, error)
 	FindUnconfirmedTransactions(height uint64) ([]TransactionRecord, error)
 	// SetStatus(ids []string, status string)
 }

--- a/modules/db/vsc/transactions/schema.go
+++ b/modules/db/vsc/transactions/schema.go
@@ -53,6 +53,8 @@ type TransactionRecord struct {
 	Nonce         int64    `json:"nonce" bson:"nonce"`
 	RcLimit       uint64   `json:"rc_limit" bson:"rc_limit"`
 	//VSC or Hive
+	OpId           uint64                     `json:"op_id" bson:"op_id"`
+	TxId           string                     `json:"tx_id" bson:"tx_id"`
 	Type           string                     `json:"type" bson:"type"`
 	Version        string                     `json:"__v" bson:"__v"`
 	Data           map[string]interface{}     `json:"data" bson:"data"`

--- a/modules/db/vsc/transactions/schema.go
+++ b/modules/db/vsc/transactions/schema.go
@@ -53,7 +53,7 @@ type TransactionRecord struct {
 	Nonce         int64    `json:"nonce" bson:"nonce"`
 	RcLimit       uint64   `json:"rc_limit" bson:"rc_limit"`
 	//VSC or Hive
-	TxId           string                     `json:"tx_id" bson:"tx_id"`
+	TxId           string                     `json:"tx_id,omitempty" bson:"tx_id,omitempty"`
 	Type           string                     `json:"type" bson:"type"`
 	Version        string                     `json:"__v" bson:"__v"`
 	Data           map[string]interface{}     `json:"data" bson:"data"`

--- a/modules/db/vsc/transactions/schema.go
+++ b/modules/db/vsc/transactions/schema.go
@@ -53,7 +53,6 @@ type TransactionRecord struct {
 	Nonce         int64    `json:"nonce" bson:"nonce"`
 	RcLimit       uint64   `json:"rc_limit" bson:"rc_limit"`
 	//VSC or Hive
-	OpId           uint64                     `json:"op_id" bson:"op_id"`
 	TxId           string                     `json:"tx_id" bson:"tx_id"`
 	Type           string                     `json:"type" bson:"type"`
 	Version        string                     `json:"__v" bson:"__v"`

--- a/modules/db/vsc/transactions/transactionsDb.go
+++ b/modules/db/vsc/transactions/transactionsDb.go
@@ -131,9 +131,8 @@ func (e *transactions) FindTransactions(ids []string, id *string, account *strin
 	if id != nil {
 		filters = append(filters, bson.E{Key: "id", Value: *id})
 	}
-
 	if ids != nil {
-		filters = append(filters, bson.E{Key: "id", Value: bson.E{Key: "$in", Value: ids}})
+		filters = append(filters, bson.E{Key: "id", Value: bson.D{{Key: "$in", Value: ids}}})
 	}
 	if account != nil {
 		filters = append(filters, bson.E{Key: "$or", Value: bson.A{

--- a/modules/db/vsc/transactions/transactionsDb.go
+++ b/modules/db/vsc/transactions/transactionsDb.go
@@ -2,6 +2,7 @@ package transactions
 
 import (
 	"context"
+	"errors"
 	"time"
 	"vsc-node/modules/db"
 	"vsc-node/modules/db/vsc"
@@ -122,10 +123,21 @@ func (e *transactions) GetTransaction(id string) *TransactionRecord {
 	return &record
 }
 
-func (e *transactions) FindTransactions(id *string, account *string, contract *string, status *TransactionStatus, byType *string, ledgerToFrom *string, ledgerTypes []string, offset int, limit int) ([]TransactionRecord, error) {
+func (e *transactions) FindTransactions(ids []string, id *string, account *string, contract *string, status *TransactionStatus, byType *string, ledgerToFrom *string, ledgerTypes []string, offset int, limit int) ([]TransactionRecord, error) {
+	if id != nil && ids != nil {
+		return nil, errors.New("Either input a single id or a list of ids.")
+	}
 	filters := bson.D{}
 	if id != nil {
 		filters = append(filters, bson.E{Key: "id", Value: *id})
+	}
+
+	if ids != nil {
+		bsonIds := bson.A{}
+		for _, t := range ids {
+			bsonIds = append(bsonIds, t)
+		}
+		filters = append(filters, bson.E{Key: "id", Value: bson.E{Key: "$in", Value: bsonIds}})
 	}
 	if account != nil {
 		filters = append(filters, bson.E{Key: "$or", Value: bson.A{

--- a/modules/db/vsc/transactions/transactionsDb.go
+++ b/modules/db/vsc/transactions/transactionsDb.go
@@ -125,7 +125,7 @@ func (e *transactions) GetTransaction(id string) *TransactionRecord {
 
 func (e *transactions) FindTransactions(ids []string, id *string, account *string, contract *string, status *TransactionStatus, byType *string, ledgerToFrom *string, ledgerTypes []string, offset int, limit int) ([]TransactionRecord, error) {
 	if id != nil && ids != nil {
-		return nil, errors.New("Either input a single id or a list of ids.")
+		return nil, errors.New("either input a single id or a list of ids")
 	}
 	filters := bson.D{}
 	if id != nil {
@@ -133,11 +133,7 @@ func (e *transactions) FindTransactions(ids []string, id *string, account *strin
 	}
 
 	if ids != nil {
-		bsonIds := bson.A{}
-		for _, t := range ids {
-			bsonIds = append(bsonIds, t)
-		}
-		filters = append(filters, bson.E{Key: "id", Value: bson.E{Key: "$in", Value: bsonIds}})
+		filters = append(filters, bson.E{Key: "id", Value: bson.E{Key: "$in", Value: ids}})
 	}
 	if account != nil {
 		filters = append(filters, bson.E{Key: "$or", Value: bson.A{

--- a/modules/gql/gqlgen/generated.go
+++ b/modules/gql/gqlgen/generated.go
@@ -2008,6 +2008,7 @@ input LedgerActionsFilter {
 
 input TransactionFilter {
   byId: String
+  byIds: [String!]
   byAccount: String
   byContract: String
   byStatus: TransactionStatus
@@ -11979,7 +11980,7 @@ func (ec *executionContext) unmarshalInputTransactionFilter(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"byId", "byAccount", "byContract", "byStatus", "byType", "byLedgerToFrom", "byLedgerTypes", "offset", "limit"}
+	fieldsInOrder := [...]string{"byId", "byIds", "byAccount", "byContract", "byStatus", "byType", "byLedgerToFrom", "byLedgerTypes", "offset", "limit"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -11993,6 +11994,13 @@ func (ec *executionContext) unmarshalInputTransactionFilter(ctx context.Context,
 				return it, err
 			}
 			it.ByID = data
+		case "byIds":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("byIds"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ByIds = data
 		case "byAccount":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("byAccount"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)

--- a/modules/gql/gqlgen/generated.go
+++ b/modules/gql/gqlgen/generated.go
@@ -282,7 +282,6 @@ type ComplexityRoot struct {
 		Id            func(childComplexity int) int
 		Ledger        func(childComplexity int) int
 		Nonce         func(childComplexity int) int
-		OpID          func(childComplexity int) int
 		RcLimit       func(childComplexity int) int
 		RequiredAuths func(childComplexity int) int
 		Status        func(childComplexity int) int
@@ -412,8 +411,6 @@ type TransactionRecordResolver interface {
 	AnchrIndex(ctx context.Context, obj *transactions.TransactionRecord) (model.Uint64, error)
 	AnchrOpidx(ctx context.Context, obj *transactions.TransactionRecord) (model.Uint64, error)
 	AnchrTs(ctx context.Context, obj *transactions.TransactionRecord) (string, error)
-
-	OpID(ctx context.Context, obj *transactions.TransactionRecord) (model.Uint64, error)
 
 	Data(ctx context.Context, obj *transactions.TransactionRecord) (model.Map, error)
 
@@ -1475,13 +1472,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.TransactionRecord.Nonce(childComplexity), true
 
-	case "TransactionRecord.op_id":
-		if e.complexity.TransactionRecord.OpID == nil {
-			break
-		}
-
-		return e.complexity.TransactionRecord.OpID(childComplexity), true
-
 	case "TransactionRecord.rc_limit":
 		if e.complexity.TransactionRecord.RcLimit == nil {
 			break
@@ -1775,7 +1765,6 @@ type TransactionRecord {
   anchr_opidx: Uint64!
   anchr_ts: String!
   type: String!
-  op_id: Uint64!
   tx_id: String!
   data: Map
   first_seen: DateTime!
@@ -6872,8 +6861,6 @@ func (ec *executionContext) fieldContext_Query_findTransaction(ctx context.Conte
 				return ec.fieldContext_TransactionRecord_anchr_ts(ctx, field)
 			case "type":
 				return ec.fieldContext_TransactionRecord_type(ctx, field)
-			case "op_id":
-				return ec.fieldContext_TransactionRecord_op_id(ctx, field)
 			case "tx_id":
 				return ec.fieldContext_TransactionRecord_tx_id(ctx, field)
 			case "data":
@@ -8877,50 +8864,6 @@ func (ec *executionContext) fieldContext_TransactionRecord_type(_ context.Contex
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _TransactionRecord_op_id(ctx context.Context, field graphql.CollectedField, obj *transactions.TransactionRecord) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_TransactionRecord_op_id(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.TransactionRecord().OpID(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(model.Uint64)
-	fc.Result = res
-	return ec.marshalNUint642vscᚑnodeᚋmodulesᚋgqlᚋmodelᚐUint64(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_TransactionRecord_op_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "TransactionRecord",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Uint64 does not have child fields")
 		},
 	}
 	return fc, nil
@@ -15321,42 +15264,6 @@ func (ec *executionContext) _TransactionRecord(ctx context.Context, sel ast.Sele
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "op_id":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._TransactionRecord_op_id(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "tx_id":
 			out.Values[i] = ec._TransactionRecord_tx_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/modules/gql/gqlgen/generated.go
+++ b/modules/gql/gqlgen/generated.go
@@ -282,9 +282,11 @@ type ComplexityRoot struct {
 		Id            func(childComplexity int) int
 		Ledger        func(childComplexity int) int
 		Nonce         func(childComplexity int) int
+		OpID          func(childComplexity int) int
 		RcLimit       func(childComplexity int) int
 		RequiredAuths func(childComplexity int) int
 		Status        func(childComplexity int) int
+		TxId          func(childComplexity int) int
 		Type          func(childComplexity int) int
 	}
 
@@ -410,6 +412,8 @@ type TransactionRecordResolver interface {
 	AnchrIndex(ctx context.Context, obj *transactions.TransactionRecord) (model.Uint64, error)
 	AnchrOpidx(ctx context.Context, obj *transactions.TransactionRecord) (model.Uint64, error)
 	AnchrTs(ctx context.Context, obj *transactions.TransactionRecord) (string, error)
+
+	OpID(ctx context.Context, obj *transactions.TransactionRecord) (model.Uint64, error)
 
 	Data(ctx context.Context, obj *transactions.TransactionRecord) (model.Map, error)
 
@@ -1471,6 +1475,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.TransactionRecord.Nonce(childComplexity), true
 
+	case "TransactionRecord.op_id":
+		if e.complexity.TransactionRecord.OpID == nil {
+			break
+		}
+
+		return e.complexity.TransactionRecord.OpID(childComplexity), true
+
 	case "TransactionRecord.rc_limit":
 		if e.complexity.TransactionRecord.RcLimit == nil {
 			break
@@ -1491,6 +1502,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.TransactionRecord.Status(childComplexity), true
+
+	case "TransactionRecord.tx_id":
+		if e.complexity.TransactionRecord.TxId == nil {
+			break
+		}
+
+		return e.complexity.TransactionRecord.TxId(childComplexity), true
 
 	case "TransactionRecord.type":
 		if e.complexity.TransactionRecord.Type == nil {
@@ -1757,6 +1775,8 @@ type TransactionRecord {
   anchr_opidx: Uint64!
   anchr_ts: String!
   type: String!
+  op_id: Uint64!
+  tx_id: String!
   data: Map
   first_seen: DateTime!
   nonce: Uint64!
@@ -6852,6 +6872,10 @@ func (ec *executionContext) fieldContext_Query_findTransaction(ctx context.Conte
 				return ec.fieldContext_TransactionRecord_anchr_ts(ctx, field)
 			case "type":
 				return ec.fieldContext_TransactionRecord_type(ctx, field)
+			case "op_id":
+				return ec.fieldContext_TransactionRecord_op_id(ctx, field)
+			case "tx_id":
+				return ec.fieldContext_TransactionRecord_tx_id(ctx, field)
 			case "data":
 				return ec.fieldContext_TransactionRecord_data(ctx, field)
 			case "first_seen":
@@ -8846,6 +8870,94 @@ func (ec *executionContext) _TransactionRecord_type(ctx context.Context, field g
 }
 
 func (ec *executionContext) fieldContext_TransactionRecord_type(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TransactionRecord",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TransactionRecord_op_id(ctx context.Context, field graphql.CollectedField, obj *transactions.TransactionRecord) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TransactionRecord_op_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TransactionRecord().OpID(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.Uint64)
+	fc.Result = res
+	return ec.marshalNUint642vscᚑnodeᚋmodulesᚋgqlᚋmodelᚐUint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TransactionRecord_op_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TransactionRecord",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Uint64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TransactionRecord_tx_id(ctx context.Context, field graphql.CollectedField, obj *transactions.TransactionRecord) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TransactionRecord_tx_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TxId, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TransactionRecord_tx_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "TransactionRecord",
 		Field:      field,
@@ -15206,6 +15318,47 @@ func (ec *executionContext) _TransactionRecord(ctx context.Context, sel ast.Sele
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "type":
 			out.Values[i] = ec._TransactionRecord_type(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "op_id":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TransactionRecord_op_id(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "tx_id":
+			out.Values[i] = ec._TransactionRecord_tx_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}

--- a/modules/gql/gqlgen/models.go
+++ b/modules/gql/gqlgen/models.go
@@ -140,6 +140,7 @@ type TransactionData struct {
 
 type TransactionFilter struct {
 	ByID           *string                         `json:"byId,omitempty"`
+	ByIds          []string                        `json:"byIds,omitempty"`
 	ByAccount      *string                         `json:"byAccount,omitempty"`
 	ByContract     *string                         `json:"byContract,omitempty"`
 	ByStatus       *transactions.TransactionStatus `json:"byStatus,omitempty"`

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -233,7 +233,7 @@ func (r *queryResolver) FindTransaction(ctx context.Context, filterOptions *Tran
 	if paginateErr != nil {
 		return nil, paginateErr
 	}
-	return r.Transactions.FindTransactions(filterOptions.ByID, filterOptions.ByAccount, filterOptions.ByContract, filterOptions.ByStatus, filterOptions.ByType, filterOptions.ByLedgerToFrom, filterOptions.ByLedgerTypes, offset, limit)
+	return r.Transactions.FindTransactions(filterOptions.ByIds, filterOptions.ByID, filterOptions.ByAccount, filterOptions.ByContract, filterOptions.ByStatus, filterOptions.ByType, filterOptions.ByLedgerToFrom, filterOptions.ByLedgerTypes, offset, limit)
 }
 
 // FindContractOutput is the resolver for the findContractOutput field.

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -457,11 +457,6 @@ func (r *transactionRecordResolver) AnchrTs(ctx context.Context, obj *transactio
 	return *obj.AnchoredTs, nil
 }
 
-// OpID is the resolver for the op_id field.
-func (r *transactionRecordResolver) OpID(ctx context.Context, obj *transactions.TransactionRecord) (model.Uint64, error) {
-	return model.Uint64(obj.OpId), nil
-}
-
 // Data is the resolver for the data field.
 func (r *transactionRecordResolver) Data(ctx context.Context, obj *transactions.TransactionRecord) (model.Map, error) {
 	return model.Map(obj.Data), nil
@@ -562,7 +557,7 @@ type witnessSlotResolver struct{ *Resolver }
 //    it when you're done.
 //  - You have helper methods in this file. Move them out to keep these resolver files clean.
 /*
-	func (r *transactionRecordResolver) TxID(ctx context.Context, obj *transactions.TransactionRecord) (string, error) {
-	return obj.TxId, nil
+	func (r *transactionRecordResolver) OpID(ctx context.Context, obj *transactions.TransactionRecord) (model.Uint64, error) {
+	return model.Uint64(obj.OpId), nil
 }
 */

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -457,6 +457,11 @@ func (r *transactionRecordResolver) AnchrTs(ctx context.Context, obj *transactio
 	return *obj.AnchoredTs, nil
 }
 
+// OpID is the resolver for the op_id field.
+func (r *transactionRecordResolver) OpID(ctx context.Context, obj *transactions.TransactionRecord) (model.Uint64, error) {
+	return model.Uint64(obj.OpId), nil
+}
+
 // Data is the resolver for the data field.
 func (r *transactionRecordResolver) Data(ctx context.Context, obj *transactions.TransactionRecord) (model.Map, error) {
 	return model.Map(obj.Data), nil
@@ -549,3 +554,15 @@ type rcRecordResolver struct{ *Resolver }
 type transactionRecordResolver struct{ *Resolver }
 type witnessResolver struct{ *Resolver }
 type witnessSlotResolver struct{ *Resolver }
+
+// !!! WARNING !!!
+// The code below was going to be deleted when updating resolvers. It has been copied here so you have
+// one last chance to move it out of harms way if you want. There are two reasons this happens:
+//  - When renaming or deleting a resolver the old code will be put in here. You can safely delete
+//    it when you're done.
+//  - You have helper methods in this file. Move them out to keep these resolver files clean.
+/*
+	func (r *transactionRecordResolver) TxID(ctx context.Context, obj *transactions.TransactionRecord) (string, error) {
+	return obj.TxId, nil
+}
+*/

--- a/modules/gql/schema.graphql
+++ b/modules/gql/schema.graphql
@@ -293,6 +293,7 @@ input LedgerActionsFilter {
 
 input TransactionFilter {
   byId: String
+  byIds: [String!]
   byAccount: String
   byContract: String
   byStatus: TransactionStatus

--- a/modules/gql/schema.graphql
+++ b/modules/gql/schema.graphql
@@ -42,7 +42,6 @@ type TransactionRecord {
   anchr_opidx: Uint64!
   anchr_ts: String!
   type: String!
-  op_id: Uint64!
   tx_id: String!
   data: Map
   first_seen: DateTime!

--- a/modules/gql/schema.graphql
+++ b/modules/gql/schema.graphql
@@ -42,6 +42,8 @@ type TransactionRecord {
   anchr_opidx: Uint64!
   anchr_ts: String!
   type: String!
+  op_id: Uint64!
+  tx_id: String!
   data: Map
   first_seen: DateTime!
   nonce: Uint64!


### PR DESCRIPTION
Example transaction link: https://api.vsc.eco/sandbox?explorerURLState=N4IgJg9gxgrgtgUwHYBcQC4QEcYIE4CeABAGICWSYAKngIZIDOtUKZESAFACQBmZANinwB5AA6t2DdERr0mLNknKD8ASiLAAOkiJE%2BlWY2YTOfFXjEmpRXgKEXxihuq07dRMmG26Avtp8gADQgAG60eGS0AEb8CAwYIK66miBm9pZOKdJJ7ilRBACCUFAQMKhZRCkAFmQhCOgAXqJVeAwpgd65IPkAkmBtGEQA2p3ulSC0AAwAzACcAIxQ8wAsy7PLAEwA7ABsAKzzO-N7tGAAHLQ7G-NbCAhRO5Nb81FR0VFeQZVuY3kb0bNZrQXrMNlBorQENM9lFJqC9tDaGcoGBpscwA85rM9pMUqMiABdTp%2BJABHxAA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for filtering transactions by multiple IDs in transaction filters.
  - Enhanced the GraphQL API with new `op_id` and `tx_id` fields on `TransactionRecord`.
  - Introduced a new `byIds` field in `TransactionFilter` to query transactions by multiple IDs.

- **Bug Fixes**
  - Prevented simultaneous use of single and multiple transaction ID filters to avoid conflicting queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->