### PR TITLE
fix: blame-based old committee exclusion + culprit labeling

### DIFF
--- a/modules/tss/dispatcher.go
+++ b/modules/tss/dispatcher.go
@@ -519,10 +519,22 @@ func (dispatcher *ReshareDispatcher) Done() *promise.Promise[DispatcherResult] {
 			// Check connection status for each culprit to provide context
 			culpritContext := make(map[string]string)
 
+			// Build old party ID set for accurate culprit labeling.
+			// tss-lib's WaitingFor() returns combined old+new parties,
+			// so we filter by actual membership to avoid mislabeling.
+			oldPidSet := make(map[string]bool)
+			for _, p := range dispatcher.oldPids {
+				oldPidSet[p.Id] = true
+			}
+
 			if dispatcher.party != nil {
 				for _, p := range dispatcher.party.WaitingFor() {
 					culprits[p.Id] = true
-					oldCulprits = append(oldCulprits, p.Id)
+					if oldPidSet[p.Id] {
+						oldCulprits = append(oldCulprits, p.Id)
+					} else {
+						newCulprits = append(newCulprits, p.Id)
+					}
 
 					// Check if culprit is connected
 					witness, err := dispatcher.tssMgr.witnessDb.GetWitnessAtHeight(p.Id, nil)

--- a/modules/tss/tss.go
+++ b/modules/tss/tss.go
@@ -699,17 +699,44 @@ func (tssMgr *TssManager) RunActions(actions []QueuedAction, leader string, isLe
 				continue
 			}
 
+			// Resolve blamed accounts by name from the current election's blame bits.
+			// The blame bitset is indexed against currentElection (which may have
+			// different members/order than commitmentElection). Matching by account
+			// name makes it work across elections.
+			blamedAccounts := make(map[string]bool)
+			if isBlame {
+				for idx, member := range currentElection.Members {
+					if blameBits.Bit(idx) == 1 {
+						blamedAccounts[member.Account] = true
+					}
+				}
+			}
+			for account, banned := range blameMap.BannedNodes {
+				if banned {
+					blamedAccounts[account] = true
+				}
+			}
+
 			commitmentBytes, err := base64.RawURLEncoding.DecodeString(commitment.Commitment)
 
 			bitset := big.NewInt(0)
 			bitset = bitset.SetBytes(commitmentBytes)
 
 			commitedMembers := make([]Participant, 0)
+			// Count the full commitment size BEFORE blame exclusion.
+			// This is needed for threshold calculation — the polynomial degree
+			// must match the original keygen/reshare, not the blame-reduced set.
+			fullOldCommitteeSize := 0
 
 			log.Trace("commitment lookup", "commitment", commitment, "err", err)
 			log.Trace("bitset details", "bitset", bitset, "commitmentBytes", commitmentBytes)
 			for idx, member := range commitmentElection.Members {
 				if idx < bitset.BitLen() && bitset.Bit(idx) == 1 {
+					fullOldCommitteeSize++
+					if blamedAccounts[member.Account] {
+						log.Verbose("excluding blamed node from old committee", "sessionId", sessionId, "account", member.Account)
+						continue
+					}
 					commitedMembers = append(commitedMembers, Participant{
 						Account: member.Account,
 					})
@@ -741,9 +768,9 @@ func (tssMgr *TssManager) RunActions(actions []QueuedAction, leader string, isLe
 			log.Verbose("reshare participant selection", "sessionId", sessionId, "oldParticipants", len(commitedMembers), "newParticipants", len(newParticipants), "excluded", len(excludedNodes), "excludedNodes", excludedNodes)
 			log.Trace("new participants list", "newParticipants", newParticipants)
 
-			// Capture pre-filter sizes — these are needed by the dispatcher for correct
-			// threshold calculation in tss-lib. Using post-filter sizes corrupts the key.
-			origOldSize := len(commitedMembers)
+			// Use the FULL commitment size for threshold calculation, not the
+			// blame-reduced count. The polynomial degree must match keygen.
+			origOldSize := fullOldCommitteeSize
 			origNewSize := len(newParticipants)
 
 			// Filter both old and new participants by connectivity


### PR DESCRIPTION
Two additions to the TSS reshare fix:

  1. Blame-based old committee exclusion (tss.go) Old committee members that were blamed in the previous cycle are now excluded by account name. The blame bitset is resolved against the current election to get account names, then checked when building the old committee from the keygen commitment. This is deterministic — all nodes read the same on-chain blame data.

     Without this: offline old members (prime.vsc, comptroller.vsc) stay in the party list forever, causing a 2-minute timeout every cycle. With this: blamed nodes are excluded on the next cycle, reshare proceeds with the remaining online members.

     Guard: if blame removes too many old members below threshold+1, the reshare is skipped (existing pre-flight check at line 794). Threshold uses fullOldCommitteeSize (pre-blame count) to match the keygen polynomial degree.

  2. Culprit labeling fix (dispatcher.go) tss-lib's WaitingFor() returns combined old+new parties. The old code put all of them into oldCulprits, causing new-committee-only nodes (comptroller.vsc) to be mislabeled as old committee blockers. Now filters by actual old party membership before labeling.

  Builds on top of:
  - BLS election mismatch fix (state_engine.go, already pushed)
  - keepTimeouts for old committee readiness (p2p.go, already pushed)
  - Retry removal (already on main)