### PR TITLE
tss: prime readiness gossip for every staggered sign slot

### DIFF
--- a/modules/tss/gossip_readiness_test.go
+++ b/modules/tss/gossip_readiness_test.go
@@ -293,6 +293,104 @@ func TestGossipReadySetDeterministicFromSameAttestations(t *testing.T) {
 	}
 }
 
+// TestSignSlotGossipTargets_BeforeWindow verifies that no targets are primed
+// before the readiness window opens (i.e. when bh is more than readinessOffset
+// blocks away from the next signInterval boundary).
+func TestSignSlotGossipTargets_BeforeWindow(t *testing.T) {
+	// signInterval=50, readinessOffset=30, bh=2000 (bh%50=0)
+	// blocksUntilSign = 50, slot-0 target-bh = 50 > 30 → empty.
+	got := signSlotGossipTargets(2000, 50, 30)
+	if len(got) != 0 {
+		t.Fatalf("expected no targets before window, got %v", got)
+	}
+}
+
+// TestSignSlotGossipTargets_WindowEntry verifies only slot-0 is primed at the
+// moment the readiness window opens.
+func TestSignSlotGossipTargets_WindowEntry(t *testing.T) {
+	// bh=2020 (bh%50=20), blocksUntilSign=30, nextBoundary=2050.
+	// Slot 0 target-bh = 30 ≤ 30 → in. Slot 1 target-bh = 35 > 30 → out.
+	got := signSlotGossipTargets(2020, 50, 30)
+	want := []uint64{2050}
+	if !equalSlice(got, want) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+}
+
+// TestSignSlotGossipTargets_FullWindowPrimesAllSlots verifies that once bh is
+// close enough, all signStaggerCount slot targets enter the gossip window.
+func TestSignSlotGossipTargets_FullWindowPrimesAllSlots(t *testing.T) {
+	// bh=2045 (bh%50=45), blocksUntilSign=5, nextBoundary=2050.
+	// Slot offsets 0/5/10/15/20/25 → target-bh 5/10/15/20/25/30, all ≤ 30.
+	got := signSlotGossipTargets(2045, 50, 30)
+	want := []uint64{2050, 2055, 2060, 2065, 2070, 2075}
+	if !equalSlice(got, want) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+}
+
+// TestSignSlotGossipTargets_AtBoundary verifies the behaviour at bh =
+// signInterval boundary (slot 0 dispatch block): no priming because the next
+// window is a full signInterval away.
+func TestSignSlotGossipTargets_AtBoundary(t *testing.T) {
+	// bh=2050, bh%50=0, blocksUntilSign=50, nextBoundary=2100.
+	// Slot 0 target-bh = 50 > 30. All slots out of range.
+	got := signSlotGossipTargets(2050, 50, 30)
+	if len(got) != 0 {
+		t.Fatalf("expected no targets at boundary, got %v", got)
+	}
+}
+
+// TestSignSlotGossipTargets_MidWindowDispatch verifies priming behaviour at a
+// staggered-slot dispatch block (e.g. slot 5 at bh=2075). Priming is for the
+// *next* window's slots, not the current one.
+func TestSignSlotGossipTargets_MidWindowDispatch(t *testing.T) {
+	// bh=2075 (bh%50=25), blocksUntilSign=25, nextBoundary=2100.
+	// Slot 0 target-bh=25 ✓, slot 1 target-bh=30 ✓, slot 2 target-bh=35 ✗.
+	got := signSlotGossipTargets(2075, 50, 30)
+	want := []uint64{2100, 2105}
+	if !equalSlice(got, want) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+}
+
+// TestSignSlotGossipTargets_ConvergesOverTicks walks BlockTick from just
+// before window entry through window close and asserts the union of targets
+// primed across all ticks covers every staggered slot exactly once.
+func TestSignSlotGossipTargets_ConvergesOverTicks(t *testing.T) {
+	const signInterval uint64 = 50
+	const readinessOffset uint64 = 30
+	// Walk from bh=2019 (just before window) through bh=2049 (just before
+	// slot-0 dispatch). The next window starts at 2050.
+	primed := map[uint64]bool{}
+	for bh := uint64(2019); bh <= 2049; bh++ {
+		for _, target := range signSlotGossipTargets(bh, signInterval, readinessOffset) {
+			primed[target] = true
+		}
+	}
+	expected := []uint64{2050, 2055, 2060, 2065, 2070, 2075}
+	if len(primed) != len(expected) {
+		t.Fatalf("expected %d primed targets, got %d: %v", len(expected), len(primed), primed)
+	}
+	for _, target := range expected {
+		if !primed[target] {
+			t.Fatalf("target %d never primed over the readiness window", target)
+		}
+	}
+}
+
+func equalSlice(a, b []uint64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestPerHeightGossipSharedAcrossKeys(t *testing.T) {
 	// Verify that a single per-height gossip entry is usable for multiple keys.
 	mgr := &TssManager{

--- a/modules/tss/tss.go
+++ b/modules/tss/tss.go
@@ -245,6 +245,34 @@ func getReadinessOffset(sconf systemconfig.SystemConfig) uint64 {
 	return offset
 }
 
+// signSlotGossipTargets returns the target block heights that need readiness
+// gossip priming for the next signInterval window. Each entry corresponds to
+// one of the `signStaggerCount` dispatch slots inside that window, at offsets
+// {0, signStaggerStep, 2*signStaggerStep, ...}.
+//
+// The sign dispatcher at tss.go:1125 looks up readiness by the session's exact
+// block height, and ReadyAttestation is BLS-signed over (account, target_block),
+// so each slot requires its own attestation. Returning only the slot-0 target
+// would leave the five staggered slots of every window without readiness —
+// they dispatch with empty signReadyAccounts and bail out with
+// "insufficient participants for signing", capping throughput at one
+// signature per window instead of signStaggerCount.
+//
+// Only targets currently within `readinessOffset` blocks of `bh` are returned;
+// later slots enter the window as bh advances and get added on subsequent ticks.
+func signSlotGossipTargets(bh, signInterval, readinessOffset uint64) []uint64 {
+	blocksUntilSign := signInterval - (bh % signInterval)
+	nextBoundary := bh + blocksUntilSign
+	targets := make([]uint64, 0, signStaggerCount)
+	for slot := uint64(0); slot < uint64(signStaggerCount); slot++ {
+		target := nextBoundary + slot*signStaggerStep
+		if target-bh <= readinessOffset {
+			targets = append(targets, target)
+		}
+	}
+	return targets
+}
+
 type TssManager struct {
 	p2p    *libp2p.P2PServer
 	pubsub libp2p.PubSubService[p2pMessage]
@@ -412,12 +440,16 @@ func (tssMgr *TssManager) BlockTick(bh uint64, headHeight *uint64) {
 			}
 		}
 	}
-	blocksUntilSign := signInterval - (bh % signInterval)
-	if blocksUntilSign <= readinessOffset && bh%signInterval != 0 {
-		// Check if there are unsigned signing requests pending.
+	// Prime readiness gossip for every staggered sign slot whose target block
+	// falls inside the current readiness window. See signSlotGossipTargets.
+	signTargets := signSlotGossipTargets(bh, signInterval, readinessOffset)
+	if len(signTargets) > 0 {
+		// Only gossip if there is at least one unsigned request pending.
 		signingRequests, _ := tssMgr.tssRequests.FindUnsignedRequests(bh, 1)
 		if len(signingRequests) > 0 {
-			gossipTargets[bh+blocksUntilSign] = true
+			for _, target := range signTargets {
+				gossipTargets[target] = true
+			}
 		}
 	}
 


### PR DESCRIPTION
- BlockTick primed gossipTargets only at the next signInterval boundary (slot 0), leaving the five staggered dispatch slots at offsets {5,10,15,20,25} without a ReadyAttestation.
- ReadyAttestation is BLS-signed over (account, target_block), so a slot-0 attestation is not transferable to later slots; the sign dispatcher at tss.go:1125 looks up gossipAttestations by the session's exact block height.
- Result: 5 of every 6 sign sessions per window failed with "insufficient participants for signing ready=0", capping throughput at one signature per signInterval instead of signStaggerCount. Observed on vsc-testnet: 24 sigs/h vs the intended ~144 sigs/h, leaving queued TssRequests stranded.
- Extract signSlotGossipTargets helper returning the in-range staggered slot targets for the current readiness window, and iterate over it in BlockTick. Attestation signing, gossip amplification, and the sign-path pre-flight gate are unchanged, so any residual gossip divergence still falls through the existing "insufficient participants" path — same failure shape, just no longer guaranteed on 5/6 slots.
- Add six unit tests covering: before-window (no priming), window entry (slot 0 only), full-window (all 6 slots), slot-0 boundary (no priming of current window), mid-window dispatch (next window's slots primed), and full tick-walk convergence.