### PR TITLE
Develop - fix panics halting tx and block processing

### DIFF
--- a/lib/dids/bls.go
+++ b/lib/dids/bls.go
@@ -136,6 +136,9 @@ func (d BlsDID) Verify(blk blocks.Block, sig string) (bool, error) {
 		return false, fmt.Errorf("failed to decode signature: %w", err)
 	}
 
+	if len(sigBytes) != 96 {
+		return false, fmt.Errorf("invalid signature length for DID %s: got %d, want 96", d.String(), len(sigBytes))
+	}
 	// decompress the sig into a P2Affine-type (which is a BlsSig)
 	signature := new(BlsSig)
 	if signature.Deserialize((*[96]byte)(sigBytes)) == nil {
@@ -439,6 +442,9 @@ func (b *BlsCircuit) add(member Member, sig string) (bool, error) {
 func (b *BlsCircuit) addRaw(DID BlsDID, sigBytes []byte) (bool, error) {
 	pubKey := DID.Identifier()
 
+	if len(sigBytes) != 96 {
+		return false, fmt.Errorf("invalid signature length for DID %s: got %d, want 96", DID.String(), len(sigBytes))
+	}
 	// decompress the sig
 	signature := new(BlsSig)
 	if signature.Deserialize((*[96]byte)(sigBytes)) != nil {
@@ -599,6 +605,9 @@ func DeserializeBlsCircuit(serialized SerializedCircuit, keyset []BlsDID, msg ci
 		return nil, err
 	}
 
+	if len(sigBytes) != 96 {
+		return nil, fmt.Errorf("invalid signature length: got %d, want 96", len(sigBytes))
+	}
 	signature := new(BlsSig)
 	err = signature.Deserialize((*[96]byte)(sigBytes))
 	if err != nil {

--- a/modules/block-producer/blockProducer.go
+++ b/modules/block-producer/blockProducer.go
@@ -328,24 +328,13 @@ func (bp *BlockProducer) generateTransactions(slotHeight uint64) []vscBlocks.Vsc
 
 		tx := txMap[keyId][0]
 
-		rcLimit := uint64(0)
-		if tx.RcLimit == 0 {
-			//Minimum of 0.05 hbd or 50 integer units
-			for _, op := range tx.Ops {
-				if op.Type == "transfer" {
-					rcLimit += 100
-				} else if op.Type == "stake_hbd" {
-					rcLimit += 200
-				} else if op.Type == "unstake_hbd" {
-					rcLimit += 200
-				} else if op.Type == "withdraw" {
-					rcLimit += 200
-				} else if op.Type == "call" {
-					rcLimit += 100
-				} else {
-					rcLimit += 50
-				}
-			}
+		// Drop txs whose declared RcLimit cannot cover the worst-case
+		// cost of their ops. Mirrors the ingestion-layer check in
+		// transaction-pool.IngestTx so a byzantine peer can't bypass it.
+		if staticMax := transactionpool.StaticMaxRcCostFromRecord(tx.Ops); staticMax > tx.RcLimit {
+			vlog.Debug("tx dropped - rc_limit insufficient for ops",
+				"id", tx.Id, "rcLimit", tx.RcLimit, "staticMax", staticMax)
+			continue
 		}
 
 		didConsume, _ := rcSession.Consume(payer, slotHeight, int64(tx.RcLimit))

--- a/modules/db/vsc/hive_blocks/hive_blocks.go
+++ b/modules/db/vsc/hive_blocks/hive_blocks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -389,17 +388,16 @@ func (h *hiveBlocks) ListenToBlockUpdates(ctx context.Context, startBlock uint64
 	go func() {
 		// Panic recovery in the block-listener goroutine. A panic in the
 		// listener (e.g. ProcessBlock) is treated as fatal-but-graceful:
-		// the panic is logged with a full stack trace, sent to errChan to
-		// halt the StreamReader, and the rest of the process keeps running
-		// so the operator can inspect logs and DB state. Halting prevents
-		// silent state divergence — fine-grained recovery for individual
-		// transactions belongs at the tx layer (see executeTxSafely in the
-		// state engine), not here.
+		// the panic and its stack trace are sent to errChan so the
+		// StreamReader halts and logs them once via its structured logger,
+		// and the rest of the process keeps running so the operator can
+		// inspect logs and DB state. Halting prevents silent state
+		// divergence — fine-grained recovery for individual transactions
+		// belongs at the tx layer (see executeTxSafely in the state
+		// engine), not here.
 		defer func() {
 			if r := recover(); r != nil {
-				stack := debug.Stack()
-				log.Printf("[hive_blocks] FATAL: panic in block listener at block %d: %v\n%s", startBlock, r, stack)
-				errChan <- fmt.Errorf("panic in block listener at block %d: %v\n%s", startBlock, r, stack)
+				errChan <- fmt.Errorf("panic in block listener at block %d: %v\n%s", startBlock, r, debug.Stack())
 			}
 		}()
 		for {

--- a/modules/db/vsc/hive_blocks/hive_blocks.go
+++ b/modules/db/vsc/hive_blocks/hive_blocks.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -385,12 +387,19 @@ func (h *hiveBlocks) ListenToBlockUpdates(ctx context.Context, startBlock uint64
 	ctx, cancel := context.WithCancel(ctx)
 	errChan := make(chan error)
 	go func() {
-		// Recover from panics in the listener callback (e.g. ProcessBlock).
-		// Without this, an unrecovered panic in the listener kills the entire
-		// node process because this goroutine has no other defer/recover.
+		// Panic recovery in the block-listener goroutine. A panic in the
+		// listener (e.g. ProcessBlock) is treated as fatal-but-graceful:
+		// the panic is logged with a full stack trace, sent to errChan to
+		// halt the StreamReader, and the rest of the process keeps running
+		// so the operator can inspect logs and DB state. Halting prevents
+		// silent state divergence — fine-grained recovery for individual
+		// transactions belongs at the tx layer (see executeTxSafely in the
+		// state engine), not here.
 		defer func() {
 			if r := recover(); r != nil {
-				errChan <- fmt.Errorf("panic in block listener at block %d: %v", startBlock, r)
+				stack := debug.Stack()
+				log.Printf("[hive_blocks] FATAL: panic in block listener at block %d: %v\n%s", startBlock, r, stack)
+				errChan <- fmt.Errorf("panic in block listener at block %d: %v\n%s", startBlock, r, stack)
 			}
 		}()
 		for {

--- a/modules/db/vsc/witnesses/interface.go
+++ b/modules/db/vsc/witnesses/interface.go
@@ -2,8 +2,6 @@ package witnesses
 
 import (
 	a "vsc-node/modules/aggregate"
-
-	"go.mongodb.org/mongo-driver/bson"
 )
 
 type Witnesses interface {
@@ -22,12 +20,15 @@ type SearchConfig struct {
 	Enabled          bool
 }
 
-type SearchOption func(cfg *bson.M) error
+// SearchOption filters witnesses post-dedupe. It must be a predicate over the
+// latest record per account, not a query-time filter — applying enabled=true
+// at the Mongo query level would surface an older enabled=true record for an
+// account whose most-recent announcement is enabled=false.
+type SearchOption func(w Witness) bool
 
 // Only returns witnesses that are enabled
 func EnabledOnly() SearchOption {
-	return func(cfg *bson.M) error {
-		(*cfg)["enabled"] = true
-		return nil
+	return func(w Witness) bool {
+		return w.Enabled
 	}
 }

--- a/modules/db/vsc/witnesses/witnesses.go
+++ b/modules/db/vsc/witnesses/witnesses.go
@@ -204,10 +204,6 @@ func (w *witnesses) GetWitnessesAtBlockHeight(bh uint64, opts ...SearchOption) (
 		"account": bson.M{"$in": distinctAccounts},
 	}
 
-	for _, opt := range opts {
-		opt(&query)
-	}
-
 	findOptions := options.Find().SetSort(bson.D{{
 		Key:   "height",
 		Value: -1,
@@ -228,6 +224,10 @@ func (w *witnesses) GetWitnessesAtBlockHeight(bh uint64, opts ...SearchOption) (
 
 	//TODO: add filtering options equivalent to the old VSC network
 
+	// Dedupe to the most recent record per account (cursor is height-desc,
+	// so the first occurrence wins). SearchOption filters are applied AFTER
+	// this — applying them to the Mongo query would let an older enabled=true
+	// record stand in for an account whose latest announcement is disabled.
 	witnessMap := make(map[string]*Witness)
 
 	for _, witness := range witnesses {
@@ -238,6 +238,16 @@ func (w *witnesses) GetWitnessesAtBlockHeight(bh uint64, opts ...SearchOption) (
 
 	outNames := make([]string, 0)
 	for _, witness := range witnessMap {
+		keep := true
+		for _, opt := range opts {
+			if !opt(*witness) {
+				keep = false
+				break
+			}
+		}
+		if !keep {
+			continue
+		}
 		outNames = append(outNames, witness.Account)
 	}
 
@@ -245,9 +255,6 @@ func (w *witnesses) GetWitnessesAtBlockHeight(bh uint64, opts ...SearchOption) (
 
 	outWit := make([]Witness, 0)
 	for _, name := range outNames {
-		if witnessMap[name] == nil {
-			return nil, fmt.Errorf("witness not found")
-		}
 		outWit = append(outWit, *witnessMap[name])
 	}
 

--- a/modules/e2e/container.go
+++ b/modules/e2e/container.go
@@ -115,6 +115,7 @@ func (c *E2EContainer) Init() error {
 	cbortypes.RegisterTypes()
 
 	c.mockReader = stateEngine.NewMockReader()
+	c.mockReader.BlockTime = 1 * time.Second
 
 	mockCreator := stateEngine.MockCreator{
 		Mr: c.mockReader,

--- a/modules/e2e/e2e_test.go
+++ b/modules/e2e/e2e_test.go
@@ -125,7 +125,7 @@ func TestE2E(t *testing.T) {
 			}, nil
 		},
 	})
-	container.AddStep(r2e.Wait(5))
+	container.AddStep(r2e.Wait(2))
 
 	var contractId string
 	container.AddStep(e2e.Step{
@@ -176,7 +176,7 @@ func TestE2E(t *testing.T) {
 		},
 	})
 
-	container.AddStep(r2e.DupElection(5 * time.Second))
+	container.AddStep(r2e.DupElection(2 * time.Second))
 	container.AddStep(e2e.Step{
 		Name: "Update Contract",
 		TestFunc: func(ctx e2e.StepCtx) (e2e.EvaluateFunc, error) {
@@ -219,7 +219,7 @@ func TestE2E(t *testing.T) {
 		},
 	})
 
-	container.AddStep(r2e.Wait(10))
+	// container.AddStep(r2e.Wait(10))
 	container.AddStep(e2e.Step{
 		Name: "Execute Contract - Test 1",
 		TestFunc: func(ctx e2e.StepCtx) (e2e.EvaluateFunc, error) {
@@ -261,9 +261,10 @@ func TestE2E(t *testing.T) {
 				return nil, err
 			}
 			tx := transactionpool.VSCTransaction{
-				Ops:   []transactionpool.VSCTransactionOp{op1, op2, op3},
-				Nonce: 0,
-				NetId: "vsc-mocknet",
+				Ops:     []transactionpool.VSCTransactionOp{op1, op2, op3},
+				Nonce:   0,
+				NetId:   "vsc-mocknet",
+				RcLimit: 1000,
 			}
 			sTx, err := transactionCreator.SignFinal(tx)
 			txId, err := transactionCreator.Broadcast(sTx)
@@ -273,7 +274,7 @@ func TestE2E(t *testing.T) {
 			}
 
 			fmt.Println("txId", txId)
-			return e2e.TxStatusAssertion([]e2e.TxStatusAssert{{txId, transactions.TransactionStatusConfirmed}}, 120), nil
+			return e2e.TxStatusAssertion([]e2e.TxStatusAssert{{txId, transactions.TransactionStatusConfirmed}}, 30), nil
 		},
 	})
 
@@ -302,7 +303,7 @@ func TestE2E(t *testing.T) {
 		},
 	})
 
-	container.AddStep(r2e.DupElection(10 * time.Second))
+	container.AddStep(r2e.DupElection(3 * time.Second))
 
 	container.AddStep(e2e.Step{
 		Name: "Execute Contract - Test 2",
@@ -346,9 +347,10 @@ func TestE2E(t *testing.T) {
 				return nil, err
 			}
 			tx := transactionpool.VSCTransaction{
-				Ops:   []transactionpool.VSCTransactionOp{op1, op2, op3},
-				Nonce: 1,
-				NetId: "vsc-mocknet",
+				Ops:     []transactionpool.VSCTransactionOp{op1, op2, op3},
+				Nonce:   1,
+				NetId:   "vsc-mocknet",
+				RcLimit: 1000,
 			}
 			sTx, err := transactionCreator.SignFinal(tx)
 			txId, err := transactionCreator.Broadcast(sTx)
@@ -377,8 +379,9 @@ func TestE2E(t *testing.T) {
 				Ops: []transactionpool.VSCTransactionOp{
 					op4,
 				},
-				Nonce: 2,
-				NetId: "vsc-mocknet",
+				Nonce:   2,
+				NetId:   "vsc-mocknet",
+				RcLimit: 200,
 			}
 			sTx2, _ := transactionCreator.SignFinal(tx2)
 			txId2, err := transactionCreator.Broadcast(sTx2)
@@ -388,10 +391,10 @@ func TestE2E(t *testing.T) {
 			}
 
 			fmt.Println("txId2", txId2)
-			return e2e.TxStatusAssertion([]e2e.TxStatusAssert{{txId, transactions.TransactionStatusConfirmed}, {txId2, transactions.TransactionStatusFailed}}, 120), nil
+			return e2e.TxStatusAssertion([]e2e.TxStatusAssert{{txId, transactions.TransactionStatusConfirmed}, {txId2, transactions.TransactionStatusFailed}}, 30), nil
 		},
 	})
-	container.AddStep(r2e.Wait(10))
+	// container.AddStep(r2e.Wait(10))
 
 	err := container.RunSteps(t)
 

--- a/modules/hive/streamer/streamer.go
+++ b/modules/hive/streamer/streamer.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"log/slog"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -206,7 +208,17 @@ func (s *StreamReader) pollDb(fail func(error)) {
 	cancel, errChan := s.hiveBlocks.ListenToBlockUpdates(s.ctx, s.lastProcessed, processBlock)
 	select {
 	case err := <-errChan:
-		vlog.Error("StreamReader stopped — listener error", "err", err, "lastProcessed", s.lastProcessed)
+		// Two-step output to keep the structured prefix line while still
+		// rendering the multi-line panic/stack trace correctly. slog's
+		// TextHandler escapes \n and \t inside string values, so passing
+		// the stack as an "err" attr produces unreadable output. Instead,
+		// log the structured "StreamReader stopped" line first, then write
+		// the verbatim error+stack to stderr — gated on the same level so
+		// disabling Error-level logs for this module suppresses both.
+		vlog.Error("StreamReader stopped — listener error", "lastProcessed", s.lastProcessed)
+		if vlog.Enabled(context.Background(), slog.LevelError) {
+			fmt.Fprintln(os.Stderr, err)
+		}
 		fail(err)
 	case <-s.ctx.Done():
 		cancel()

--- a/modules/hive/streamer/streamer.go
+++ b/modules/hive/streamer/streamer.go
@@ -148,7 +148,9 @@ func (s *StreamReader) Start() *promise.Promise[any] {
 
 func inteceptError() {
 	MyError := recover()
-	vlog.Warn("intercepted error", "err", MyError)
+	if MyError != nil {
+		vlog.Warn("intercepted panic", "err", MyError)
+	}
 }
 
 // polls the database at intervals, processing new blocks as they arrive
@@ -204,6 +206,7 @@ func (s *StreamReader) pollDb(fail func(error)) {
 	cancel, errChan := s.hiveBlocks.ListenToBlockUpdates(s.ctx, s.lastProcessed, processBlock)
 	select {
 	case err := <-errChan:
+		vlog.Error("StreamReader stopped — listener error", "err", err, "lastProcessed", s.lastProcessed)
 		fail(err)
 	case <-s.ctx.Done():
 		cancel()

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -881,10 +881,14 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 							continue
 						}
 
-						circuit, _ := dids.DeserializeBlsCircuit(dids.SerializedCircuit{
+						circuit, derr := dids.DeserializeBlsCircuit(dids.SerializedCircuit{
 							Signature: commitment.Signature,
 							BitVector: commitment.BitSet,
 						}, members, commitmentCid)
+						if derr != nil || circuit == nil {
+							tssLog.Warn("BLS deserialize failed", "keyId", commitment.KeyId, "sessionId", commitment.SessionId, "err", derr)
+							continue
+						}
 
 						verified, _, _ := circuit.Verify()
 						tssIndexHeight := se.SystemConfig().ConsensusParams().TssIndexHeight

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"runtime/debug"
 	"slices"
 	"sort"
 	"strconv"
@@ -1032,6 +1033,40 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 	}
 }
 
+// executeTxSafely runs a transaction handler with panic recovery so that a
+// malformed or attacker-crafted op cannot halt block processing. A panic in
+// the handler is converted to a failed TxResult; the failure is recorded
+// through the normal oplog flow (TxOutput{Ok:false}) and ExecuteBatch
+// continues with the next op in the batch.
+func executeTxSafely(
+	vscTx VSCTransaction,
+	se common_types.StateEngine,
+	ledgerSession ledgerSystem.LedgerSession,
+	rcSession rcSystem.RcSession,
+	callSession *contract_session.CallSession,
+	payer string,
+) (result TxResult) {
+	defer func() {
+		if r := recover(); r != nil {
+			self := vscTx.TxSelf()
+			log.Error(
+				"PANIC during transaction execution",
+				"txId", self.TxId,
+				"type", vscTx.Type(),
+				"blockHeight", self.BlockHeight,
+				"panic", fmt.Sprint(r),
+				"stack", string(debug.Stack()),
+			)
+			result = TxResult{
+				Success: false,
+				Ret:     "internal error: panic during execution",
+				RcUsed:  100,
+			}
+		}
+	}()
+	return vscTx.ExecuteTx(se, ledgerSession, rcSession, callSession, payer)
+}
+
 func (se *StateEngine) ExecuteBatch() {
 
 	lastBlock, _ := se.vscBlocks.GetBlockByHeight(se.slotStatus.SlotHeight)
@@ -1124,7 +1159,7 @@ func (se *StateEngine) ExecuteBatch() {
 					}
 				}
 			}
-			result := vscTx.ExecuteTx(se, ledgerSession, rcSession, callSession, payer)
+			result := executeTxSafely(vscTx, se, ledgerSession, rcSession, callSession, payer)
 
 			log.Debug(
 				"TRANSACTION STATUS",

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -560,7 +560,12 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 					parsedTx := &TxElectionResult{
 						Self: txSelf,
 					}
-					json.Unmarshal(cj.Json, &parsedTx)
+					// Pass parsedTx (a *TxElectionResult), not &parsedTx
+					// (**TxElectionResult). With the double pointer, a JSON
+					// payload of `null` would set the inner pointer to nil
+					// and the subsequent ExecuteTx call would panic with a
+					// nil receiver.
+					json.Unmarshal(cj.Json, parsedTx)
 					parsedTx.ExecuteTx(se)
 					continue
 				}

--- a/modules/state-processing/system_txs.go
+++ b/modules/state-processing/system_txs.go
@@ -621,11 +621,20 @@ func (t *TxProposeBlock) Validate(se *StateEngine) bool {
 		Block:      blockCid,
 	}
 
-	cid, _ := se.da.HashObject(blockHeader)
+	cid, err := se.da.HashObject(blockHeader)
+	if err != nil || cid == nil {
+		return false
+	}
 
 	circuit, err := dids.DeserializeBlsCircuit(t.SignedBlock.Signature, memberDids, *cid)
+	if err != nil || circuit == nil {
+		return false
+	}
 
 	verified, includedDids, err := circuit.Verify()
+	if err != nil {
+		return false
+	}
 
 	if uint64(t.SignedBlock.Headers.Br[1])+CONSENSUS_SPECS.SlotLength <= t.Self.BlockHeight {
 		fmt.Println(
@@ -660,9 +669,18 @@ func (t *TxProposeBlock) Validate(se *StateEngine) bool {
 // ProcessTx implements VSCTransaction.
 func (t *TxProposeBlock) ExecuteTx(se *StateEngine) {
 
-	blockCid, _ := cid.Parse(t.SignedBlock.Block)
-	node, _ := se.da.GetDag(blockCid)
-	jsonBytes, _ := node.MarshalJSON()
+	blockCid, err := cid.Parse(t.SignedBlock.Block)
+	if err != nil {
+		return
+	}
+	node, err := se.da.GetDag(blockCid)
+	if err != nil || node == nil {
+		return
+	}
+	jsonBytes, err := node.MarshalJSON()
+	if err != nil {
+		return
+	}
 	blockContentC := vscBlocks.VscBlock{}
 	// json.Unmarshal(jsonBytes, &blockContent)
 

--- a/modules/state-processing/transactions.go
+++ b/modules/state-processing/transactions.go
@@ -412,14 +412,14 @@ func (t *TxVSCWithdraw) ExecuteTx(
 		Amount:      amount,
 		BlockHeight: t.Self.BlockHeight,
 	}
-	if t.From == "" {
-		params.From = t.Self.RequiredAuths[0]
-	} else {
+	if t.From != "" {
 		params.From = t.From
+	} else if len(t.Self.RequiredAuths) > 0 {
+		params.From = t.Self.RequiredAuths[0]
 	}
 
 	//Verifies
-	if !slices.Contains(t.Self.RequiredAuths, t.From) {
+	if t.From == "" || !slices.Contains(t.Self.RequiredAuths, t.From) {
 		return TxResult{
 			Success: false,
 			Ret:     "Invalid RequiredAuths",
@@ -469,7 +469,7 @@ func (t *TxStakeHbd) ExecuteTx(
 	if t.NetId != se.SystemConfig().NetId() {
 		return errorToTxResult(fmt.Errorf("wrong net ID"), 50)
 	}
-	if t.To == "" || t.From == "" {
+	if t.To == "" {
 		return TxResult{
 			Success: false,
 			Ret:     "Invalid to/from",
@@ -498,13 +498,13 @@ func (t *TxStakeHbd) ExecuteTx(
 			BlockHeight: t.Self.BlockHeight,
 		},
 	}
-	if t.From == "" {
-		params.From = "hive:" + t.Self.RequiredAuths[0]
-	} else {
+	if t.From != "" {
 		params.From = t.From
+	} else if len(t.Self.RequiredAuths) > 0 {
+		params.From = "hive:" + t.Self.RequiredAuths[0]
 	}
 
-	if !slices.Contains(t.Self.RequiredAuths, t.From) {
+	if t.From == "" || !slices.Contains(t.Self.RequiredAuths, t.From) {
 		return TxResult{
 			Success: false,
 			Ret:     "Invalid RequiredAuths",
@@ -557,7 +557,7 @@ func (t *TxUnstakeHbd) ExecuteTx(
 	if t.NetId != se.SystemConfig().NetId() {
 		return errorToTxResult(fmt.Errorf("wrong net ID"), 50)
 	}
-	if t.To == "" || t.From == "" {
+	if t.To == "" {
 		return TxResult{
 			Success: false,
 			Ret:     "Invalid to/from",
@@ -587,13 +587,13 @@ func (t *TxUnstakeHbd) ExecuteTx(
 			Type:        "unstake",
 		},
 	}
-	if t.From == "" {
-		params.From = "hive:" + t.Self.RequiredAuths[0]
-	} else {
+	if t.From != "" {
 		params.From = t.From
+	} else if len(t.Self.RequiredAuths) > 0 {
+		params.From = "hive:" + t.Self.RequiredAuths[0]
 	}
 
-	if !slices.Contains(t.Self.RequiredAuths, t.From) {
+	if t.From == "" || !slices.Contains(t.Self.RequiredAuths, t.From) {
 		return TxResult{
 			Success: false,
 			Ret:     "Invalid RequiredAuths",

--- a/modules/state-processing/utils.go
+++ b/modules/state-processing/utils.go
@@ -184,6 +184,11 @@ type MockReader struct {
 	ProcessFunction streamer.ProcessFunction
 	LastBlock       uint64
 
+	// BlockTime controls both the real-time interval at which StartRealtime
+	// produces blocks and the simulated timestamp delta between consecutive
+	// blocks. Defaults to 3s (Hive mainnet block time).
+	BlockTime time.Duration
+
 	lastTs time.Time
 	mutex  *sync.Mutex
 }
@@ -217,9 +222,9 @@ func (mr *MockReader) BroadcastTx() {
 
 }
 
-// Run the mock in real time, producing blocks every 3s.
+// Run the mock in real time, producing blocks at mr.BlockTime intervals.
 func (mr *MockReader) StartRealtime() {
-	ticker := time.NewTicker(3 * time.Second)
+	ticker := time.NewTicker(mr.BlockTime)
 	quit := make(chan struct{})
 	go func() {
 		for {
@@ -237,7 +242,7 @@ func (mr *MockReader) StartRealtime() {
 
 func (mr *MockReader) witnessBlock() {
 	mr.mutex.Lock()
-	ts := mr.lastTs.Add(3 * time.Second)
+	ts := mr.lastTs.Add(mr.BlockTime)
 
 	bn := mr.LastBlock + 1
 	headerbytes := make([]byte, 4)
@@ -283,7 +288,8 @@ func (mr *MockReader) IngestTx(tx hive_blocks.Tx) {
 
 func NewMockReader() *MockReader {
 	return &MockReader{
-		mutex: &sync.Mutex{},
+		BlockTime: 3 * time.Second,
+		mutex:     &sync.Mutex{},
 	}
 }
 

--- a/modules/transaction-pool/static_rc_cost_test.go
+++ b/modules/transaction-pool/static_rc_cost_test.go
@@ -1,0 +1,185 @@
+package transactionpool_test
+
+import (
+	"testing"
+
+	"vsc-node/modules/db/vsc/transactions"
+	transactionpool "vsc-node/modules/transaction-pool"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// callOp crafts a valid `call` VSCTransactionOp with the given rc_limit
+// via the same SerializeVSC path IngestTx sees from real clients.
+func callOp(t *testing.T, rcLimit uint) transactionpool.VSCTransactionOp {
+	t.Helper()
+	call := &transactionpool.VscContractCall{
+		Caller:     "hive:alice",
+		ContractId: "vsc1dontcare",
+		Action:     "noop",
+		Payload:    "{}",
+		RcLimit:    rcLimit,
+		NetId:      "vsc-mocknet",
+	}
+	op, err := call.SerializeVSC()
+	if err != nil {
+		t.Fatalf("SerializeVSC failed: %v", err)
+	}
+	return op
+}
+
+func TestStaticMaxRcCost(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		assert.Equal(t, uint64(0), transactionpool.StaticMaxRcCost(nil))
+		assert.Equal(t, uint64(0), transactionpool.StaticMaxRcCost([]transactionpool.VSCTransactionOp{}))
+	})
+
+	t.Run("CallUsesPerOpRcLimit", func(t *testing.T) {
+		ops := []transactionpool.VSCTransactionOp{
+			callOp(t, 1000),
+			callOp(t, 500),
+		}
+		assert.Equal(t, uint64(1500), transactionpool.StaticMaxRcCost(ops))
+	})
+
+	t.Run("CallBelowMinFloor", func(t *testing.T) {
+		// A call op declaring rc_limit=10 must be floored to 100 so the
+		// cap can't be trivially bypassed by a malformed op.
+		ops := []transactionpool.VSCTransactionOp{callOp(t, 10)}
+		assert.Equal(t, uint64(100), transactionpool.StaticMaxRcCost(ops))
+	})
+
+	t.Run("FixedCostOps", func(t *testing.T) {
+		ops := []transactionpool.VSCTransactionOp{
+			{Type: "transfer"},
+			{Type: "withdraw"},
+			{Type: "stake_hbd"},
+			{Type: "unstake_hbd"},
+			{Type: "surprise"}, // default/unknown → 50
+		}
+		assert.Equal(t, uint64(100+200+200+200+50),
+			transactionpool.StaticMaxRcCost(ops))
+	})
+
+	t.Run("Mixed", func(t *testing.T) {
+		ops := []transactionpool.VSCTransactionOp{
+			callOp(t, 700),
+			{Type: "transfer"},
+			{Type: "withdraw"},
+		}
+		assert.Equal(t, uint64(700+100+200), transactionpool.StaticMaxRcCost(ops))
+	})
+}
+
+func TestStaticMaxRcCostFromRecord(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		assert.Equal(t, uint64(0), transactionpool.StaticMaxRcCostFromRecord(nil))
+	})
+
+	t.Run("CallUsesDataRcLimit", func(t *testing.T) {
+		ops := []transactions.TransactionOperation{
+			{Type: "call", Data: map[string]interface{}{"rc_limit": uint(1000)}},
+			{Type: "call", Data: map[string]interface{}{"rc_limit": int64(500)}},
+			{Type: "call", Data: map[string]interface{}{"rc_limit": float64(300)}},
+		}
+		assert.Equal(t, uint64(1800),
+			transactionpool.StaticMaxRcCostFromRecord(ops))
+	})
+
+	t.Run("CallMissingRcLimitFallsBackToFloor", func(t *testing.T) {
+		ops := []transactions.TransactionOperation{
+			{Type: "call", Data: map[string]interface{}{}},
+			{Type: "call", Data: nil},
+		}
+		assert.Equal(t, uint64(200),
+			transactionpool.StaticMaxRcCostFromRecord(ops))
+	})
+
+	t.Run("CallBelowMinFloor", func(t *testing.T) {
+		ops := []transactions.TransactionOperation{
+			{Type: "call", Data: map[string]interface{}{"rc_limit": int64(50)}},
+		}
+		assert.Equal(t, uint64(100),
+			transactionpool.StaticMaxRcCostFromRecord(ops))
+	})
+
+	t.Run("FixedCostOps", func(t *testing.T) {
+		ops := []transactions.TransactionOperation{
+			{Type: "transfer"},
+			{Type: "withdraw"},
+			{Type: "stake_hbd"},
+			{Type: "unstake_hbd"},
+			{Type: "surprise"},
+		}
+		assert.Equal(t, uint64(100+200+200+200+50),
+			transactionpool.StaticMaxRcCostFromRecord(ops))
+	})
+}
+
+// TestRcLimitInvariant_Ingestion exercises the logic the ingestion gate
+// uses. The gate in IngestTx is literally:
+//
+//	if StaticMaxRcCost(ops) > Headers.RcLimit { return err }
+//
+// so asserting the helper's arithmetic against realistic op lists covers
+// both the reject and accept paths the real gate produces.
+func TestRcLimitInvariant_Ingestion(t *testing.T) {
+	tests := []struct {
+		name    string
+		rcLimit uint64
+		ops     []transactionpool.VSCTransactionOp
+		reject  bool
+	}{
+		{
+			name:    "RejectsMultiTransfer",
+			rcLimit: 150, // < 3*100
+			ops: []transactionpool.VSCTransactionOp{
+				{Type: "transfer"},
+				{Type: "transfer"},
+				{Type: "transfer"},
+			},
+			reject: true,
+		},
+		{
+			name:    "AcceptsMultiTransfer",
+			rcLimit: 350, // ≥ 3*100
+			ops: []transactionpool.VSCTransactionOp{
+				{Type: "transfer"},
+				{Type: "transfer"},
+				{Type: "transfer"},
+			},
+			reject: false,
+		},
+		{
+			name:    "RejectsCallWithHighRcLimit",
+			rcLimit: 500,
+			ops:     []transactionpool.VSCTransactionOp{callOp(t, 10000)},
+			reject:  true,
+		},
+		{
+			name:    "AcceptsCallWithinBudget",
+			rcLimit: 10000,
+			ops:     []transactionpool.VSCTransactionOp{callOp(t, 5000)},
+			reject:  false,
+		},
+		{
+			name:    "RejectsMixedOverBudget",
+			rcLimit: 500,
+			ops: []transactionpool.VSCTransactionOp{
+				callOp(t, 300),
+				{Type: "withdraw"}, // 200
+				{Type: "transfer"}, // 100 → sum 600
+			},
+			reject: true,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			staticMax := transactionpool.StaticMaxRcCost(tc.ops)
+			rejects := staticMax > tc.rcLimit
+			assert.Equal(t, tc.reject, rejects,
+				"staticMax=%d rcLimit=%d", staticMax, tc.rcLimit)
+		})
+	}
+}

--- a/modules/transaction-pool/transaction-pool.go
+++ b/modules/transaction-pool/transaction-pool.go
@@ -191,6 +191,12 @@ func (tp *TransactionPool) IngestTx(sTx SerializedVSCTransaction, options ...Ing
 		if uint64(rcsAvailable) < txShell.Headers.RcLimit || txShell.Headers.RcLimit == 0 {
 			return nil, fmt.Errorf("not enough RCS available: %d < %d", rcsAvailable, txShell.Headers.RcLimit)
 		}
+
+		// Reject multi-op txs whose declared RcLimit cannot cover the
+		// worst-case cost of their ops. See StaticMaxRcCost.
+		if staticMax := StaticMaxRcCost(txShell.Tx); staticMax > txShell.Headers.RcLimit {
+			return nil, fmt.Errorf("rc_limit insufficient for declared ops: %d < %d", txShell.Headers.RcLimit, staticMax)
+		}
 	}
 
 	//VALIDATION COMPLETE

--- a/modules/transaction-pool/utils.go
+++ b/modules/transaction-pool/utils.go
@@ -3,6 +3,7 @@ package transactionpool
 import (
 	"encoding/json"
 	"vsc-node/modules/common"
+	"vsc-node/modules/db/vsc/transactions"
 
 	"github.com/ipfs/go-cid"
 	cbornode "github.com/ipfs/go-ipld-cbor"
@@ -41,4 +42,132 @@ func DecodeTxCbor(op VSCTransactionOp, input interface{}) error {
 	jsonBytes, _ := node.MarshalJSON()
 
 	return json.Unmarshal(jsonBytes, input)
+}
+
+// Per-op-type maximum RC costs, used by StaticMaxRcCost to decide whether
+// a declared Headers.RcLimit can cover a multi-op tx's worst case. Values
+// mirror the per-op success-path costs in state-processing/transactions.go
+// and the block-producer fallback at block-producer/blockProducer.go:331.
+// Kept in this file so they're accessible from both the ingestion gate
+// here and the sequencing gate in block-producer.
+const (
+	RcCostTransfer uint64 = 100
+	RcCostWithdraw uint64 = 200
+	RcCostStake    uint64 = 200
+	RcCostUnstake  uint64 = 200
+	RcCostCallMin  uint64 = 100 // minimum floor; call ops declare their own
+	RcCostUnknown  uint64 = 50
+)
+
+// callRcLimit decodes a call op's payload and returns its declared
+// rc_limit. Returns RcCostCallMin if the field is missing or zero so the
+// cap can't be trivially bypassed by a malformed op.
+func callRcLimit(op VSCTransactionOp) uint64 {
+	var payload struct {
+		RcLimit uint64 `json:"rc_limit"`
+	}
+	if err := DecodeTxCbor(op, &payload); err != nil {
+		return RcCostCallMin
+	}
+	if payload.RcLimit < RcCostCallMin {
+		return RcCostCallMin
+	}
+	return payload.RcLimit
+}
+
+// StaticMaxRcCost returns the maximum possible total RC consumption for a
+// list of offchain ops. Used to reject multi-op txs whose declared
+// Headers.RcLimit cannot cover the worst-case cost, enforcing:
+//
+//	Σ(per-op max cost) ≤ Headers.RcLimit
+//
+// For `call` ops it uses the per-op rc_limit decoded from the payload (the
+// WASM gas ceiling). For fixed-cost ops it uses the success-path RcUsed
+// returned by state-processing's per-type ExecuteTx methods.
+func StaticMaxRcCost(ops []VSCTransactionOp) uint64 {
+	var total uint64
+	for _, op := range ops {
+		switch op.Type {
+		case "call":
+			total += callRcLimit(op)
+		case "transfer":
+			total += RcCostTransfer
+		case "withdraw":
+			total += RcCostWithdraw
+		case "stake_hbd":
+			total += RcCostStake
+		case "unstake_hbd":
+			total += RcCostUnstake
+		default:
+			total += RcCostUnknown
+		}
+	}
+	return total
+}
+
+// StaticMaxRcCostFromRecord is the sequencing-layer analogue of
+// StaticMaxRcCost that works on a block producer's TransactionRecord ops.
+// The record's per-op Data map carries the decoded rc_limit for call ops
+// (see TxVscCallContract.ToData).
+func StaticMaxRcCostFromRecord(ops []transactions.TransactionOperation) uint64 {
+	var total uint64
+	for _, op := range ops {
+		switch op.Type {
+		case "call":
+			total += recordCallRcLimit(op)
+		case "transfer":
+			total += RcCostTransfer
+		case "withdraw":
+			total += RcCostWithdraw
+		case "stake_hbd":
+			total += RcCostStake
+		case "unstake_hbd":
+			total += RcCostUnstake
+		default:
+			total += RcCostUnknown
+		}
+	}
+	return total
+}
+
+// recordCallRcLimit extracts the call op's rc_limit from the Data map.
+// The field is stored as a uint by TxVscCallContract.ToData but may be
+// round-tripped through BSON/JSON as int32/int64/float64, so handle all.
+// Missing or malformed field falls back to the minimum floor.
+func recordCallRcLimit(op transactions.TransactionOperation) uint64 {
+	raw, ok := op.Data["rc_limit"]
+	if !ok {
+		return RcCostCallMin
+	}
+	var v uint64
+	switch n := raw.(type) {
+	case uint:
+		v = uint64(n)
+	case uint32:
+		v = uint64(n)
+	case uint64:
+		v = n
+	case int:
+		if n > 0 {
+			v = uint64(n)
+		}
+	case int32:
+		if n > 0 {
+			v = uint64(n)
+		}
+	case int64:
+		if n > 0 {
+			v = uint64(n)
+		}
+	case float64:
+		if n > 0 {
+			v = uint64(n)
+		}
+	default:
+		return RcCostCallMin
+	}
+	if v < RcCostCallMin {
+		return RcCostCallMin
+	}
+	return v
 }

--- a/modules/tss/dispatcher.go
+++ b/modules/tss/dispatcher.go
@@ -239,6 +239,13 @@ func (dispatcher *ReshareDispatcher) Start() error {
 			defer func() {
 				initOnce.Do(func() { partyInitWg.Done() })
 				if r := recover(); r != nil {
+					// The reachable panic in this path is BuildLocalSaveDataSubset
+					// (keygen/save_data.go:92) when a party's PartyID.Key isn't
+					// found in the loaded keydata.Ks — caused by epoch-modification
+					// mismatch (prevCommitmentType disagreeing with how keydata was
+					// produced) or an OLD-committee member who wasn't in the original
+					// keygen. Subset-shrinking (e.g. excluding banned nodes) does NOT
+					// trigger it; the library is designed for that case.
 					log.Error("panic recovered in old party start", "algo", "ECDSA", "sessionId", dispatcher.sessionId, "panic", r)
 					dispatcher.err = fmt.Errorf("panic in old party start: %v", r)
 				}


### PR DESCRIPTION
Panic handler for individual TX processing: if a panic occurs while processing a TX, mark that TX as failed

Panic announcement for block processing: if a panic occurs outside individual TX logic while processing a block, loudly log the panic, but remain fatal to avoid CID mismatch on panics that arise from local state

Fixed ~5 panic locations in TX and block processing exposed via audit 