### PR TITLE
tss: limit concurrent signing sessions per interval

### DIFF
--- a/lib/test_utils/mock_tss.go
+++ b/lib/test_utils/mock_tss.go
@@ -3,6 +3,7 @@ package test_utils
 import (
 	"fmt"
 	"slices"
+	"sort"
 	"vsc-node/modules/aggregate"
 	tss "vsc-node/modules/db/vsc/tss"
 )
@@ -222,7 +223,7 @@ func (m *MockTssRequestsDb) SetSignedRequest(req tss.TssRequest) error {
 	return nil
 }
 
-func (m *MockTssRequestsDb) FindUnsignedRequests(blockHeight uint64) ([]tss.TssRequest, error) {
+func (m *MockTssRequestsDb) FindUnsignedRequests(blockHeight uint64, limit int64) ([]tss.TssRequest, error) {
 	// Backfill legacy requests missing created_height.
 	for id, req := range m.Requests {
 		if req.Status == tss.SignPending && req.CreatedHeight == 0 {
@@ -247,6 +248,12 @@ func (m *MockTssRequestsDb) FindUnsignedRequests(blockHeight uint64) ([]tss.TssR
 		if req.Sig == "" && req.Status == tss.SignPending {
 			results = append(results, req)
 		}
+	}
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].CreatedHeight < results[j].CreatedHeight
+	})
+	if limit > 0 && int64(len(results)) > limit {
+		results = results[:limit]
 	}
 	return results, nil
 }

--- a/lib/test_utils/mock_tss_test.go
+++ b/lib/test_utils/mock_tss_test.go
@@ -1,0 +1,111 @@
+package test_utils
+
+import (
+	"testing"
+
+	tss "vsc-node/modules/db/vsc/tss"
+)
+
+func TestFindUnsignedRequests_FIFOOrder(t *testing.T) {
+	mock := &MockTssRequestsDb{
+		Requests: map[string]tss.TssRequest{
+			"a": {Id: "a", KeyId: "k1", Msg: "aa", Status: tss.SignPending, CreatedHeight: 300},
+			"b": {Id: "b", KeyId: "k1", Msg: "bb", Status: tss.SignPending, CreatedHeight: 100},
+			"c": {Id: "c", KeyId: "k1", Msg: "cc", Status: tss.SignPending, CreatedHeight: 200},
+		},
+	}
+
+	results, err := mock.FindUnsignedRequests(500, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	if results[0].CreatedHeight != 100 || results[1].CreatedHeight != 200 || results[2].CreatedHeight != 300 {
+		t.Errorf("expected FIFO order [100,200,300], got [%d,%d,%d]",
+			results[0].CreatedHeight, results[1].CreatedHeight, results[2].CreatedHeight)
+	}
+}
+
+func TestFindUnsignedRequests_LimitTruncates(t *testing.T) {
+	mock := &MockTssRequestsDb{
+		Requests: map[string]tss.TssRequest{
+			"a": {Id: "a", KeyId: "k1", Msg: "aa", Status: tss.SignPending, CreatedHeight: 300},
+			"b": {Id: "b", KeyId: "k1", Msg: "bb", Status: tss.SignPending, CreatedHeight: 100},
+			"c": {Id: "c", KeyId: "k1", Msg: "cc", Status: tss.SignPending, CreatedHeight: 200},
+			"d": {Id: "d", KeyId: "k1", Msg: "dd", Status: tss.SignPending, CreatedHeight: 400},
+			"e": {Id: "e", KeyId: "k1", Msg: "ee", Status: tss.SignPending, CreatedHeight: 500},
+		},
+	}
+
+	results, err := mock.FindUnsignedRequests(600, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	// Should be the 3 oldest
+	if results[0].CreatedHeight != 100 {
+		t.Errorf("expected oldest first (100), got %d", results[0].CreatedHeight)
+	}
+	if results[2].CreatedHeight != 300 {
+		t.Errorf("expected third oldest (300), got %d", results[2].CreatedHeight)
+	}
+}
+
+func TestFindUnsignedRequests_Limit1ForExistenceCheck(t *testing.T) {
+	mock := &MockTssRequestsDb{
+		Requests: map[string]tss.TssRequest{
+			"a": {Id: "a", KeyId: "k1", Msg: "aa", Status: tss.SignPending, CreatedHeight: 100},
+			"b": {Id: "b", KeyId: "k1", Msg: "bb", Status: tss.SignPending, CreatedHeight: 200},
+		},
+	}
+
+	results, err := mock.FindUnsignedRequests(300, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for existence check, got %d", len(results))
+	}
+	if results[0].CreatedHeight != 100 {
+		t.Errorf("expected oldest (100), got %d", results[0].CreatedHeight)
+	}
+}
+
+func TestFindUnsignedRequests_SkipsSignedAndFailed(t *testing.T) {
+	mock := &MockTssRequestsDb{
+		Requests: map[string]tss.TssRequest{
+			"a":       {Id: "a", KeyId: "k1", Msg: "aa", Status: tss.SignPending, CreatedHeight: 100},
+			"signed":  {Id: "signed", KeyId: "k1", Msg: "ss", Sig: "somesig", Status: tss.SignComplete, CreatedHeight: 50},
+			"failed":  {Id: "failed", KeyId: "k1", Msg: "ff", Status: tss.SignFailed, CreatedHeight: 60},
+			"b":       {Id: "b", KeyId: "k1", Msg: "bb", Status: tss.SignPending, CreatedHeight: 200},
+		},
+	}
+
+	results, err := mock.FindUnsignedRequests(300, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 unsigned pending results, got %d", len(results))
+	}
+}
+
+func TestFindUnsignedRequests_LimitLargerThanResults(t *testing.T) {
+	mock := &MockTssRequestsDb{
+		Requests: map[string]tss.TssRequest{
+			"a": {Id: "a", KeyId: "k1", Msg: "aa", Status: tss.SignPending, CreatedHeight: 100},
+		},
+	}
+
+	results, err := mock.FindUnsignedRequests(300, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (fewer than limit), got %d", len(results))
+	}
+}

--- a/modules/db/vsc/tss/interface.go
+++ b/modules/db/vsc/tss/interface.go
@@ -42,7 +42,7 @@ type TssKeys interface {
 type TssRequests interface {
 	a.Plugin
 	SetSignedRequest(req TssRequest) error
-	FindUnsignedRequests(blockHeight uint64) ([]TssRequest, error)
+	FindUnsignedRequests(blockHeight uint64, limit int64) ([]TssRequest, error)
 	FindRequests(keyID string, msgHex []string) ([]TssRequest, error)
 	UpdateRequest(req TssRequest) error
 }

--- a/modules/db/vsc/tss/requests.go
+++ b/modules/db/vsc/tss/requests.go
@@ -76,7 +76,7 @@ func (tssReqs *tssRequests) SetSignedRequest(req TssRequest) error {
 	return singeResult.Err()
 }
 
-func (tssReqs *tssRequests) FindUnsignedRequests(blockHeight uint64) ([]TssRequest, error) {
+func (tssReqs *tssRequests) FindUnsignedRequests(blockHeight uint64, limit int64) ([]TssRequest, error) {
 	ctx := context.Background()
 
 	// Backfill legacy requests that lack a created_height so they enter
@@ -102,19 +102,21 @@ func (tssReqs *tssRequests) FindUnsignedRequests(blockHeight uint64) ([]TssReque
 		})
 	}
 
-	requests := make([]TssRequest, 0)
+	opts := options.Find().
+		SetSort(bson.D{{Key: "created_height", Value: 1}}).
+		SetLimit(limit)
+
 	findResult, err := tssReqs.Find(ctx, bson.M{
 		"status": "unsigned",
-	})
+	}, opts)
 
 	if err != nil {
 		return nil, err
 	}
 
-	for findResult.Next(ctx) {
-		var req TssRequest
-		findResult.Decode(&req)
-		requests = append(requests, req)
+	var requests []TssRequest
+	if err := findResult.All(ctx, &requests); err != nil {
+		return nil, err
 	}
 	return requests, nil
 }

--- a/modules/tss/tss.go
+++ b/modules/tss/tss.go
@@ -55,6 +55,10 @@ const (
 	TSS_BAN_GRACE_PERIOD_EPOCHS = 3             // Epochs before new nodes can be banned (as int for comparison)
 	BLAME_EXPIRE                = uint64(28800) // 24 hour blame
 	TSS_BLAME_EPOCH_COUNT       = (4 * 7) - 1   // Number of past epochs to include in blame scoring
+
+	// maxConcurrentSignSessions caps how many signing requests are dispatched
+	// per interval to avoid flooding p2p with concurrent TSS sessions.
+	maxConcurrentSignSessions = int64(3)
 )
 
 // ReadyAttestation is a BLS-signed self-attestation that a node is online and
@@ -391,7 +395,7 @@ func (tssMgr *TssManager) BlockTick(bh uint64, headHeight *uint64) {
 	blocksUntilSign := signInterval - (bh % signInterval)
 	if blocksUntilSign <= readinessOffset && bh%signInterval != 0 {
 		// Check if there are unsigned signing requests pending.
-		signingRequests, _ := tssMgr.tssRequests.FindUnsignedRequests(bh)
+		signingRequests, _ := tssMgr.tssRequests.FindUnsignedRequests(bh, 1)
 		if len(signingRequests) > 0 {
 			gossipTargets[bh+blocksUntilSign] = true
 		}
@@ -498,7 +502,7 @@ func (tssMgr *TssManager) BlockTick(bh uint64, headHeight *uint64) {
 			}
 		}
 		if bh%signInterval == 0 {
-			signingRequests, _ := tssMgr.tssRequests.FindUnsignedRequests(bh)
+			signingRequests, _ := tssMgr.tssRequests.FindUnsignedRequests(bh, maxConcurrentSignSessions)
 
 			for _, signReq := range signingRequests {
 				keyInfo, _ := tssMgr.tssKeys.FindKey(signReq.KeyId)


### PR DESCRIPTION
- Add `limit int64` param to FindUnsignedRequests interface and all implementations (DB, mock)
- DB query now sorts by created_height ASC and applies SetLimit, so oldest requests are processed first (FIFO)
- Cap signing dispatch to maxConcurrentSignSessions (3) per interval, preventing p2p flooding under high withdrawal load
- Gossip readiness check passes limit=1 (existence check only)
- Mock applies sort + truncation to match DB behavior
- Add 5 unit tests covering FIFO order, limit truncation, existence check, signed/failed filtering, and limit > result count