### PR TITLE
fix: node crash via empty required_auths in Hive custom_json

### DIFF
--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -300,6 +300,13 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 			opVal := headerOp.Value
 			RequiredAuths := common.ArrayToStringArray(opVal["required_auths"])
 
+			// Hive allows custom_json with required_auths:[] and
+			// required_posting_auths:["user"]. Without this guard,
+			// RequiredAuths[0] below panics and crashes the node.
+			if len(RequiredAuths) == 0 {
+				continue
+			}
+
 			cj := CustomJson{
 				Id:                   opVal["id"].(string),
 				RequiredAuths:        common.ArrayToStringArray(opVal["required_auths"]),
@@ -418,6 +425,10 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 				RequiredAuths:        common.ArrayToStringArray(opVal["required_auths"]),
 				RequiredPostingAuths: common.ArrayToStringArray(opVal["required_posting_auths"]),
 				Json:                 []byte(opVal["json"].(string)),
+			}
+
+			if len(cj.RequiredAuths) == 0 {
+				continue
 			}
 
 			txSelf := TxSelf{


### PR DESCRIPTION
Any Hive user can crash every VSC node by broadcasting a custom_json with required_auths: [] and
  required_posting_auths: ["attacker"]. Hive accepts this — it's a valid transaction format. The state engine accesses
  RequiredAuths[0] without a length check in two custom_json processing paths (lines 310, 351, 455, 472 and the
  system_txs functions at lines 209, 221, 329, 429, 532, 660). Panic with zero recover() crashes the process.

  The existing empty-auths fix (transaction pool line 124) only guards the VSC P2P transaction path. The Hive
  custom_json processing path was unguarded.

  Fix: len(RequiredAuths) == 0 → continue at both entry points, before any [0] access. All legitimate VSC operations
  require active authority, so empty required_auths is never valid.

  Test plan

  - go vet passes
  - All existing tests pass
  - Normal block processing unaffected (guard only skips empty-auth custom_json)
  - Zero CRLF