### PR TITLE
fix: gateway base64 submission + inbound contract-transfer visibility

### DIFF
--- a/modules/db/vsc/transactions/transactionsDb.go
+++ b/modules/db/vsc/transactions/transactionsDb.go
@@ -3,12 +3,14 @@ package transactions
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 	"vsc-node/modules/db"
 	"vsc-node/modules/db/vsc"
 	"vsc-node/modules/db/vsc/hive_blocks"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -24,6 +26,17 @@ func (e *transactions) Init() error {
 	err := e.Collection.Init()
 	if err != nil {
 		return err
+	}
+
+	// Indexes inbound contract-transfer recipients extracted at ingest
+	// (see Ingest). Sparse: the vast majority of txs have no contract
+	// recipients. Non-unique: many txs can credit the same account.
+	indexModel := mongo.IndexModel{
+		Keys:    bson.D{{Key: "payload_recipients", Value: 1}},
+		Options: options.Index().SetSparse(true),
+	}
+	if err = e.CreateIndexIfNotExist(indexModel); err != nil {
+		return fmt.Errorf("failed to create payload_recipients index: %w", err)
 	}
 
 	return nil

--- a/modules/db/vsc/transactions/transactionsDb.go
+++ b/modules/db/vsc/transactions/transactionsDb.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"time"
 	"vsc-node/modules/db"
 	"vsc-node/modules/db/vsc"
@@ -169,13 +170,22 @@ func (e *transactions) FindTransactions(ids []string, id *string, account *strin
 		filters = append(filters, bson.E{Key: "id", Value: bson.D{{Key: "$in", Value: ids}}})
 	}
 	if account != nil {
-		filters = append(filters, bson.E{Key: "$or", Value: bson.A{
+		or := bson.A{
 			bson.D{{Key: "required_auths", Value: *account}},
 			bson.D{{Key: "required_posting_auths", Value: *account}},
 			bson.D{{Key: "ops.data.to", Value: *account}},
 			// Inbound contract transfers: recipient extracted at ingest.
 			bson.D{{Key: "payload_recipients", Value: *account}},
-		}})
+			// TRANSITIONAL: makes historical docs ingested before the
+			// payload_recipients field existed still visible. Unindexed
+			// regex; remove this single clause once
+			// magi-mongo-indexer/scripts/backfill_payload_recipients.js
+			// has populated payload_recipients across mainnet + testnet.
+			bson.D{{Key: "ops.data.payload", Value: bson.M{
+				"$regex": `"to"\s*:\s*"` + regexp.QuoteMeta(*account) + `"`,
+			}}},
+		}
+		filters = append(filters, bson.E{Key: "$or", Value: or})
 	}
 	if contract != nil {
 		filters = append(filters, bson.E{Key: "ops.data.contract_id", Value: *contract})

--- a/modules/db/vsc/transactions/transactionsDb.go
+++ b/modules/db/vsc/transactions/transactionsDb.go
@@ -2,6 +2,7 @@ package transactions
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -83,6 +84,29 @@ func (e *transactions) Ingest(offTx IngestTransactionUpdate) error {
 		}
 	}
 
+	// Extract recipients buried in contract-call payloads (e.g. sats/token
+	// transfers). The recipient lives inside ops.data.payload as a JSON
+	// string, unreachable by Mongo equality; surface it as an indexed field
+	// so FindTransactions can match inbound contract transfers.
+	payloadRecipients := []string{}
+	for _, op := range offTx.Ops {
+		if op.Type != "call" {
+			continue
+		}
+		pl, ok := op.Data["payload"].(string)
+		if !ok {
+			continue
+		}
+		var parsed map[string]interface{}
+		if json.Unmarshal([]byte(pl), &parsed) != nil {
+			continue
+		}
+		if to, ok := parsed["to"].(string); ok && to != "" {
+			payloadRecipients = append(payloadRecipients, to)
+		}
+	}
+	setOp["payload_recipients"] = payloadRecipients
+
 	_, err := e.UpdateOne(ctx, queryy, bson.M{
 		"$set": setOp,
 	}, opts)
@@ -149,6 +173,8 @@ func (e *transactions) FindTransactions(ids []string, id *string, account *strin
 			bson.D{{Key: "required_auths", Value: *account}},
 			bson.D{{Key: "required_posting_auths", Value: *account}},
 			bson.D{{Key: "ops.data.to", Value: *account}},
+			// Inbound contract transfers: recipient extracted at ingest.
+			bson.D{{Key: "payload_recipients", Value: *account}},
 		}})
 	}
 	if contract != nil {

--- a/modules/db/vsc/transactions/transactionsDb_test.go
+++ b/modules/db/vsc/transactions/transactionsDb_test.go
@@ -13,6 +13,7 @@ import (
 	"vsc-node/modules/db/vsc/transactions"
 
 	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 // testAnchorHeight is the hive block height every test transaction is anchored
@@ -112,6 +113,48 @@ func TestInboundContractTransferVisibleToRecipient(t *testing.T) {
 	// Unrelated account sees nothing.
 	other := "hive:nobody"
 	res, err = tx.FindTransactions(nil, nil, &other, nil, nil, nil, nil, nil, nil, nil, 0, 50)
+	assert.NoError(t, err)
+	assert.Len(t, res, 0)
+}
+
+func TestLegacyInboundTransferVisibleViaRegexFallback(t *testing.T) {
+	tx, dbi, dbConfig := setupTxDB(t)
+
+	// Simulate a document ingested by OLD code: no payload_recipients
+	// field, recipient only present inside the ops.data.payload string.
+	// anchr_height matches the seeded hive block so the timestamp pipeline
+	// does not drop it.
+	coll := dbi.Database(dbConfig.GetDbName()).Collection("transaction_pool")
+	_, err := coll.InsertOne(context.Background(), bson.M{
+		"id":             "tx-legacy-1",
+		"status":         "CONFIRMED",
+		"type":           "call",
+		"required_auths": bson.A{"hive:devser.v4vapp"},
+		"anchr_height":   testAnchorHeight,
+		"ops": bson.A{bson.M{
+			"type": "call",
+			"data": bson.M{
+				"contract_id": "vsc1BdrQ6EtbQ64rq2PkPd21x4MaLnVRcJj85d",
+				"action":      "transfer",
+				"payload":     `{"amount":"99","to":"hive:v4vapp-test"}`,
+			},
+		}},
+		// NOTE: deliberately no "payload_recipients" key.
+	})
+	assert.NoError(t, err)
+
+	// Recipient must still be found, via the regex fallback.
+	acct := "hive:v4vapp-test"
+	res, err := tx.FindTransactions(nil, nil, &acct, nil, nil, nil, nil, nil, nil, nil, 0, 50)
+	assert.NoError(t, err)
+	assert.Len(t, res, 1)
+	if len(res) == 1 {
+		assert.Equal(t, "tx-legacy-1", res[0].Id)
+	}
+
+	// Prefix safety: a longer account name must not match this doc.
+	bobby := "hive:v4vapp-testxyz"
+	res, err = tx.FindTransactions(nil, nil, &bobby, nil, nil, nil, nil, nil, nil, nil, 0, 50)
 	assert.NoError(t, err)
 	assert.Len(t, res, 0)
 }

--- a/modules/db/vsc/transactions/transactionsDb_test.go
+++ b/modules/db/vsc/transactions/transactionsDb_test.go
@@ -1,0 +1,54 @@
+package transactions_test
+
+import (
+	"context"
+	"testing"
+
+	"vsc-node/lib/test_utils"
+	"vsc-node/modules/aggregate"
+	"vsc-node/modules/config"
+	"vsc-node/modules/db"
+	"vsc-node/modules/db/vsc"
+	"vsc-node/modules/db/vsc/transactions"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// setupTxDB boots an isolated test transaction_pool collection and returns
+// the Transactions plugin plus the raw mongo handles, so later tests can
+// insert legacy-shaped documents directly via
+// dbi.Database(dbConfig.GetDbName()).Collection("transaction_pool").
+func setupTxDB(t *testing.T) (transactions.Transactions, db.Db, db.DbConfig) {
+	config.UseMainConfigDuringTests = true
+	dbConfig := db.NewDbConfig()
+	dbConfig.Init()
+	dbConfig.SetDbName("go-vsc-tx-test")
+	dbi := db.New(dbConfig)
+	v := vsc.New(dbi, dbConfig)
+	tx := transactions.New(v)
+
+	test_utils.RunPlugin(t, aggregate.New([]aggregate.Plugin{
+		dbConfig, dbi, v, tx,
+	}))
+	err := v.Clear()
+	assert.NoError(t, err)
+	return tx, dbi, dbConfig
+}
+
+// TestInitIdempotent asserts the payload_recipients index is created by Init
+// and that a second Init does not error (CreateIndexIfNotExist).
+func TestInitIdempotent(t *testing.T) {
+	tx, dbi, dbConfig := setupTxDB(t)
+	assert.NoError(t, tx.Init()) // second call must be a no-op, not an error
+
+	coll := dbi.Database(dbConfig.GetDbName()).Collection("transaction_pool")
+	specs, err := coll.Indexes().ListSpecifications(context.Background())
+	assert.NoError(t, err)
+	found := false
+	for _, s := range specs {
+		if s.Name == "payload_recipients_1" {
+			found = true
+		}
+	}
+	assert.True(t, found, "payload_recipients index must exist after Init")
+}

--- a/modules/db/vsc/transactions/transactionsDb_test.go
+++ b/modules/db/vsc/transactions/transactionsDb_test.go
@@ -9,15 +9,25 @@ import (
 	"vsc-node/modules/config"
 	"vsc-node/modules/db"
 	"vsc-node/modules/db/vsc"
+	"vsc-node/modules/db/vsc/hive_blocks"
 	"vsc-node/modules/db/vsc/transactions"
 
 	"github.com/stretchr/testify/assert"
 )
 
-// setupTxDB boots an isolated test transaction_pool collection and returns
-// the Transactions plugin plus the raw mongo handles, so later tests can
-// insert legacy-shaped documents directly via
-// dbi.Database(dbConfig.GetDbName()).Collection("transaction_pool").
+// testAnchorHeight is the hive block height every test transaction is anchored
+// to. setupTxDB seeds a matching hive_blocks document so the timestamp
+// $lookup/$unwind in FindTransactions resolves (otherwise the unwind, which
+// does not preserve null/empty arrays, drops the transaction).
+const testAnchorHeight uint64 = 100
+
+func u64(v uint64) *uint64 { return &v }
+
+// setupTxDB boots an isolated test transaction_pool collection, seeds one
+// hive_blocks document at testAnchorHeight, and returns the Transactions
+// plugin plus the raw mongo handles (so later tests can insert legacy-shaped
+// documents directly via
+// dbi.Database(dbConfig.GetDbName()).Collection("transaction_pool")).
 func setupTxDB(t *testing.T) (transactions.Transactions, db.Db, db.DbConfig) {
 	config.UseMainConfigDuringTests = true
 	dbConfig := db.NewDbConfig()
@@ -26,11 +36,20 @@ func setupTxDB(t *testing.T) (transactions.Transactions, db.Db, db.DbConfig) {
 	dbi := db.New(dbConfig)
 	v := vsc.New(dbi, dbConfig)
 	tx := transactions.New(v)
+	hb, err := hive_blocks.New(v)
+	assert.NoError(t, err)
 
 	test_utils.RunPlugin(t, aggregate.New([]aggregate.Plugin{
-		dbConfig, dbi, v, tx,
+		dbConfig, dbi, v, tx, hb,
 	}))
-	err := v.Clear()
+	err = v.Clear()
+	assert.NoError(t, err)
+
+	err = hb.StoreBlocks(testAnchorHeight, hive_blocks.HiveBlock{
+		BlockNumber: testAnchorHeight,
+		BlockID:     "test-blk-100",
+		Timestamp:   "2026-05-18T00:00:00",
+	})
 	assert.NoError(t, err)
 	return tx, dbi, dbConfig
 }
@@ -51,4 +70,48 @@ func TestInitIdempotent(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "payload_recipients index must exist after Init")
+}
+
+func TestInboundContractTransferVisibleToRecipient(t *testing.T) {
+	tx, _, _ := setupTxDB(t)
+
+	err := tx.Ingest(transactions.IngestTransactionUpdate{
+		Id:             "tx-call-1",
+		Status:         "CONFIRMED",
+		Type:           "call",
+		RequiredAuths:  []string{"hive:devser.v4vapp"},
+		AnchoredHeight: u64(testAnchorHeight),
+		Ops: []transactions.TransactionOperation{
+			{
+				Type: "call",
+				Data: map[string]interface{}{
+					"contract_id": "vsc1BdrQ6EtbQ64rq2PkPd21x4MaLnVRcJj85d",
+					"action":      "transfer",
+					"payload":     `{"amount":"432","to":"hive:v4vapp-test"}`,
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	// Recipient (in payload, NOT in required_auths) must see the tx.
+	acct := "hive:v4vapp-test"
+	res, err := tx.FindTransactions(nil, nil, &acct, nil, nil, nil, nil, nil, nil, nil, 0, 50)
+	assert.NoError(t, err)
+	assert.Len(t, res, 1)
+	if len(res) == 1 {
+		assert.Equal(t, "tx-call-1", res[0].Id)
+	}
+
+	// Sender still finds it via required_auths (no regression).
+	sender := "hive:devser.v4vapp"
+	res, err = tx.FindTransactions(nil, nil, &sender, nil, nil, nil, nil, nil, nil, nil, 0, 50)
+	assert.NoError(t, err)
+	assert.Len(t, res, 1)
+
+	// Unrelated account sees nothing.
+	other := "hive:nobody"
+	res, err = tx.FindTransactions(nil, nil, &other, nil, nil, nil, nil, nil, nil, nil, 0, 50)
+	assert.NoError(t, err)
+	assert.Len(t, res, 0)
 }

--- a/modules/gql/gqlgen/b64_decode_test.go
+++ b/modules/gql/gqlgen/b64_decode_test.go
@@ -1,0 +1,45 @@
+package gqlgen
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestDecodeSubmittedB64(t *testing.T) {
+	// Bytes chosen so StdEncoding produces '+' and '/' (the exact failure
+	// the bug report reproduced on testnet: "AAEC+wQF/gcI").
+	raw := []byte{0x00, 0x01, 0x02, 0xfb, 0x04, 0x05, 0xfe, 0x07, 0x08}
+
+	std := base64.StdEncoding.EncodeToString(raw)
+	if !strings.ContainsAny(std, "+/") {
+		t.Fatalf("test fixture invalid: std encoding %q has no + or /", std)
+	}
+
+	cases := []struct {
+		name string
+		in   string
+		ok   bool
+	}{
+		{"std with + and /", std, true},
+		{"url-safe", base64.URLEncoding.EncodeToString(raw), true},
+		{"raw std unpadded", base64.RawStdEncoding.EncodeToString(raw), true},
+		{"raw url unpadded", base64.RawURLEncoding.EncodeToString(raw), true},
+		{"garbage", "!!!not base64!!!", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := decodeSubmittedB64(c.in)
+			if c.ok {
+				if err != nil {
+					t.Fatalf("expected ok, got err: %v", err)
+				}
+				if string(got) != string(raw) {
+					t.Fatalf("bytes mismatch: got %x want %x", got, raw)
+				}
+			} else if err == nil {
+				t.Fatalf("expected error for %q", c.in)
+			}
+		})
+	}
+}

--- a/modules/gql/gqlgen/base64.go
+++ b/modules/gql/gqlgen/base64.go
@@ -1,0 +1,26 @@
+package gqlgen
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+// decodeSubmittedB64 accepts any common base64 alphabet/padding (standard or
+// URL-safe, padded or raw). Frontends using btoa() emit standard base64 with
+// + and /, which base64.URLEncoding rejects; this superset accepts all of them
+// without ambiguity (Std/URL only diverge on 2 symbols the other rejects).
+//
+// This helper deliberately lives outside schema.resolvers.go: gqlgen rewrites
+// that file on every `make generate` and strips non-resolver functions from
+// it. Files other than schema.resolvers.go are never touched by codegen.
+func decodeSubmittedB64(s string) ([]byte, error) {
+	for _, enc := range []*base64.Encoding{
+		base64.StdEncoding, base64.URLEncoding,
+		base64.RawStdEncoding, base64.RawURLEncoding,
+	} {
+		if b, err := enc.DecodeString(s); err == nil {
+			return b, nil
+		}
+	}
+	return nil, fmt.Errorf("illegal base64 data: not valid standard or url-safe base64")
+}

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -6,7 +6,6 @@ package gqlgen
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -414,11 +413,11 @@ func (r *queryResolver) FindContract(ctx context.Context, filterOptions *FindCon
 
 // SubmitTransactionV1 is the resolver for the submitTransactionV1 field.
 func (r *queryResolver) SubmitTransactionV1(ctx context.Context, tx string, sig string) (*TransactionSubmitResult, error) {
-	Tx, err := base64.URLEncoding.DecodeString(tx)
+	Tx, err := decodeSubmittedB64(tx)
 	if err != nil {
 		return nil, err
 	}
-	Sig, err := base64.URLEncoding.DecodeString(sig)
+	Sig, err := decodeSubmittedB64(sig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Two go-vsc-node backend fixes for the reported gateway issues. Both are UX/availability — no fund loss.

- **base64 submission:** `SubmitTransactionV1` decoded with   `base64.URLEncoding`, rejecting the `+`/`/` from frontend `btoa()` → EVM  submissions effectively blocked. Now uses a tolerant decoder (std/url,  padded/unpadded). Strict superset; sig verification still gates everything.  Helper lives in its own `modules/gql/gqlgen/base64.go` (not in the  gqlgen-regenerated schema.resolvers.go`).
- **invisible inbound transfers:** contract-call recipients are buried in the   `ops.data.payload` JSON   string, unmatched by `FindTransactions`. Now extracted at ingest into a  sparse-indexed `payload_recipients` field + added to the account filter, with  a transitional regex fallback for un-backfilled historical docs.

**Tests:** `gql` PASS (decoder 5/5); `transactions` PASS 3/3. e2e not run (pre-existing unrelated build block, independent of this change).
