### PR TITLE
Add GraphQL log subscriptions & included logs in ContractOutputResult

### DIFF
--- a/cmd/vsc-node/main.go
+++ b/cmd/vsc-node/main.go
@@ -28,6 +28,7 @@ import (
 	"vsc-node/modules/gateway"
 	"vsc-node/modules/gql"
 	"vsc-node/modules/gql/gqlgen"
+	"vsc-node/modules/gql/logstream"
 	"vsc-node/modules/hive/streamer"
 	p2pInterface "vsc-node/modules/p2p"
 	stateEngine "vsc-node/modules/state-processing"
@@ -50,7 +51,6 @@ func main() {
 	fmt.Println("MONGO_URL", os.Getenv("MONGO_URL"))
 	fmt.Println("HIVE_API", hiveApiUrl.Get().HiveURI)
 	fmt.Println("Git Commit", announcements.GitCommit)
-
 	dbImpl := db.New(dbConf)
 	vscDb := vsc.New(dbImpl)
 	reindexDb := db.NewReindex(vscDb.DbInstance)
@@ -124,7 +124,9 @@ func main() {
 	l := logger.PrefixedLogger{
 		"vsc-node",
 	}
-	se := stateEngine.New(l, da, witnessDb, electionDb, contractDb, contractState, txDb, ledgerDbImpl, balanceDb, hiveBlocks, interestClaims, vscBlocks, actionsDb, rcDb, nonceDb, wasm)
+
+	ls := logstream.NewLogStream()
+	se := stateEngine.New(l, da, witnessDb, electionDb, contractDb, contractState, txDb, ledgerDbImpl, balanceDb, hiveBlocks, interestClaims, vscBlocks, actionsDb, rcDb, nonceDb, wasm, ls)
 
 	rcSystem := se.RcSystem
 
@@ -154,6 +156,7 @@ func main() {
 		da,
 		contractDb,
 		contractState,
+		*ls,
 	}}), "0.0.0.0:8080")
 
 	plugins := make([]aggregate.Plugin, 0)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/ethereum/go-ethereum v1.14.12
 	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/hasura/go-graphql-client v0.13.1
-	github.com/libp2p/go-libp2p-gorpc v0.6.0
 	github.com/moznion/go-optional v0.12.0
 	github.com/protolambda/bls12-381-util v0.1.0
 	github.com/robfig/cron/v3 v3.0.1
@@ -21,9 +20,6 @@ require (
 	github.com/vektah/gqlparser/v2 v2.5.23
 	github.com/vsc-eco/go-ethereum v0.0.1
 	github.com/vsc-eco/hivego v0.0.0-20250604205027-fa6c9e2c8be7
-	github.com/zealic/go2node v0.1.0
-	github.com/zyedidia/generic v1.2.1
-	gitlab.com/NebulousLabs/go-upnp v0.0.0-20211002182029-11da932010b6
 	go.mongodb.org/mongo-driver v1.16.0
 )
 
@@ -58,7 +54,6 @@ require (
 require (
 	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/coder/websocket v1.8.13 // indirect
-	github.com/creachadair/mds v0.23.0 // indirect
 	github.com/sosodev/duration v1.3.1 // indirect
 	github.com/urfave/cli/v2 v2.27.6 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
@@ -139,7 +134,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
-	github.com/creachadair/jrpc2 v1.3.1
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
@@ -152,7 +146,7 @@ require (
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/gorilla/websocket v1.5.3
 	github.com/holiman/uint256 v1.3.1 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/ipfs/go-cid v0.5.0
@@ -222,11 +216,9 @@ require (
 	github.com/quic-go/webtransport-go v0.8.1-0.20241018022711-4ac2c9250e66 // indirect
 	github.com/raulk/go-watchdog v1.3.0 // indirect
 	github.com/second-state/WasmEdge-go v0.13.4
-	github.com/segmentio/fasthash v1.0.3 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/stretchr/testify v1.10.0
-	gitlab.com/NebulousLabs/fastrand v0.0.0-20181126182046-603482d69e40 // indirect
 	go.uber.org/dig v1.18.0 // indirect
 	go.uber.org/fx v1.23.0 // indirect
 	go.uber.org/mock v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,10 +103,6 @@ github.com/crate-crypto/go-ipa v0.0.0-20240223125850-b1e8a79f509c h1:uQYC5Z1mdLR
 github.com/crate-crypto/go-ipa v0.0.0-20240223125850-b1e8a79f509c/go.mod h1:geZJZH3SzKCqnz5VT0q/DyIG/tvu/dZk+VIfXicupJs=
 github.com/crate-crypto/go-kzg-4844 v1.1.0 h1:EN/u9k2TF6OWSHrCCDBBU6GLNMq88OspHHlMnHfoyU4=
 github.com/crate-crypto/go-kzg-4844 v1.1.0/go.mod h1:JolLjpSff1tCCJKaJx4psrlEdlXuJEC996PL3tTAFks=
-github.com/creachadair/jrpc2 v1.3.1 h1:4B2R9050CYdhCKepbFVWQVG0/EFqRa9MuuM1Thd7tZo=
-github.com/creachadair/jrpc2 v1.3.1/go.mod h1:GtMp2RXHMnrdOY8hWWlbBpjWXSVDXhuO/LMRJAtRFno=
-github.com/creachadair/mds v0.23.0 h1:cANHIuKZwbfIoo/zEWA2sn+uGYjqYHuWvpoApkdjGpg=
-github.com/creachadair/mds v0.23.0/go.mod h1:ArfS0vPHoLV/SzuIzoqTEZfoYmac7n9Cj8XPANHocvw=
 github.com/cskr/pubsub v1.0.2 h1:vlOzMhl6PFn60gRlTQQsIfVwaPB/B/8MziK8FhEPt/0=
 github.com/cskr/pubsub v1.0.2/go.mod h1:/8MzYXk/NJAz782G8RPkFzXTZVu63VotefPnR9TIRis=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -158,8 +154,6 @@ github.com/filecoin-project/go-clock v0.1.0/go.mod h1:4uB/O4PvOjlx1VCMdZ9MyDZXRm
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v1.1.0 h1:KjPQoQCEFdZDiP03phOvGi11+SVVhBG2wOWAorLsstg=
 github.com/flynn/noise v1.1.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=
-github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
-github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -366,8 +360,6 @@ github.com/libp2p/go-libp2p v0.38.2 h1:9SZQDOCi82A25An4kx30lEtr6kGTxrtoaDkbs5xrK
 github.com/libp2p/go-libp2p v0.38.2/go.mod h1:QWV4zGL3O9nXKdHirIC59DoRcZ446dfkjbOJ55NEWFo=
 github.com/libp2p/go-libp2p-asn-util v0.4.1 h1:xqL7++IKD9TBFMgnLPZR6/6iYhawHKHl950SO9L6n94=
 github.com/libp2p/go-libp2p-asn-util v0.4.1/go.mod h1:d/NI6XZ9qxw67b4e+NgpQexCIiFYJjErASrYW4PFDN8=
-github.com/libp2p/go-libp2p-gorpc v0.6.0 h1:Z3ODCzbKe+2lUtEjRc+W+l8Olj63r68G5w1wrQ9ZsOw=
-github.com/libp2p/go-libp2p-gorpc v0.6.0/go.mod h1:jGTsI/yn1xL/9VupJ+DIXo8ExobWDKjwVdjNAfhFKxk=
 github.com/libp2p/go-libp2p-kad-dht v0.29.0 h1:045eW21lGlMSD9aKSZZGH4fnBMIInPwQLxIQ35P962I=
 github.com/libp2p/go-libp2p-kad-dht v0.29.0/go.mod h1:mIci3rHSwDsxQWcCjfmxD8vMTgh5xLuvwb1D5WP8ZNk=
 github.com/libp2p/go-libp2p-kbucket v0.6.4 h1:OjfiYxU42TKQSB8t8WYd8MKhYhMJeO2If+NiuKfb6iQ=
@@ -563,8 +555,6 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/second-state/WasmEdge-go v0.13.4 h1:NHfJC+aayUW93ydAzlcX7Jx1WDRpI24KvY5SAbeTyvY=
 github.com/second-state/WasmEdge-go v0.13.4/go.mod h1:HyBf9hVj1sRAjklsjc1Yvs9b5RcmthPG9z99dY78TKg=
-github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
-github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
@@ -654,8 +644,6 @@ github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49u
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
 github.com/vsc-eco/go-ethereum v0.0.1 h1:FlOvDj10WZCwzDK7bmcOVBaDuTBtUkWeoZGqrErJ7J0=
 github.com/vsc-eco/go-ethereum v0.0.1/go.mod h1:hjzsxodERJCS+XYc169Nz36F/7d1GKvMBya4E7MjFWs=
-github.com/vsc-eco/hivego v0.0.0-20250326022052-753ab49b6067 h1:KnmM6/lOgoY9cdrrni1tYHhRouXj3nOAa3kXCI2TJzM=
-github.com/vsc-eco/hivego v0.0.0-20250326022052-753ab49b6067/go.mod h1:iCM8eljf5SOSnYtAq4qy/Ax8qpi83lPr+rahUVcQ2e8=
 github.com/vsc-eco/hivego v0.0.0-20250604205027-fa6c9e2c8be7 h1:m0C8VkOU/0YHStDMAtEOzhTnzdRtdjgcSwtHvjz8NhQ=
 github.com/vsc-eco/hivego v0.0.0-20250604205027-fa6c9e2c8be7/go.mod h1:iCM8eljf5SOSnYtAq4qy/Ax8qpi83lPr+rahUVcQ2e8=
 github.com/warpfork/go-testmark v0.12.1 h1:rMgCpJfwy1sJ50x0M0NgyphxYYPMOODIJHhsXyEHU0s=
@@ -688,14 +676,6 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/zealic/go2node v0.1.0 h1:ofxpve08cmLJBwFdI0lPCk9jfwGWOSD+s6216x0oAaA=
-github.com/zealic/go2node v0.1.0/go.mod h1:GrkFr+HctXwP7vzcU9RsgtAeJjTQ6Ud0IPCQAqpTfBg=
-github.com/zyedidia/generic v1.2.1 h1:Zv5KS/N2m0XZZiuLS82qheRG4X1o5gsWreGb0hR7XDc=
-github.com/zyedidia/generic v1.2.1/go.mod h1:ly2RBz4mnz1yeuVbQA/VFwGjK3mnHGRj1JuoG336Bis=
-gitlab.com/NebulousLabs/fastrand v0.0.0-20181126182046-603482d69e40 h1:dizWJqTWjwyD8KGcMOwgrkqu1JIkofYgKkmDeNE7oAs=
-gitlab.com/NebulousLabs/fastrand v0.0.0-20181126182046-603482d69e40/go.mod h1:rOnSnoRyxMI3fe/7KIbVcsHRGxe30OONv8dEgo+vCfA=
-gitlab.com/NebulousLabs/go-upnp v0.0.0-20211002182029-11da932010b6 h1:WKij6HF8ECp9E7K0E44dew9NrRDGiNR5u4EFsXnJUx4=
-gitlab.com/NebulousLabs/go-upnp v0.0.0-20211002182029-11da932010b6/go.mod h1:vhrHTGDh4YR7wK8Z+kRJ+x8SF/6RUM3Vb64Si5FD0L8=
 go.mongodb.org/mongo-driver v1.16.0 h1:tpRsfBJMROVHKpdGyc1BBEzzjDUWjItxbVSZ8Ls4BQ4=
 go.mongodb.org/mongo-driver v1.16.0/go.mod h1:oB6AhJQvFQL4LEHyXi6aJzQJtBiTQHiAd83l0GdFaiw=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
@@ -784,7 +764,6 @@ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=
@@ -854,7 +833,6 @@ golang.org/x/term v0.16.0/go.mod h1:yn7UURbUtPyrVJPGPq404EukNFxcm/foM+bV/bfcDsY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=

--- a/modules/db/vsc/contracts/contracts.go
+++ b/modules/db/vsc/contracts/contracts.go
@@ -105,7 +105,6 @@ func (ch *contractState) IngestOutput(output IngestOutputArgs) {
 			"results":  output.Results,
 		},
 	}, options)
-
 }
 
 func (ch *contractState) GetLastOutput(contractId string, height uint64) (ContractOutput, error) {

--- a/modules/db/vsc/contracts/interface.go
+++ b/modules/db/vsc/contracts/interface.go
@@ -1,6 +1,8 @@
 package contracts
 
-import a "vsc-node/modules/aggregate"
+import (
+	a "vsc-node/modules/aggregate"
+)
 
 type Contracts interface {
 	a.Plugin

--- a/modules/e2e/node.go
+++ b/modules/e2e/node.go
@@ -25,6 +25,7 @@ import (
 	"vsc-node/modules/gateway"
 	"vsc-node/modules/gql"
 	"vsc-node/modules/gql/gqlgen"
+	"vsc-node/modules/gql/logstream"
 	p2pInterface "vsc-node/modules/p2p"
 	stateEngine "vsc-node/modules/state-processing"
 	transactionpool "vsc-node/modules/transaction-pool"
@@ -129,7 +130,9 @@ func MakeNode(input MakeNodeInput) *Node {
 	datalayer := DataLayer.New(p2p, input.Username)
 	wasm := wasm_runtime.New()
 
-	se := stateEngine.New(logger, datalayer, witnessesDb, electionDb, contractDb, contractState, txDb, ledgerDbImpl, balanceDb, hiveBlocks, interestClaims, vscBlocks, actionsDb, rcDb, nonceDb, wasm)
+	ls := logstream.NewLogStream()
+
+	se := stateEngine.New(logger, datalayer, witnessesDb, electionDb, contractDb, contractState, txDb, ledgerDbImpl, balanceDb, hiveBlocks, interestClaims, vscBlocks, actionsDb, rcDb, nonceDb, wasm, ls)
 
 	txpool := transactionpool.New(p2p, txDb, nonceDb, hiveBlocks, datalayer, identityConfig, se.RcSystem)
 
@@ -195,6 +198,7 @@ func MakeNode(input MakeNodeInput) *Node {
 			datalayer,
 			contractDb,
 			contractState,
+			*ls,
 		}}), "0.0.0.0:7080")
 		plugins = append(plugins, gqlManager)
 	}

--- a/modules/gql/gqlgen/models.go
+++ b/modules/gql/gqlgen/models.go
@@ -74,7 +74,23 @@ type LocalNodeInfo struct {
 	Epoch              model.Uint64 `json:"epoch"`
 }
 
+type Log struct {
+	BlockHeight     model.Uint64 `json:"blockHeight"`
+	TxHash          string       `json:"txHash"`
+	ContractAddress string       `json:"contractAddress"`
+	Log             string       `json:"log"`
+	Timestamp       string       `json:"timestamp"`
+}
+
+type LogFilter struct {
+	FromBlock         *model.Uint64 `json:"fromBlock,omitempty"`
+	ContractAddresses []string      `json:"contractAddresses,omitempty"`
+}
+
 type Query struct {
+}
+
+type Subscription struct {
 }
 
 type TransactionFilter struct {

--- a/modules/gql/gqlgen/resolver.go
+++ b/modules/gql/gqlgen/resolver.go
@@ -10,6 +10,7 @@ import (
 	rcDb "vsc-node/modules/db/vsc/rcs"
 	"vsc-node/modules/db/vsc/transactions"
 	"vsc-node/modules/db/vsc/witnesses"
+	"vsc-node/modules/gql/logstream"
 	stateEngine "vsc-node/modules/state-processing"
 	transactionpool "vsc-node/modules/transaction-pool"
 )
@@ -33,4 +34,5 @@ type Resolver struct {
 	Da             *datalayer.DataLayer
 	Contracts      contracts.Contracts
 	ContractsState contracts.ContractState
+	LogStream      logstream.LogStream
 }

--- a/modules/gql/logstream/logstream.go
+++ b/modules/gql/logstream/logstream.go
@@ -1,0 +1,92 @@
+package logstream
+
+import (
+	"sync"
+)
+
+// ContractLog is a single emitted log from a contract execution.
+type ContractLog struct {
+	BlockHeight     uint64
+	TxHash          string
+	ContractAddress string
+	Log             string
+	Timestamp       string
+}
+
+// LogFilterInternal restricts logs by minimum block or contract addresses.
+type LogFilterInternal struct {
+	FromBlock         *uint64
+	ContractAddresses map[string]struct{}
+}
+
+// logSubscriber represents a subscription including only filtered logs.
+type logSubscriber struct {
+	Id     int
+	Filter LogFilterInternal
+	Ch     chan ContractLog
+}
+
+// LogStream manages active subscribers and dispatches contract logs to them.
+type LogStream struct {
+	mu          sync.Mutex
+	nextID      int
+	subscribers map[int]*logSubscriber
+}
+
+// NewLogStream returns an initialized LogStream.
+func NewLogStream() *LogStream {
+	return &LogStream{
+		subscribers: make(map[int]*logSubscriber),
+	}
+}
+
+// Publish dispatches a log to all matching subscribers.
+func (ls *LogStream) Publish(log ContractLog) {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	// fmt.Printf("[logstream] Publish called: height=%d, addr=%s, tx=%s, log=%s\n",
+	//	log.BlockHeight, log.ContractAddress, log.TxHash, log.Log)
+
+	for _, sub := range ls.subscribers {
+		// fmt.Printf("[logstream] checking subscriber %d\n", sub.Id)
+		if sub.Filter.FromBlock != nil && log.BlockHeight < *sub.Filter.FromBlock {
+			continue
+		}
+		if len(sub.Filter.ContractAddresses) > 0 {
+			if _, ok := sub.Filter.ContractAddresses[log.ContractAddress]; !ok {
+				continue
+			}
+		}
+		select {
+		case sub.Ch <- log:
+			// fmt.Printf("[logstream] subscriber %d received log\n", sub.Id)
+		default: // subscribers log channel is full (they are not reading fat enuugh)
+			// fmt.Printf("[logstream] subscriber %d channel full, dropped log!\n", sub.Id)
+		}
+	}
+}
+
+// Subscribe registers and returns a new subscriber for the given filter.
+func (ls *LogStream) Subscribe(filter LogFilterInternal) *logSubscriber {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	id := ls.nextID
+	ls.nextID++
+	sub := &logSubscriber{
+		Id:     id,
+		Filter: filter,
+		Ch:     make(chan ContractLog, 128),
+	}
+	ls.subscribers[id] = sub
+	// fmt.Println("new subscriber: ", id)
+	return sub
+}
+
+// Unsubscribe removes a subscriber and closes its channel.
+func (ls *LogStream) Unsubscribe(sub *logSubscriber) {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	delete(ls.subscribers, sub.Id)
+	// fmt.Println("closed subscriber: ", sub.Id)
+	close(sub.Ch)
+}

--- a/modules/gql/schema.graphql
+++ b/modules/gql/schema.graphql
@@ -70,6 +70,7 @@ type TransactionOutput {
 type ContractOutputResult {
   ret: String!
   ok: Boolean!
+  logs: [String!] 
 }
 
 type ContractOutput {
@@ -293,6 +294,24 @@ type Query {
   getElection(epoch: Uint64!): ElectionResult
   electionByBlockHeight(blockHeight: Uint64): ElectionResult!
 }
+
+type Log {
+  blockHeight: Uint64!
+  txHash: String!
+  contractAddress: String!
+  log: String!        # raw string from sdk.Log()
+  timestamp: String!  # consistent with other timestamps
+}
+
+input LogFilter {
+  fromBlock: Uint64
+  contractAddresses: [String!]
+}
+
+type Subscription {
+  logs(filter: LogFilter): Log!
+}
+
 
 scalar Uint64
 scalar Int64

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -20,6 +20,7 @@ import (
 	"vsc-node/modules/db/vsc/transactions"
 	vscBlocks "vsc-node/modules/db/vsc/vsc_blocks"
 	"vsc-node/modules/db/vsc/witnesses"
+	"vsc-node/modules/gql/logstream"
 	ledgerSystem "vsc-node/modules/ledger-system"
 	rcSystem "vsc-node/modules/rc-system"
 	wasm_runtime "vsc-node/modules/wasm/runtime_ipc"
@@ -80,6 +81,8 @@ type StateEngine struct {
 	slotStatus *SlotStatus
 
 	BlockHeight int
+
+	LogStream *logstream.LogStream
 }
 
 //Transaction
@@ -1166,6 +1169,7 @@ func New(logger logger.Logger, da *DataLayer.DataLayer,
 	rcDb rcDb.RcDb,
 	nonceDb nonces.Nonces,
 	wasm *wasm_runtime.Wasm,
+	logstream *logstream.LogStream,
 ) *StateEngine {
 
 	ls := &LedgerSystem{
@@ -1204,5 +1208,6 @@ func New(logger logger.Logger, da *DataLayer.DataLayer,
 			VirtualLedger: make(map[string][]ledgerSystem.LedgerUpdate),
 			Ls:            ls,
 		},
+		LogStream: logstream,
 	}
 }


### PR DESCRIPTION
**This PR adds support for subscribing to and querying contract logs via GraphQL.**
External services (indexers, dapps, monitoring) can now receive real-time events from `sdk.Log()` calls during contract execution, as well as query historical logs.

## Key changes

#### LogStream module
- Added a lightweight pub/sub system for contract logs
- Supports filtering by block height and contract addresses by subscribing clients
- Handles n subscribers with safe channel backpressure (logs dropped if subscriber channel is full)

#### GraphQL
- Added logs in the ContractOutputResult schema
- Added logs subscription field to the schema
- Resolvers now forward contract logs to subscribers through LogStream

#### StateEngine
- Emits logs when contract outputs are ingested
- Includes metadata: block height, tx hash, contract address, log string, and timestamp

## Notes
Observer nodes can also forward logs they ingest from block producers, so subscriptions work for both producers and observers. WebSocket transport is **left open** (CheckOrigin = true) to align with existing go-vsc-node behavior. Operators are expected to secure endpoints via reverse proxies (nginx/apache) if they want more control.

Example subscription:
```graphql
subscription {
  logs(filter: {
    contractAddresses: ["vsc1Bmbe2GzDpaKvz6dpnSA6KqEaBRQRDFYapt"]
    fromBlock: null
  }) {
    blockHeight
    txHash
    contractAddress
    log
    timestamp
  }
}
```


