### PR TITLE
Tss Reshare and Signing Retry Fixes

### DIFF
--- a/lib/test_utils/mock_tss.go
+++ b/lib/test_utils/mock_tss.go
@@ -223,15 +223,6 @@ func (m *MockTssRequestsDb) SetSignedRequest(req tss.TssRequest) error {
 }
 
 func (m *MockTssRequestsDb) FindUnsignedRequests(blockHeight uint64) ([]tss.TssRequest, error) {
-	// Revive any requests left in legacy "failed" state (from the removed
-	// block-age expiry) so they are retried.
-	for id, req := range m.Requests {
-		if req.Status == "failed" {
-			req.Status = tss.SignPending
-			m.Requests[id] = req
-		}
-	}
-
 	var results []tss.TssRequest
 	for _, req := range m.Requests {
 		if req.Sig == "" && req.Status == tss.SignPending {

--- a/lib/test_utils/mock_tss.go
+++ b/lib/test_utils/mock_tss.go
@@ -223,22 +223,12 @@ func (m *MockTssRequestsDb) SetSignedRequest(req tss.TssRequest) error {
 }
 
 func (m *MockTssRequestsDb) FindUnsignedRequests(blockHeight uint64) ([]tss.TssRequest, error) {
-	// Backfill legacy requests missing created_height.
+	// Revive any requests left in legacy "failed" state (from the removed
+	// block-age expiry) so they are retried.
 	for id, req := range m.Requests {
-		if req.Status == tss.SignPending && req.CreatedHeight == 0 {
-			req.CreatedHeight = blockHeight
+		if req.Status == "failed" {
+			req.Status = tss.SignPending
 			m.Requests[id] = req
-		}
-	}
-
-	// Mark expired requests as failed.
-	if blockHeight > tss.SignExpiryBlocks {
-		cutoff := blockHeight - tss.SignExpiryBlocks
-		for id, req := range m.Requests {
-			if req.Status == tss.SignPending && req.CreatedHeight <= cutoff {
-				req.Status = tss.SignFailed
-				m.Requests[id] = req
-			}
 		}
 	}
 

--- a/modules/db/vsc/elections/elections.go
+++ b/modules/db/vsc/elections/elections.go
@@ -182,7 +182,7 @@ func (e *elections) GetElectionByHeight(height uint64) (ElectionResult, error) {
 }
 
 // Utility function
-func CalculateSigningScore(circuit dids.BlsCircuit, election ElectionResult) (uint64, uint64) {
+func CalculateSigningScore(circuit *dids.BlsCircuit, election ElectionResult) (uint64, uint64) {
 	IncludedDids := circuit.IncludedDIDs()
 	BitVector := circuit.RawBitVector()
 	WeightTotal := uint64(0)

--- a/modules/db/vsc/tss/interface.go
+++ b/modules/db/vsc/tss/interface.go
@@ -17,10 +17,6 @@ const KeyDeprecationGracePeriod = uint64(403200)
 // clock is started and the key stays deprecated indefinitely until renewed.
 const KeyRetirementEnabled = false
 
-// SignExpiryBlocks is the number of blocks after which an unsigned signing request
-// is marked as failed. At ~3s/block this is roughly 50 minutes (20 sign intervals).
-const SignExpiryBlocks = uint64(1000)
-
 type TssKeys interface {
 	a.Plugin
 	InsertKey(id string, t TssKeyAlgo, epochs uint64) error
@@ -95,12 +91,11 @@ type TssKey struct {
 }
 
 type TssRequest struct {
-	Id            string        `bson:"id"`
-	Status        TssSignStatus `bson:"status"`
-	KeyId         string        `bson:"key_id"`
-	Msg           string        `bson:"msg"`
-	Sig           string        `bson:"sig"`
-	CreatedHeight uint64        `bson:"created_height"`
+	Id     string        `bson:"id"`
+	Status TssSignStatus `bson:"status"`
+	KeyId  string        `bson:"key_id"`
+	Msg    string        `bson:"msg"`
+	Sig    string        `bson:"sig"`
 }
 
 // CommitmentMetadata optionally stores error/reason for blame commitments (e.g. timeout vs error).

--- a/modules/db/vsc/tss/requests.go
+++ b/modules/db/vsc/tss/requests.go
@@ -78,13 +78,33 @@ func (tssReqs *tssRequests) SetSignedRequest(req TssRequest) error {
 func (tssReqs *tssRequests) FindUnsignedRequests(blockHeight uint64) ([]TssRequest, error) {
 	ctx := context.Background()
 
-	// Revive requests that were marked "failed" by the removed block-age expiry
-	// so they are retried. Idempotent — a no-op once drained.
-	tssReqs.UpdateMany(ctx, bson.M{
-		"status": "failed",
-	}, bson.M{
-		"$set": bson.M{"status": "unsigned"},
-	})
+	// Revive "failed" requests (from the removed block-age expiry, or from
+	// deprecated-key filtering when a key is later renewed) — but only for keys
+	// that are currently active. Requests whose key is still deprecated/retired
+	// stay "failed" so selection skips them without re-checking every tick.
+	activeKeysColl := tssReqs.Database().Collection("tss_keys")
+	activeCur, keyErr := activeKeysColl.Find(ctx, bson.M{"status": TssKeyActive},
+		options.Find().SetProjection(bson.M{"id": 1}))
+	if keyErr == nil {
+		var activeKeyIds []string
+		for activeCur.Next(ctx) {
+			var k struct {
+				Id string `bson:"id"`
+			}
+			if activeCur.Decode(&k) == nil {
+				activeKeyIds = append(activeKeyIds, k.Id)
+			}
+		}
+		activeCur.Close(ctx)
+		if len(activeKeyIds) > 0 {
+			tssReqs.UpdateMany(ctx, bson.M{
+				"status": "failed",
+				"key_id": bson.M{"$in": activeKeyIds},
+			}, bson.M{
+				"$set": bson.M{"status": "unsigned"},
+			})
+		}
+	}
 
 	requests := make([]TssRequest, 0)
 	findResult, err := tssReqs.Find(ctx, bson.M{

--- a/modules/db/vsc/tss/requests.go
+++ b/modules/db/vsc/tss/requests.go
@@ -69,8 +69,7 @@ func (tssReqs *tssRequests) SetSignedRequest(req TssRequest) error {
 		"msg":    req.Msg,
 	}, bson.M{
 		"$set": bson.M{
-			"status":         "unsigned",
-			"created_height": req.CreatedHeight,
+			"status": "unsigned",
 		},
 	}, updateOptions)
 	return singeResult.Err()
@@ -79,28 +78,13 @@ func (tssReqs *tssRequests) SetSignedRequest(req TssRequest) error {
 func (tssReqs *tssRequests) FindUnsignedRequests(blockHeight uint64) ([]TssRequest, error) {
 	ctx := context.Background()
 
-	// Backfill legacy requests that lack a created_height so they enter
-	// the same expiry window as newly created requests.
+	// Revive requests that were marked "failed" by the removed block-age expiry
+	// so they are retried. Idempotent — a no-op once drained.
 	tssReqs.UpdateMany(ctx, bson.M{
-		"status": "unsigned",
-		"$or": bson.A{
-			bson.M{"created_height": bson.M{"$exists": false}},
-			bson.M{"created_height": 0},
-		},
+		"status": "failed",
 	}, bson.M{
-		"$set": bson.M{"created_height": blockHeight},
+		"$set": bson.M{"status": "unsigned"},
 	})
-
-	// Mark expired unsigned requests as failed so they stop being retried.
-	if blockHeight > SignExpiryBlocks {
-		cutoff := blockHeight - SignExpiryBlocks
-		tssReqs.UpdateMany(ctx, bson.M{
-			"status":         "unsigned",
-			"created_height": bson.M{"$lte": cutoff},
-		}, bson.M{
-			"$set": bson.M{"status": string(SignFailed)},
-		})
-	}
 
 	requests := make([]TssRequest, 0)
 	findResult, err := tssReqs.Find(ctx, bson.M{

--- a/modules/state-processing/system_txs.go
+++ b/modules/state-processing/system_txs.go
@@ -66,14 +66,15 @@ func (output *ContractOutput) Ingest(se *StateEngine, txSelf TxSelf, slotHeight 
 		}
 
 		for _, tssOp := range tssOps {
-			if tssOp.Type == "create" {
+			switch tssOp.Type {
+			case "create":
 				tssLog.Verbose("creating TSS key", "keyId", tssOp.KeyId, "algo", tssOp.Args, "epochs", tssOp.Epochs)
 				_, err := se.tssKeys.FindKey(tssOp.KeyId)
 
 				if err == mongo.ErrNoDocuments {
 					se.tssKeys.InsertKey(tssOp.KeyId, tss_db.TssKeyAlgo(tssOp.Args), tssOp.Epochs)
 				}
-			} else if tssOp.Type == "renew" {
+			case "renew":
 				key, err := se.tssKeys.FindKey(tssOp.KeyId)
 				renewable := err == nil && tssOp.Epochs > 0 &&
 					(key.Status == tss_db.TssKeyActive || key.Status == tss_db.TssKeyDeprecated)
@@ -92,16 +93,23 @@ func (output *ContractOutput) Ingest(se *StateEngine, txSelf TxSelf, slotHeight 
 							key.Status = tss_db.TssKeyActive
 							key.DeprecatedHeight = 0
 						}
-						tssLog.Info("key renewed", "keyId", key.Id, "newExpiryEpoch", key.ExpiryEpoch, "status", key.Status)
+						tssLog.Info(
+							"key renewed",
+							"keyId",
+							key.Id,
+							"newExpiryEpoch",
+							key.ExpiryEpoch,
+							"status",
+							key.Status,
+						)
 						se.tssKeys.SetKey(key)
 					}
 				}
-			} else if tssOp.Type == "sign" {
+			case "sign":
 				se.tssRequests.SetSignedRequest(tss_db.TssRequest{
-					KeyId:         tssOp.KeyId,
-					Status:        "unsigned",
-					Msg:           tssOp.Args,
-					CreatedHeight: txSelf.BlockHeight,
+					KeyId:  tssOp.KeyId,
+					Status: "unsigned",
+					Msg:    tssOp.Args,
 				})
 				// if err == mongo.ErrNoDocuments {
 				// 	se.tssKeys.InsertKey(tssOp.KeyId, tss_db.TssKeyAlgo(tssOp.Args))
@@ -633,7 +641,7 @@ func (t *TxProposeBlock) Validate(se *StateEngine) bool {
 		return false
 	}
 
-	signingScore, total := elections.CalculateSigningScore(*circuit, elecResult)
+	signingScore, total := elections.CalculateSigningScore(circuit, elecResult)
 
 	verifiedR := signingScore > ((total * 2) / 3)
 

--- a/modules/tss/dispatcher.go
+++ b/modules/tss/dispatcher.go
@@ -540,15 +540,16 @@ func (dispatcher *ReshareDispatcher) Done() *promise.Promise[DispatcherResult] {
 			// Check connection status for each culprit to provide context
 			culpritContext := make(map[string]string)
 
-			// Collect all waiting parties from both old and new sides.
-			// WaitingFor() returns combined old+new, so we deduplicate via
-			// the culprits map and label based on actual committee membership.
+			// Only the new party's WaitingFor identifies root-cause culprits.
+			// When round 1 stalls on a missing old-committee broadcast, the new
+			// party still sits in round 1 and points at the silent old member.
+			// The old party has advanced to round 2 and is waiting on every new
+			// party's ACK — those new parties are themselves blocked in round 1
+			// by the same root cause, so old.WaitingFor reports collateral
+			// victims. Merging both inflated culprit counts past maxBlamed and
+			// tripped systemic-blame suppression (tss.go:1552), so no blame
+			// ever landed on Hive and the offender was never excluded.
 			allWaiting := make(map[string]bool)
-			if dispatcher.party != nil {
-				for _, p := range dispatcher.party.WaitingFor() {
-					allWaiting[p.Id] = true
-				}
-			}
 			if dispatcher.newParty != nil {
 				for _, p := range dispatcher.newParty.WaitingFor() {
 					allWaiting[p.Id] = true

--- a/modules/tss/tss.go
+++ b/modules/tss/tss.go
@@ -504,12 +504,18 @@ func (tssMgr *TssManager) BlockTick(bh uint64, headHeight *uint64) {
 				keyInfo, _ := tssMgr.tssKeys.FindKey(signReq.KeyId)
 				if keyInfo.Status != tss_db.TssKeyActive {
 					log.Warn(
-						"signing attempted for non-active key, skipping",
+						"marking sign request as failed for non-active key",
 						"keyId",
 						keyInfo.Id,
 						"status",
 						keyInfo.Status,
 					)
+					tssMgr.tssRequests.UpdateRequest(tss_db.TssRequest{
+						KeyId:  signReq.KeyId,
+						Msg:    signReq.Msg,
+						Sig:    signReq.Sig,
+						Status: tss_db.SignFailed,
+					})
 					continue
 				}
 				if !keyLocks[signReq.KeyId] {


### PR DESCRIPTION
- removed retry expiry for tss requests. Expiry is now handled solely by key deprecation
- removed old committee union from reshare blames to avoid collateral blame when new session fails to advance to stage 2 