### PR TITLE
mapping bot: add retroactive scan and multi-instance dedupe

### DIFF
--- a/cmd/mapping-bot/database/state.go
+++ b/cmd/mapping-bot/database/state.go
@@ -66,6 +66,60 @@ func (s *StateStore) IncrementBlockHeight(ctx context.Context) (uint64, error) {
 	return result.Height, nil
 }
 
+// AdvanceBlockHeightIfCurrent atomically advances height from current to next.
+// Returns true if the advance was applied, false if current did not match.
+func (s *StateStore) AdvanceBlockHeightIfCurrent(ctx context.Context, current, next uint64) (bool, error) {
+	result, err := s.heightCollection.UpdateOne(
+		ctx,
+		bson.M{"_id": "current", "height": current},
+		bson.M{"$set": bson.M{"height": next}},
+	)
+	if err != nil {
+		return false, fmt.Errorf("failed to advance block height from %d to %d: %w", current, next, err)
+	}
+	return result.MatchedCount > 0, nil
+}
+
+// TryAcquireBlockLease attempts to lease processing rights for a specific height.
+// Returns true if the lease was acquired by owner.
+func (s *StateStore) TryAcquireBlockLease(ctx context.Context, height uint64, owner string, ttl time.Duration) (bool, error) {
+	now := time.Now().UTC()
+	until := now.Add(ttl)
+	filter := bson.M{
+		"_id":    "current",
+		"height": height,
+		"$or": bson.A{
+			bson.M{"lockUntil": bson.M{"$exists": false}},
+			bson.M{"lockUntil": bson.M{"$lt": now}},
+			bson.M{"lockOwner": owner},
+		},
+	}
+	update := bson.M{
+		"$set": bson.M{
+			"lockOwner": owner,
+			"lockUntil": until,
+		},
+	}
+	result, err := s.heightCollection.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return false, fmt.Errorf("failed to acquire block lease [height:%d owner:%s]: %w", height, owner, err)
+	}
+	return result.MatchedCount > 0, nil
+}
+
+// ReleaseBlockLease releases a previously acquired block lease.
+func (s *StateStore) ReleaseBlockLease(ctx context.Context, height uint64, owner string) error {
+	_, err := s.heightCollection.UpdateOne(
+		ctx,
+		bson.M{"_id": "current", "height": height, "lockOwner": owner},
+		bson.M{"$unset": bson.M{"lockOwner": "", "lockUntil": ""}},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to release block lease [height:%d owner:%s]: %w", height, owner, err)
+	}
+	return nil
+}
+
 // === Transaction Methods ===
 
 // AddPendingTransaction adds a new unsigned transaction
@@ -111,7 +165,7 @@ func (s *StateStore) GetPendingTransaction(ctx context.Context, txID string) (*T
 	err := s.txCollection.FindOne(ctx, bson.M{"_id": txID, "state": TxStatePending}).Decode(&tx)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
-			return nil, fmt.Errorf("transaction %s not found", txID)
+			return nil, fmt.Errorf("transaction %s not found: %w", txID, ErrTxNotFound)
 		}
 		return nil, fmt.Errorf("failed to get transaction %s: %w", txID, err)
 	}

--- a/cmd/mapping-bot/database/types.go
+++ b/cmd/mapping-bot/database/types.go
@@ -50,8 +50,10 @@ type AddressMapping struct {
 
 // BlockHeight stores the last processed block height
 type BlockHeight struct {
-	ID     string `bson:"_id"` // Always "current"
-	Height uint64 `bson:"height"`
+	ID        string     `bson:"_id"` // Always "current"
+	Height    uint64     `bson:"height"`
+	LockOwner string     `bson:"lockOwner,omitempty"`
+	LockUntil *time.Time `bson:"lockUntil,omitempty"`
 }
 
 // Transaction represents a transaction in any state

--- a/cmd/mapping-bot/http_server.go
+++ b/cmd/mapping-bot/http_server.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -128,10 +129,18 @@ func requestHandler(
 			return
 		}
 
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MiB
 		var requestBody requestBody
-		if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
-			writeResponse(w, http.StatusInternalServerError, "")
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&requestBody); err != nil {
+			writeResponse(w, http.StatusBadRequest, "invalid request body")
 			writeError(err)
+			return
+		}
+		var trailing json.RawMessage
+		if err := dec.Decode(&trailing); err == nil || !errors.Is(err, io.EOF) {
+			writeResponse(w, http.StatusBadRequest, "invalid request body")
 			return
 		}
 
@@ -215,6 +224,11 @@ func signHandler(
 	bot *mapper.Bot,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeResponse(w, http.StatusMethodNotAllowed, "only POST allowed")
+			return
+		}
+
 		// Auth: require API key in Authorization header
 		apiKey := bot.BotConfig.SignApiKey()
 		if apiKey == "" {
@@ -227,8 +241,16 @@ func signHandler(
 			return
 		}
 
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MiB
 		var req signRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&req); err != nil {
+			writeResponse(w, http.StatusBadRequest, "invalid JSON")
+			return
+		}
+		var trailing json.RawMessage
+		if err := dec.Decode(&trailing); err == nil || !errors.Is(err, io.EOF) {
 			writeResponse(w, http.StatusBadRequest, "invalid JSON")
 			return
 		}

--- a/cmd/mapping-bot/main.go
+++ b/cmd/mapping-bot/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -96,6 +97,8 @@ func main() {
 	}
 	defer db.Close(context.Background())
 	lastClear := time.Now()
+	hostname, _ := os.Hostname()
+	instanceID := fmt.Sprintf("%s-%d", hostname, os.Getpid())
 
 	bot, err := mapper.NewBot(db, chainCfg, mappingBotConfig, identityConfig, hiveConfig, sysConfig)
 	if err != nil {
@@ -151,17 +154,37 @@ func main() {
 			blockHeight = startHeight
 		}
 
+		leaseAcquired, err := bot.Db.State.TryAcquireBlockLease(ctx, blockHeight, instanceID, 2*chainCfg.BlockInterval)
+		if err != nil {
+			bot.L.Error("error acquiring block lease", "height", blockHeight, "err", err)
+			cancel()
+			time.Sleep(chainCfg.SleepInterval)
+			continue
+		}
+		if !leaseAcquired {
+			// Another bot instance is processing this height right now.
+			cancel()
+			time.Sleep(2 * time.Second)
+			continue
+		}
+
 		hash, status, err := bot.Chain.Client.GetBlockHashAtHeight(blockHeight)
 		if status == http.StatusNotFound {
 			bot.L.Info("no new block")
 			// At head — still run unmap/confirmations, then sleep before checking again
 			bot.HandleUnmap()
 			bot.HandleConfirmations()
+			if err := bot.Db.State.ReleaseBlockLease(ctx, blockHeight, instanceID); err != nil {
+				bot.L.Warn("failed to release block lease", "height", blockHeight, "err", err)
+			}
 			time.Sleep(chainCfg.SleepInterval)
 			cancel()
 			continue
 		} else if err != nil {
 			bot.L.Error("error fetching block hash", "height", blockHeight, "err", err)
+			if err := bot.Db.State.ReleaseBlockLease(ctx, blockHeight, instanceID); err != nil {
+				bot.L.Warn("failed to release block lease", "height", blockHeight, "err", err)
+			}
 			time.Sleep(chainCfg.SleepInterval)
 			cancel()
 			continue
@@ -169,6 +192,9 @@ func main() {
 		blockBytes, err := bot.Chain.Client.GetRawBlock(hash)
 		if err != nil {
 			bot.L.Error("error fetching raw block", "hash", hash, "err", err)
+			if err := bot.Db.State.ReleaseBlockLease(ctx, blockHeight, instanceID); err != nil {
+				bot.L.Warn("failed to release block lease", "height", blockHeight, "err", err)
+			}
 			time.Sleep(chainCfg.SleepInterval)
 			cancel()
 			continue
@@ -188,6 +214,9 @@ func main() {
 			bot.HandleConfirmations()
 		}()
 		wg.Wait()
+		if err := bot.Db.State.ReleaseBlockLease(ctx, blockHeight, instanceID); err != nil {
+			bot.L.Warn("failed to release block lease", "height", blockHeight, "err", err)
+		}
 
 		cancel()
 		// If the block wasn't processed (e.g., not yet in the contract), sleep before retrying.

--- a/cmd/mapping-bot/mapper/integration_test.go
+++ b/cmd/mapping-bot/mapper/integration_test.go
@@ -29,8 +29,8 @@ type testBotConfig struct{}
 
 func (c *testBotConfig) ContractId() string { return "test-contract" }
 func (c *testBotConfig) HttpPort() uint16   { return 0 }
-func (c *testBotConfig) SignApiKey() string  { return "" }
-func (c *testBotConfig) FilePath() string    { return "" }
+func (c *testBotConfig) SignApiKey() string { return "" }
+func (c *testBotConfig) FilePath() string   { return "" }
 
 // newTestBotWithMocks creates a Bot wired to all mock dependencies.
 // Returns the bot and all mocks so the caller can inspect/configure them.
@@ -124,6 +124,56 @@ func buildTestBlock(t *testing.T, destAddr string, params *chaincfg.Params) []by
 	return buf.Bytes()
 }
 
+// buildTestBlockTwoPayments is like buildTestBlock but adds two payment txs to destAddr.
+func buildTestBlockTwoPayments(t *testing.T, destAddr string, params *chaincfg.Params) []byte {
+	t.Helper()
+
+	coinbaseTx := wire.NewMsgTx(wire.TxVersion)
+	coinbaseTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{}, Index: 0xffffffff},
+		SignatureScript:  []byte{0x04, 0xff, 0xff, 0x00, 0x1d, 0x01, 0x04},
+		Sequence:         0xffffffff,
+	})
+	coinbaseTx.AddTxOut(&wire.TxOut{Value: 50e8, PkScript: []byte{txscript.OP_TRUE}})
+
+	addr, err := btcutil.DecodeAddress(destAddr, params)
+	require.NoError(t, err)
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	makePayment := func(prevHash chainhash.Hash, value int64) *wire.MsgTx {
+		tx := wire.NewMsgTx(wire.TxVersion)
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: wire.OutPoint{Hash: prevHash, Index: 0},
+			SignatureScript:  []byte{txscript.OP_TRUE},
+			Sequence:         0xffffffff,
+		})
+		tx.AddTxOut(&wire.TxOut{Value: value, PkScript: pkScript})
+		return tx
+	}
+
+	paymentTx1 := makePayment(coinbaseTx.TxHash(), 10000)
+	paymentTx2 := makePayment(paymentTx1.TxHash(), 15000)
+
+	block := wire.MsgBlock{
+		Header: wire.BlockHeader{
+			Version:    1,
+			PrevBlock:  chainhash.Hash{},
+			MerkleRoot: chainhash.Hash{},
+			Timestamp:  time.Now(),
+			Bits:       0x1d00ffff,
+			Nonce:      0,
+		},
+		Transactions: []*wire.MsgTx{coinbaseTx, paymentTx1, paymentTx2},
+	}
+	// Merkle root correctness is not required for parser tests.
+	block.Header.MerkleRoot = chainhash.DoubleHashH([]byte("test-merkle"))
+
+	var buf bytes.Buffer
+	require.NoError(t, block.Serialize(&buf))
+	return buf.Bytes()
+}
+
 // ---------------------------------------------------------------------------
 // TestHandleMap_EndToEnd
 // ---------------------------------------------------------------------------
@@ -133,6 +183,7 @@ func TestHandleMap_EndToEnd(t *testing.T) {
 
 	// Set contract's last height high enough that block 100 is already known
 	gql.lastHeight = "200"
+	gql.txStatuses = map[string]string{"mock-tx-id": "CONFIRMED"}
 
 	// Register a known deposit address so ParseBlock can find it.
 	// We need a real P2WSH address on testnet4.
@@ -141,6 +192,7 @@ func TestHandleMap_EndToEnd(t *testing.T) {
 
 	// Build a block with a tx sending to that address
 	blockBytes := buildTestBlock(t, depositAddr, &chaincfg.TestNet4Params)
+	require.NoError(t, state.SetBlockHeight(context.Background(), 100))
 
 	bot.HandleMap(blockBytes, 100)
 
@@ -152,7 +204,78 @@ func TestHandleMap_EndToEnd(t *testing.T) {
 	// Verify: block height was incremented
 	h, err := state.GetBlockHeight(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, uint64(1), h)
+	assert.Equal(t, uint64(101), h)
+}
+
+func TestHandleExistingTxs_MapsHistoricalForNewAddress(t *testing.T) {
+	bot, gql, caller, _, addr, chainClient := newTestBotWithMocks()
+	gql.txStatuses = map[string]string{"mock-tx-id": "CONFIRMED"}
+
+	depositAddr := "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+	addr.instructions[depositAddr] = "deposit_to=hive:testuser"
+	blockBytes := buildTestBlock(t, depositAddr, &chaincfg.TestNet4Params)
+
+	var block wire.MsgBlock
+	require.NoError(t, block.Deserialize(bytes.NewReader(blockBytes)))
+	require.GreaterOrEqual(t, len(block.Transactions), 2)
+	historicalTxID := block.Transactions[1].TxID()
+
+	chainClient.rawBlocks["block-100"] = blockBytes
+	chainClient.addressTxs[depositAddr] = []chain.TxHistoryEntry{
+		{TxID: historicalTxID, Confirmed: true},
+	}
+	chainClient.txDetails[historicalTxID] = chain.TxConfirmationDetails{
+		Confirmed:   true,
+		BlockHeight: 100,
+		BlockHash:   "block-100",
+		TxIndex:     1,
+	}
+
+	bot.HandleExistingTxs(depositAddr)
+
+	calls := caller.getCalls()
+	require.NotEmpty(t, calls, "expected historical map call")
+	assert.Equal(t, "map", calls[0].Action)
+}
+
+func TestHandleExistingTxs_MapsMultipleHistoryTxsInSameBlock(t *testing.T) {
+	bot, gql, caller, _, addr, chainClient := newTestBotWithMocks()
+	gql.txStatuses = map[string]string{"mock-tx-id": "CONFIRMED"}
+
+	depositAddr := "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+	addr.instructions[depositAddr] = "deposit_to=hive:testuser"
+	blockBytes := buildTestBlockTwoPayments(t, depositAddr, &chaincfg.TestNet4Params)
+
+	var block wire.MsgBlock
+	require.NoError(t, block.Deserialize(bytes.NewReader(blockBytes)))
+	require.GreaterOrEqual(t, len(block.Transactions), 3)
+	txID1 := block.Transactions[1].TxID()
+	txID2 := block.Transactions[2].TxID()
+
+	chainClient.rawBlocks["block-200"] = blockBytes
+	chainClient.addressTxs[depositAddr] = []chain.TxHistoryEntry{
+		{TxID: txID1, Confirmed: true},
+		{TxID: txID2, Confirmed: true},
+	}
+	chainClient.txDetails[txID1] = chain.TxConfirmationDetails{
+		Confirmed:   true,
+		BlockHeight: 200,
+		BlockHash:   "block-200",
+		TxIndex:     1,
+	}
+	chainClient.txDetails[txID2] = chain.TxConfirmationDetails{
+		Confirmed:   true,
+		BlockHeight: 200,
+		BlockHash:   "block-200",
+		TxIndex:     2,
+	}
+
+	bot.HandleExistingTxs(depositAddr)
+
+	calls := caller.getCalls()
+	require.Len(t, calls, 2, "expected one map call per historical tx in block")
+	assert.Equal(t, "map", calls[0].Action)
+	assert.Equal(t, "map", calls[1].Action)
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/mapping-bot/mapper/interfaces.go
+++ b/cmd/mapping-bot/mapper/interfaces.go
@@ -31,6 +31,7 @@ type StateStore interface {
 	IncrementBlockHeight(ctx context.Context) (uint64, error)
 	GetBlockHeight(ctx context.Context) (uint64, error)
 	SetBlockHeight(ctx context.Context, height uint64) error
+	AdvanceBlockHeightIfCurrent(ctx context.Context, current, next uint64) (bool, error)
 
 	AddPendingTransaction(ctx context.Context, txID string, rawTx []byte, unsignedHashes []contractinterface.UnsignedSigHash) error
 	GetPendingTransaction(ctx context.Context, txID string) (*database.Transaction, error)

--- a/cmd/mapping-bot/mapper/mapping.go
+++ b/cmd/mapping-bot/mapper/mapping.go
@@ -1,10 +1,14 @@
 package mapper
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"strconv"
 	"time"
+
+	"github.com/btcsuite/btcd/wire"
 )
 
 // dropHeightDiff is set per-chain via ChainConfig.DropHeightDiff
@@ -54,10 +58,14 @@ func (b *Bot) HandleMap(
 		}
 	}
 
-	_, err = b.stateDB().IncrementBlockHeight(ctx)
+	advanced, err := b.stateDB().AdvanceBlockHeightIfCurrent(ctx, blockHeight, blockHeight+1)
 	if err != nil {
-		b.L.Error("error incrementing last block height", "err", err)
+		b.L.Error("error advancing last block height", "err", err, "blockHeight", blockHeight)
 		return false
+	}
+	if !advanced {
+		// Another bot instance likely advanced the height first.
+		b.L.Info("block height already advanced by another instance", "blockHeight", blockHeight)
 	}
 
 	b.setLastBlock(blockHeight)
@@ -69,7 +77,82 @@ func (b *Bot) HandleMap(
 // is the primary detection mechanism.
 func (b *Bot) HandleExistingTxs(chainAddress string) {
 	b.L.Debug("checking existing txs for new address", "address", chainAddress)
-	// Existing tx detection is handled by the main block processing loop.
-	// This function is a placeholder for future address-history scanning
-	// which requires chain-specific implementation.
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	entries, err := b.Chain.Client.GetAddressTxs(chainAddress)
+	if err != nil {
+		b.L.Error("failed to fetch address tx history", "address", chainAddress, "err", err)
+		return
+	}
+	if len(entries) == 0 {
+		return
+	}
+
+	blockTxIDs := make(map[string]map[string]uint64)
+	for _, entry := range entries {
+		if !entry.Confirmed {
+			continue
+		}
+
+		details, err := b.Chain.Client.GetTxDetails(entry.TxID)
+		if err != nil {
+			b.L.Warn("failed to fetch tx confirmation details", "txid", entry.TxID, "err", err)
+			continue
+		}
+		if !details.Confirmed || details.BlockHash == "" {
+			continue
+		}
+		if _, ok := blockTxIDs[details.BlockHash]; !ok {
+			blockTxIDs[details.BlockHash] = make(map[string]uint64)
+		}
+		blockTxIDs[details.BlockHash][entry.TxID] = details.BlockHeight
+	}
+
+	for blockHash, wantedTxIDs := range blockTxIDs {
+		var blockHeight uint64
+		for _, h := range wantedTxIDs {
+			blockHeight = h
+			break
+		}
+		blockBytes, err := b.Chain.Client.GetRawBlock(blockHash)
+		if err != nil {
+			b.L.Warn("failed to fetch raw block for historical tx scan", "blockHash", blockHash, "err", err)
+			continue
+		}
+		foundTxs, err := b.ParseBlock(ctx, blockBytes, blockHeight)
+		if err != nil {
+			b.L.Warn("failed to parse historical block", "blockHash", blockHash, "height", blockHeight, "err", err)
+			continue
+		}
+
+		// Only map historical txs that were present in the address history.
+		for _, tx := range foundTxs {
+			txID := txIDFromRawTxHex(tx.TxData.RawTxHex)
+			if _, ok := wantedTxIDs[txID]; !ok {
+				continue
+			}
+
+			jsonBytes, err := json.Marshal(tx)
+			if err != nil {
+				b.L.Warn("could not marshal historical transaction", "err", err)
+				continue
+			}
+			if err := b.callWithRetry(ctx, json.RawMessage(jsonBytes), "map", 3); err != nil {
+				b.L.Error("historical map call failed after retries", "err", err)
+			}
+		}
+	}
+}
+
+func txIDFromRawTxHex(rawTxHex string) string {
+	rawTx, err := hex.DecodeString(rawTxHex)
+	if err != nil {
+		return ""
+	}
+	var tx wire.MsgTx
+	if err := tx.Deserialize(bytes.NewReader(rawTx)); err != nil {
+		return ""
+	}
+	return tx.TxID()
 }

--- a/cmd/mapping-bot/mapper/mock_test.go
+++ b/cmd/mapping-bot/mapper/mock_test.go
@@ -153,6 +153,16 @@ func (m *mockStateStore) SetBlockHeight(ctx context.Context, height uint64) erro
 	return nil
 }
 
+func (m *mockStateStore) AdvanceBlockHeightIfCurrent(ctx context.Context, current, next uint64) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.blockHeight != current {
+		return false, nil
+	}
+	m.blockHeight = next
+	return true, nil
+}
+
 func (m *mockStateStore) AddPendingTransaction(ctx context.Context, txID string, rawTx []byte, unsignedHashes []contractinterface.UnsignedSigHash) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -342,14 +352,15 @@ func (m *mockAddressStore) Insert(ctx context.Context, chainAddr, instruction st
 // ---------------------------------------------------------------------------
 
 type mockChainClient struct {
-	mu            sync.Mutex
-	posted        []string
-	tipHeight     uint64
-	blockHashes   map[uint64]string
-	rawBlocks     map[string][]byte
-	txStatuses    map[string]bool // txid -> confirmed
-	txDetails     map[string]chain.TxConfirmationDetails
-	postTxErr     error
+	mu          sync.Mutex
+	posted      []string
+	tipHeight   uint64
+	blockHashes map[uint64]string
+	rawBlocks   map[string][]byte
+	txStatuses  map[string]bool // txid -> confirmed
+	txDetails   map[string]chain.TxConfirmationDetails
+	addressTxs  map[string][]chain.TxHistoryEntry
+	postTxErr   error
 }
 
 func newMockChainClient() *mockChainClient {
@@ -358,6 +369,7 @@ func newMockChainClient() *mockChainClient {
 		rawBlocks:   make(map[string][]byte),
 		txStatuses:  make(map[string]bool),
 		txDetails:   make(map[string]chain.TxConfirmationDetails),
+		addressTxs:  make(map[string][]chain.TxHistoryEntry),
 	}
 }
 
@@ -369,7 +381,9 @@ func (m *mockChainClient) PostTx(rawTx string) error {
 }
 
 func (m *mockChainClient) GetAddressTxs(address string) ([]chain.TxHistoryEntry, error) {
-	return nil, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.addressTxs[address], nil
 }
 
 func (m *mockChainClient) GetRawBlock(hash string) ([]byte, error) {
@@ -409,4 +423,3 @@ func (m *mockChainClient) GetTxDetails(txid string) (chain.TxConfirmationDetails
 	defer m.mu.Unlock()
 	return m.txDetails[txid], nil
 }
-

--- a/cmd/mapping-bot/mapper/parser.go
+++ b/cmd/mapping-bot/mapper/parser.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"errors"
 
 	"vsc-node/cmd/mapping-bot/database"
 
@@ -53,7 +54,7 @@ func (b *Bot) ParseBlock(
 						break
 					}
 					matchedTxIndices[txIndex] = append(matchedTxIndices[txIndex], instruction)
-				} else if err != database.ErrAddrNotFound {
+				} else if !errors.Is(err, database.ErrAddrNotFound) {
 					return nil, err
 				}
 			}


### PR DESCRIPTION
Implement historical remapping for newly registered addresses and add a Mongo-backed lease/CAS flow so multiple bot instances do not double-process blocks. Harden request parsing and align Mongo error handling semantics with existing working paths.

Made-with: Cursor