### PR TITLE
Fix stake_hbd oplog append

### DIFF
--- a/modules/state-processing/ledger_system.go
+++ b/modules/state-processing/ledger_system.go
@@ -1127,7 +1127,7 @@ func (le *LedgerExecutor) Stake(stakeOp StakeOp, ledgerSession *LedgerSession, o
 	// 	})
 	// }
 
-	le.Oplog = append(le.Oplog, ledgerSystem.OpLogEvent{
+	ledgerSession.AppendOplog(ledgerSystem.OpLogEvent{
 		Id: stakeOp.Id,
 		// Index: 1,
 


### PR DESCRIPTION
It should go to `ledgerSession` instead of `ledgerExecutor` like other operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved how operation log events are handled during staking by delegating the logging process to the session, ensuring more consistent and reliable ledger updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->