### PR TITLE
fix: oracle ETH payload format — structured JSON matching contract Ad…

### DIFF
--- a/modules/oracle/chain/handle_block_tick.go
+++ b/modules/oracle/chain/handle_block_tick.go
@@ -559,7 +559,7 @@ type ethAddBlockEntry struct {
 
 // makeTransactionPayload builds the chain-appropriate payload.
 // UTXO chains (BTC/DASH/LTC) use concatenated hex + fee rate.
-// ETH uses an array of individual hex strings.
+// ETH uses structured block entries expected by AddBlocksParams.
 func makeTransactionPayload(blocks []chainBlock) (any, error) {
 	if len(blocks) == 0 {
 		return &utxoAddBlocksPayload{}, nil
@@ -605,6 +605,10 @@ func makeEthPayload(blocks []chainBlock) (*ethAddBlocksPayload, error) {
 		}
 		var baseFee uint64
 		if eth.header.BaseFee != nil {
+			// Reject out-of-range/negative fees instead of silently truncating.
+			if eth.header.BaseFee.Sign() < 0 || eth.header.BaseFee.BitLen() > 64 {
+				return nil, fmt.Errorf("block %d base fee out of uint64 range", i)
+			}
 			baseFee = eth.header.BaseFee.Uint64()
 		}
 		entries[i] = ethAddBlockEntry{

--- a/modules/oracle/chain/handle_block_tick.go
+++ b/modules/oracle/chain/handle_block_tick.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -541,10 +542,19 @@ type utxoAddBlocksPayload struct {
 	LatestFee int64  `json:"latest_fee"`
 }
 
-// ethAddBlocksPayload matches the ETH mapping contract's AddBlocksParams:
-// an array of individually hex-encoded RLP block headers (variable length).
+// ethAddBlocksPayload matches the ETH mapping contract's AddBlocksParams.
 type ethAddBlocksPayload struct {
-	Blocks []string `json:"blocks"`
+	Blocks    []ethAddBlockEntry `json:"blocks"`
+	LatestFee uint64             `json:"latest_fee"`
+}
+
+type ethAddBlockEntry struct {
+	BlockNumber      uint64 `json:"block_number"`
+	TransactionsRoot string `json:"transactions_root"`
+	ReceiptsRoot     string `json:"receipts_root"`
+	BaseFeePerGas    uint64 `json:"base_fee_per_gas"`
+	GasLimit         uint64 `json:"gas_limit"`
+	Timestamp        uint64 `json:"timestamp"`
 }
 
 // makeTransactionPayload builds the chain-appropriate payload.
@@ -586,15 +596,31 @@ func makeUtxoPayload(blocks []chainBlock) (*utxoAddBlocksPayload, error) {
 }
 
 func makeEthPayload(blocks []chainBlock) (*ethAddBlocksPayload, error) {
-	headers := make([]string, len(blocks))
+	entries := make([]ethAddBlockEntry, len(blocks))
+	var latestFee uint64
 	for i, block := range blocks {
-		hex, err := block.Serialize()
-		if err != nil {
-			return nil, err
+		eth, ok := block.(*ethChainData)
+		if !ok {
+			return nil, fmt.Errorf("block %d is not ethChainData", i)
 		}
-		headers[i] = hex
+		var baseFee uint64
+		if eth.header.BaseFee != nil {
+			baseFee = eth.header.BaseFee.Uint64()
+		}
+		entries[i] = ethAddBlockEntry{
+			BlockNumber:      eth.Height,
+			TransactionsRoot: hex.EncodeToString(eth.header.TxHash.Bytes()),
+			ReceiptsRoot:     hex.EncodeToString(eth.header.ReceiptHash.Bytes()),
+			BaseFeePerGas:    baseFee,
+			GasLimit:         eth.header.GasLimit,
+			Timestamp:        eth.header.Time,
+		}
+		latestFee = baseFee
 	}
-	return &ethAddBlocksPayload{Blocks: headers}, nil
+	return &ethAddBlocksPayload{
+		Blocks:    entries,
+		LatestFee: latestFee,
+	}, nil
 }
 
 // findMemberWeight returns the election weight for a given BLS DID.

--- a/modules/oracle/chain/handle_block_tick_test.go
+++ b/modules/oracle/chain/handle_block_tick_test.go
@@ -120,6 +120,47 @@ func TestMakeTransactionPayload_ETH(t *testing.T) {
 	assert.Equal(t, uint64(1000000000), payload.LatestFee)
 }
 
+func TestMakeTransactionPayload_ETHNilBaseFee(t *testing.T) {
+	blocks := []chainBlock{
+		&ethChainData{
+			Height: 101,
+			header: &types.Header{
+				TxHash:      common.HexToHash("bbbbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd"),
+				ReceiptHash: common.HexToHash("2222334411223344112233441122334411223344112233441122334411223344"),
+				BaseFee:     nil,
+				GasLimit:    31000000,
+				Time:        1700000001,
+			},
+		},
+	}
+
+	raw, err := makeTransactionPayload(blocks)
+	assert.NoError(t, err)
+	payload := raw.(*ethAddBlocksPayload)
+	assert.Equal(t, uint64(0), payload.Blocks[0].BaseFeePerGas)
+	assert.Equal(t, uint64(0), payload.LatestFee)
+}
+
+func TestMakeTransactionPayload_ETHBaseFeeOverflow(t *testing.T) {
+	overflowFee := new(big.Int).Lsh(big.NewInt(1), 65)
+	blocks := []chainBlock{
+		&ethChainData{
+			Height: 102,
+			header: &types.Header{
+				TxHash:      common.HexToHash("ccccccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd"),
+				ReceiptHash: common.HexToHash("3333334411223344112233441122334411223344112233441122334411223344"),
+				BaseFee:     overflowFee,
+				GasLimit:    32000000,
+				Time:        1700000002,
+			},
+		},
+	}
+
+	_, err := makeTransactionPayload(blocks)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "base fee out of uint64 range")
+}
+
 func TestMakeTransaction(t *testing.T) {
 	tx := makeTransaction("vsc1contract", `["aabb","ccdd"]`, "addBlocks", "BTC", "vsc-mocknet", 0)
 

--- a/modules/oracle/chain/handle_block_tick_test.go
+++ b/modules/oracle/chain/handle_block_tick_test.go
@@ -1,11 +1,14 @@
 package chain
 
 import (
+	"math/big"
 	"testing"
 	"vsc-node/lib/dids"
 	"vsc-node/modules/db/vsc/elections"
 
 	"github.com/btcsuite/btcd/wire"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -92,14 +95,29 @@ func TestMakeTransactionPayload_BTCFeeRate(t *testing.T) {
 
 func TestMakeTransactionPayload_ETH(t *testing.T) {
 	blocks := []chainBlock{
-		&mockChainBlock{height: 100, data: "aabbccdd", chainType: "ETH"},
-		&mockChainBlock{height: 101, data: "11223344", chainType: "ETH"},
+		&ethChainData{
+			Height: 100,
+			header: &types.Header{
+				TxHash:      common.HexToHash("aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd"),
+				ReceiptHash: common.HexToHash("1122334411223344112233441122334411223344112233441122334411223344"),
+				BaseFee:     big.NewInt(1000000000),
+				GasLimit:    30000000,
+				Time:        1700000000,
+			},
+		},
 	}
 
 	raw, err := makeTransactionPayload(blocks)
 	assert.NoError(t, err)
 	payload := raw.(*ethAddBlocksPayload)
-	assert.Equal(t, []string{"aabbccdd", "11223344"}, payload.Blocks)
+	assert.Equal(t, 1, len(payload.Blocks))
+	assert.Equal(t, uint64(100), payload.Blocks[0].BlockNumber)
+	assert.Equal(t, "aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd", payload.Blocks[0].TransactionsRoot)
+	assert.Equal(t, "1122334411223344112233441122334411223344112233441122334411223344", payload.Blocks[0].ReceiptsRoot)
+	assert.Equal(t, uint64(1000000000), payload.Blocks[0].BaseFeePerGas)
+	assert.Equal(t, uint64(30000000), payload.Blocks[0].GasLimit)
+	assert.Equal(t, uint64(1700000000), payload.Blocks[0].Timestamp)
+	assert.Equal(t, uint64(1000000000), payload.LatestFee)
 }
 
 func TestMakeTransaction(t *testing.T) {


### PR DESCRIPTION
## Summary
  - Fix ETH oracle payload format to match EVM mapping contract's AddBlocksParams
  - Oracle was sending RLP hex strings, contract expects structured JSON with named fields
  - Zero ETH chain relay transactions ever landed on testnet due to this mismatch
  - Added BaseFee nil guard for pre-EIP-1559 safety
  
  ## Test plan
  - [x] `TestMakeTransactionPayload_ETH` — passes with real ethChainData
  - [x] All 56 oracle/chain tests pass, zero regressions
  - [x] Payload format verified against contract's AddBlocksParams struct