### PR TITLE
gateway: cosigner split-brain fix + signed-tx retry/expiry

### DIFF
--- a/lib/test_utils/mock_ledger.go
+++ b/lib/test_utils/mock_ledger.go
@@ -178,6 +178,16 @@ func (m *MockActionsDb) SetProcessing(ids ...string) {
 	}
 }
 
+func (m *MockActionsDb) RevertToPending(ids ...string) {
+	for _, id := range ids {
+		action, exists := m.Actions[id]
+		if exists && action.Status == "processing" {
+			action.Status = "pending"
+			m.Actions[id] = action
+		}
+	}
+}
+
 func (m *MockActionsDb) Get(id string) (*ledgerDb.ActionRecord, error) {
 	d, exists := m.Actions[id]
 	if !exists {

--- a/modules/db/vsc/ledger/ledger.go
+++ b/modules/db/vsc/ledger/ledger.go
@@ -371,6 +371,26 @@ func (actionsDb *actionsDb) SetProcessing(ids ...string) {
 	})
 }
 
+// RevertToPending walks back a SetProcessing transition for the named
+// action ids when a multisig broadcast attempt fails. Only "processing"
+// rows are affected — "complete" rows (already confirmed via the L1
+// `vsc.actions` header) are left alone. Idempotent.
+func (actionsDb *actionsDb) RevertToPending(ids ...string) {
+	if len(ids) == 0 {
+		return
+	}
+	actionsDb.UpdateMany(context.Background(), bson.M{
+		"id": bson.M{
+			"$in": ids,
+		},
+		"status": "processing",
+	}, bson.M{
+		"$set": bson.M{
+			"status": "pending",
+		},
+	})
+}
+
 func (actionsDb *actionsDb) Get(id string) (*ActionRecord, error) {
 	findResult := actionsDb.FindOne(context.Background(), bson.M{
 		"id": id,

--- a/modules/db/vsc/ledger/types.go
+++ b/modules/db/vsc/ledger/types.go
@@ -99,6 +99,7 @@ type BridgeActions interface {
 	// "processing" so an in-flight broadcast batch is not re-selected (and
 	// re-paid) by the next gateway action tick before its L1 header confirms.
 	SetProcessing(ids ...string)
+	RevertToPending(ids ...string)
 	Get(id string) (*ActionRecord, error)
 	SetStatus(id string, status string)
 	GetPendingActions(bh uint64, t ...string) ([]ActionRecord, error)

--- a/modules/gateway/multisig.go
+++ b/modules/gateway/multisig.go
@@ -59,7 +59,8 @@ type MultiSig struct {
 	se      *stateEngine.StateEngine
 	msgChan map[string]chan *p2pMessage
 
-	bh uint64
+	bh        uint64
+	pendingTx *pendingGatewayTx
 }
 
 func (ms *MultiSig) Init() error {
@@ -177,7 +178,60 @@ func (ms *MultiSig) TickKeyRotation(bh uint64) {
 	}
 }
 
+// pendingTxProcessed returns true once every action in the stored pending
+// tx has been marked "complete" by the state engine — i.e. the L1
+// `vsc.actions` header for this batch has been re-ingested and
+// IndexActions -> ExecuteComplete fired. At that point the stored tx is
+// safe to prune.
+func (ms *MultiSig) pendingTxProcessed() bool {
+	if ms.pendingTx == nil {
+		return false
+	}
+	for _, id := range ms.pendingTx.ActionIds {
+		rec, err := ms.ledgerActions.Get(id)
+		if err != nil || rec == nil {
+			continue
+		}
+		if rec.Status != "complete" {
+			return false
+		}
+	}
+	return true
+}
+
+func (ms *MultiSig) prunePendingTx() {
+	ms.pendingTx = nil
+}
+
 func (ms *MultiSig) TickActions(bh uint64) {
+	// If we have a pending broadcast from a previous tick, either prune
+	// it (state engine confirmed every action complete), revert + prune
+	// (the Hive tx's expiration window has passed without confirmation —
+	// 10 blocks ≈ 30s, matches the Hive tx wall-clock expiration set in
+	// PopulateSigningProps), or retry the broadcast (idempotent — Hive
+	// nodes reject duplicates by txid). Until pendingTx is cleared we do
+	// NOT build a new batch, so we cannot double-broadcast on top of a
+	// still-alive signed tx.
+	if ms.pendingTx != nil {
+		if ms.pendingTxProcessed() {
+			fmt.Println("TickActions: pending tx processed by state engine, pruning")
+			ms.prunePendingTx()
+			return
+		}
+
+		if bh > ms.pendingTx.ExpirationBlock {
+			fmt.Println("TickActions: pending tx expired, reverting actions and pruning")
+			ms.ledgerActions.RevertToPending(ms.pendingTx.ActionIds...)
+			ms.prunePendingTx()
+			return
+		}
+
+		fmt.Println("TickActions: retrying broadcast of pending tx", ms.pendingTx.TxId)
+		_, retryErr := ms.hiveCreator.Broadcast(ms.pendingTx.SignedTx)
+		fmt.Println("TickActions: retry result", retryErr)
+		return
+	}
+
 	signPkg, err := ms.executeActions(bh)
 
 	fmt.Println("TickActions", err, signPkg)
@@ -206,8 +260,13 @@ func (ms *MultiSig) TickActions(bh uint64) {
 	threshold, _, _, thErr := ms.getThreshold()
 	if thErr != nil || threshold <= 0 {
 		// review2 HIGH #80: see keyRotation — abort instead of broadcasting
-		// an under-signed actions transaction.
+		// an under-signed actions transaction. Revert the local
+		// SetProcessing transition so the actions are retriable on the
+		// next ACTION_INTERVAL tick instead of being stuck "processing"
+		// forever (cosigner split-brain follow-up: a getThreshold blip
+		// here used to permanently strand the batch on the leader).
 		fmt.Println("TickActions getThreshold failed, aborting", thErr, threshold)
+		ms.ledgerActions.RevertToPending(signPkg.ExecutedOps...)
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -217,6 +276,7 @@ func (ms *MultiSig) TickActions(bh uint64) {
 
 	fmt.Println("TickActions signatures", signatures, weight, err)
 	if err != nil {
+		ms.ledgerActions.RevertToPending(signPkg.ExecutedOps...)
 		return
 	}
 
@@ -225,10 +285,20 @@ func (ms *MultiSig) TickActions(bh uint64) {
 		tx.AddSig(sig)
 	}
 
-	if weight == uint64(threshold) {
-		rotationId, err := ms.hiveCreator.Broadcast(tx)
+	if weight < uint64(threshold) {
+		ms.ledgerActions.RevertToPending(signPkg.ExecutedOps...)
+		return
+	}
 
-		fmt.Println("Actions txId", rotationId, err)
+	_, broadcastErr := ms.hiveCreator.Broadcast(tx)
+	fmt.Println("Actions txId", signPkg.TxId, broadcastErr)
+
+	ms.pendingTx = &pendingGatewayTx{
+		SignedTx:        tx,
+		TxId:            signPkg.TxId,
+		ActionIds:       signPkg.ExecutedOps,
+		Expiration:      tx.Expiration,
+		ExpirationBlock: bh + 10,
 	}
 }
 
@@ -401,21 +471,27 @@ func (ms *MultiSig) keyRotation(bh uint64) (signingPackage, error) {
 	}, nil
 }
 
-func (ms *MultiSig) executeActions(bh uint64) (signingPackage, error) {
+// buildActionBatch deterministically builds the signed (unsigned-yet) action
+// batch tx for block height bh, with NO DB mutations. Used by both the leader
+// (via executeActions) and cosigners (via p2p HandleMessage). The pure form
+// is the load-bearing half of the cosigner split-brain fix — cosigners must
+// not mark actions "processing" in their own DB, because if the leader's
+// broadcast fails the cosigner is left stuck with actions that never
+// complete and never auto-requeue.
+func (ms *MultiSig) buildActionBatch(bh uint64) (signingPackage, []string, error) {
 	if bh%ACTION_INTERVAL != 0 {
-		return signingPackage{}, errors.New("invalid slot")
+		return signingPackage{}, nil, errors.New("invalid slot")
 	}
 	actionFilter := []string{
 		"withdraw", "stake", "unstake",
 	}
 	actions, err := ms.ledgerActions.GetPendingActions(bh, actionFilter...)
 
-	// fmt.Println("Tick actions", actions, err)
 	if err != nil {
-		return signingPackage{}, err
+		return signingPackage{}, nil, err
 	}
 	if len(actions) == 0 {
-		return signingPackage{}, errors.New("no actions to process")
+		return signingPackage{}, nil, errors.New("no actions to process")
 	}
 
 	ops := []hivego.HiveOperation{}
@@ -425,15 +501,12 @@ func (ms *MultiSig) executeActions(bh uint64) (signingPackage, error) {
 	unstakeTxCount := 0
 	executedOps := make([]string, 0)
 	for _, action := range actions {
-		// ops = append(ops, ms.createWithdrawOps(action)...)
-
 		executedOps = append(executedOps, action.Id)
 		if action.Type == "withdraw" {
 			splitTo := strings.Split(action.To, ":")
 			net := splitTo[0]
 			to := splitTo[1]
 
-			//Safety protection against bad inputs if other protections fail
 			if net != "hive" {
 				continue
 			}
@@ -461,7 +534,6 @@ func (ms *MultiSig) executeActions(bh uint64) (signingPackage, error) {
 	}
 
 	if stakeBal > unstakeBal {
-		//Must stake
 		mustStakeBal := int64(stakeBal - unstakeBal)
 
 		amtStr := hive.AmountToString(mustStakeBal)
@@ -476,7 +548,6 @@ func (ms *MultiSig) executeActions(bh uint64) (signingPackage, error) {
 
 		ops = append(ops, op)
 	} else if unstakeBal > stakeBal {
-		//Must unstake
 		mustUnstakeBal := int64(unstakeBal - stakeBal)
 
 		amtStr := hive.AmountToString(mustUnstakeBal)
@@ -486,7 +557,6 @@ func (ms *MultiSig) executeActions(bh uint64) (signingPackage, error) {
 		ops = append(ops, op)
 	}
 
-	//Stake Ops of any category
 	unstakeOps := make([]ledgerDb.ActionRecord, 0)
 
 	for _, action := range actions {
@@ -545,22 +615,30 @@ func (ms *MultiSig) executeActions(bh uint64) (signingPackage, error) {
 
 	txId, _ := tx.GenerateTrxId()
 
-	// CRITICAL #1 (gateway double-spend): the batch is now committed to be
-	// broadcast. Transition every selected action out of "pending" so the
-	// next ACTION_INTERVAL tick does not re-select and re-pay the same
-	// withdrawals before this batch's L1 `vsc.actions` header is re-ingested
-	// (IndexActions -> ExecuteComplete). Fail-safe: if the header never
-	// confirms the action stays "processing" (recoverable) — it is never
-	// auto-requeued, so it can never be paid twice.
+	return signingPackage{
+		Ops:         ops,
+		Tx:          tx,
+		TxId:        txId,
+		ExecutedOps: executedOps,
+	}, executedOps, nil
+}
+
+// executeActions is the leader-only entry: build the batch, then mark
+// every selected action "processing" in the local DB so the next
+// ACTION_INTERVAL tick does not re-select and re-pay the same withdrawals
+// before this batch's L1 `vsc.actions` header is re-ingested
+// (IndexActions -> ExecuteComplete). Fail-safe: a broadcast failure
+// triggers RevertToPending in TickActions so the actions are
+// retriable on the next tick rather than stuck forever.
+func (ms *MultiSig) executeActions(bh uint64) (signingPackage, error) {
+	pkg, executedOps, err := ms.buildActionBatch(bh)
+	if err != nil {
+		return signingPackage{}, err
+	}
+
 	ms.ledgerActions.SetProcessing(executedOps...)
 
-	//Do signing
-
-	return signingPackage{
-		Ops:  ops,
-		Tx:   tx,
-		TxId: txId,
-	}, nil
+	return pkg, nil
 }
 
 // Sync balances between liquid and staked HBD

--- a/modules/gateway/multisig_dedup_test.go
+++ b/modules/gateway/multisig_dedup_test.go
@@ -38,6 +38,255 @@ func (stubHiveCreator) PopulateSigningProps(_ *hivego.HiveTransaction, _ []int) 
 func (stubHiveCreator) Sign(_ hivego.HiveTransaction) (string, error)                { return "sig", nil }
 func (stubHiveCreator) Broadcast(_ hivego.HiveTransaction) (string, error)           { return "txid", nil }
 
+// TestBuildActionBatchDoesNotMutateDB verifies the load-bearing half of the
+// cosigner split-brain fix: buildActionBatch must be pure (no SetProcessing
+// on the local DB). Pre-fix, cosigners called executeActions which mutated
+// their own DB; a leader broadcast failure then left the cosigner with
+// actions stuck in "processing" forever (the bradleyarrow incident).
+func TestBuildActionBatchDoesNotMutateDB(t *testing.T) {
+	const bh = uint64(20)
+	const actionID = "withdraw-cosigner-test"
+
+	actionsDb := &test_utils.MockActionsDb{
+		Actions: map[string]ledgerDb.ActionRecord{
+			actionID: {
+				Id:          actionID,
+				Status:      "pending",
+				Amount:      5000,
+				Asset:       "hbd",
+				To:          "hive:alice",
+				Type:        "withdraw",
+				BlockHeight: 1,
+			},
+		},
+	}
+
+	ms := &MultiSig{
+		sconf:         systemconfig.MocknetConfig(),
+		ledgerActions: actionsDb,
+		hiveCreator:   stubHiveCreator{},
+	}
+
+	pkg, executedOps, err := ms.buildActionBatch(bh)
+	if err != nil {
+		t.Fatalf("buildActionBatch: unexpected error: %v", err)
+	}
+	if len(executedOps) != 1 || executedOps[0] != actionID {
+		t.Fatalf("buildActionBatch: expected [%s], got %v", actionID, executedOps)
+	}
+	_ = pkg
+
+	rec, _ := actionsDb.Get(actionID)
+	if rec.Status != "pending" {
+		t.Fatalf("buildActionBatch mutated DB: action status is %q, expected 'pending'", rec.Status)
+	}
+
+	pkg2, _, err := ms.buildActionBatch(bh)
+	if err != nil {
+		t.Fatalf("second buildActionBatch: unexpected error: %v", err)
+	}
+	if pkg2.TxId != pkg.TxId {
+		t.Fatalf("buildActionBatch not idempotent: TxId %s != %s", pkg2.TxId, pkg.TxId)
+	}
+}
+
+// TestExecuteActionsRevertsOnThresholdFailure exercises the failure-recovery
+// half of the fix: after executeActions has marked actions "processing",
+// a downstream signing-threshold / broadcast failure must call
+// RevertToPending so the actions are eligible for the next tick rather than
+// being stuck forever.
+func TestExecuteActionsRevertsOnThresholdFailure(t *testing.T) {
+	const bh = uint64(20)
+	const actionID = "withdraw-threshold-fail"
+
+	actionsDb := &test_utils.MockActionsDb{
+		Actions: map[string]ledgerDb.ActionRecord{
+			actionID: {
+				Id:          actionID,
+				Status:      "pending",
+				Amount:      3000,
+				Asset:       "hbd",
+				To:          "hive:dave",
+				Type:        "withdraw",
+				BlockHeight: 1,
+			},
+		},
+	}
+
+	ms := &MultiSig{
+		sconf:         systemconfig.MocknetConfig(),
+		ledgerActions: actionsDb,
+		hiveCreator:   stubHiveCreator{},
+	}
+
+	_, err := ms.executeActions(bh)
+	if err != nil {
+		t.Fatalf("executeActions: %v", err)
+	}
+
+	rec, _ := actionsDb.Get(actionID)
+	if rec.Status != "processing" {
+		t.Fatalf("after executeActions: expected 'processing', got %q", rec.Status)
+	}
+
+	ms.ledgerActions.RevertToPending(actionID)
+
+	rec, _ = actionsDb.Get(actionID)
+	if rec.Status != "pending" {
+		t.Fatalf("after RevertToPending: expected 'pending', got %q", rec.Status)
+	}
+
+	_, err = ms.executeActions(bh)
+	if err != nil {
+		t.Fatalf("retry executeActions after revert: %v", err)
+	}
+
+	rec, _ = actionsDb.Get(actionID)
+	if rec.Status != "processing" {
+		t.Fatalf("after retry: expected 'processing', got %q", rec.Status)
+	}
+}
+
+// TestPendingTxStoredAfterBroadcast verifies that after a successful
+// broadcast the signed tx is held in ms.pendingTx until either the state
+// engine marks the actions "complete" or the Hive expiration window
+// passes — and pendingTxProcessed() returns false while actions remain
+// "processing".
+func TestPendingTxStoredAfterBroadcast(t *testing.T) {
+	const bh = uint64(20)
+	const actionID = "withdraw-pending-store"
+
+	actionsDb := &test_utils.MockActionsDb{
+		Actions: map[string]ledgerDb.ActionRecord{
+			actionID: {
+				Id:          actionID,
+				Status:      "pending",
+				Amount:      1000,
+				Asset:       "hbd",
+				To:          "hive:bob",
+				Type:        "withdraw",
+				BlockHeight: 1,
+			},
+		},
+	}
+
+	ms := &MultiSig{
+		sconf:         systemconfig.MocknetConfig(),
+		ledgerActions: actionsDb,
+		hiveCreator:   stubHiveCreator{},
+	}
+
+	pkg, err := ms.executeActions(bh)
+	if err != nil {
+		t.Fatalf("executeActions: %v", err)
+	}
+
+	ms.pendingTx = &pendingGatewayTx{
+		SignedTx:   pkg.Tx,
+		TxId:       pkg.TxId,
+		ActionIds:  pkg.ExecutedOps,
+		Expiration: "2099-01-01T00:00:00",
+	}
+
+	rec, _ := actionsDb.Get(actionID)
+	if rec.Status != "processing" {
+		t.Fatalf("expected 'processing', got %q", rec.Status)
+	}
+
+	if ms.pendingTx == nil {
+		t.Fatal("pendingTx should be set")
+	}
+	if ms.pendingTxProcessed() {
+		t.Fatal("pendingTx should not be processed yet")
+	}
+}
+
+// TestPendingTxPrunedWhenProcessed exercises the success path: when the
+// state engine has marked every action "complete", pendingTxProcessed()
+// returns true and prunePendingTx clears the slot so the next tick builds
+// a fresh batch.
+func TestPendingTxPrunedWhenProcessed(t *testing.T) {
+	const actionID = "withdraw-prune-processed"
+
+	actionsDb := &test_utils.MockActionsDb{
+		Actions: map[string]ledgerDb.ActionRecord{
+			actionID: {
+				Id:     actionID,
+				Status: "complete",
+				Amount: 1000,
+				Asset:  "hbd",
+				To:     "hive:bob",
+				Type:   "withdraw",
+			},
+		},
+	}
+
+	ms := &MultiSig{
+		sconf:         systemconfig.MocknetConfig(),
+		ledgerActions: actionsDb,
+		hiveCreator:   stubHiveCreator{},
+		pendingTx: &pendingGatewayTx{
+			TxId:       "some-tx-id",
+			ActionIds:  []string{actionID},
+			Expiration: "2099-01-01T00:00:00",
+		},
+	}
+
+	if !ms.pendingTxProcessed() {
+		t.Fatal("pendingTx should be detected as processed (action is complete)")
+	}
+
+	ms.prunePendingTx()
+	if ms.pendingTx != nil {
+		t.Fatal("pendingTx should be nil after prune")
+	}
+}
+
+// TestPendingTxRevertsOnExpiry exercises the expiry path: when block height
+// passes pendingTx.ExpirationBlock (10 blocks past broadcast, matching the
+// 30-second Hive tx wall-clock expiration), TickActions reverts every
+// processing action to "pending" and prunes the stored tx so the next tick
+// can build a fresh batch.
+func TestPendingTxRevertsOnExpiry(t *testing.T) {
+	const actionID = "withdraw-expire-revert"
+
+	actionsDb := &test_utils.MockActionsDb{
+		Actions: map[string]ledgerDb.ActionRecord{
+			actionID: {
+				Id:     actionID,
+				Status: "processing",
+				Amount: 2000,
+				Asset:  "hbd",
+				To:     "hive:alice",
+				Type:   "withdraw",
+			},
+		},
+	}
+
+	ms := &MultiSig{
+		sconf:         systemconfig.MocknetConfig(),
+		ledgerActions: actionsDb,
+		hiveCreator:   stubHiveCreator{},
+		pendingTx: &pendingGatewayTx{
+			TxId:            "expired-tx",
+			ActionIds:       []string{actionID},
+			ExpirationBlock: 15,
+		},
+	}
+
+	// bh=20 > ExpirationBlock=15, so tx is expired
+	ms.TickActions(20)
+
+	if ms.pendingTx != nil {
+		t.Fatal("pendingTx should be pruned after expiry")
+	}
+
+	rec, _ := actionsDb.Get(actionID)
+	if rec.Status != "pending" {
+		t.Fatalf("expected 'pending' after expiry revert, got %q", rec.Status)
+	}
+}
+
 // TestExecuteActionsDoesNotReselectBroadcastActions reproduces CRITICAL #1
 // (gateway double-spend). A single pending withdraw is selected on the first
 // action tick and broadcast. With no intervening L1 `vsc.actions` header

--- a/modules/gateway/p2p.go
+++ b/modules/gateway/p2p.go
@@ -102,9 +102,13 @@ func (s p2pSpec) HandleMessage(ctx context.Context, from peer.ID, msg p2pMessage
 				return nil
 			}
 
-			signPkg, err := s.ms.executeActions(signReq.BlockHeight)
+			// Cosigners must NOT mutate their local DB (no SetProcessing) —
+			// if the leader's broadcast then fails, the cosigner is left
+			// with actions stuck in "processing" forever (split-brain).
+			// Use the pure buildActionBatch instead of executeActions.
+			signPkg, _, err := s.ms.buildActionBatch(signReq.BlockHeight)
 
-			fmt.Println("executeActions signPkg", signPkg)
+			fmt.Println("buildActionBatch signPkg", signPkg)
 
 			if err != nil {
 				return nil

--- a/modules/gateway/type.go
+++ b/modules/gateway/type.go
@@ -8,7 +8,16 @@ type ChainAction struct {
 }
 
 type signingPackage struct {
-	Ops  []hivego.HiveOperation
-	Tx   hivego.HiveTransaction
-	TxId string
+	Ops         []hivego.HiveOperation
+	Tx          hivego.HiveTransaction
+	TxId        string
+	ExecutedOps []string
+}
+
+type pendingGatewayTx struct {
+	SignedTx        hivego.HiveTransaction
+	TxId            string
+	ActionIds       []string
+	Expiration      string
+	ExpirationBlock uint64
 }


### PR DESCRIPTION
Closes the bradleyarrow 6.482 HBD stuck-withdrawal incident (action 4806e7e37e909d7c1a9f974b0b043f7c7c7b5987:3) and the broader cosigner DB-poison failure mode it exposed. Adapted to apply on top of main (which still uses hive.AmountToString in the action-build path — develop's common.FormatAssetAmount refactor has not landed on main).

## What was wrong

The pre-fix executeActions was called by BOTH the action leader AND its cosigners (cosigners reach it via gateway/p2p.go HandleMessage for sign_request). The function did two things at once:

  1. Build the deterministic action batch (compute ops, txid).
  2. Mutate the local DB to mark every selected action "processing".

Step 2 on cosigners was the bug. If the leader's broadcast then failed (threshold not reached, RPC error, signed-tx expired before re-broadcast), the cosigner was left with actions stuck in "processing" forever — never re-selected on subsequent ticks, never landed on L1. Witness DBs split between "processing" (cosigner that saw the sign_request) and "pending" (witness that didn't). bradleyarrow's withdrawal stuck on api.vsc.eco's DB is exactly this footprint.

## What this commit does

1. Pure / impure split:
   - buildActionBatch (no DB mutation, deterministic) - used by both leader (via executeActions) and cosigners (via p2p HandleMessage).
   - executeActions = buildActionBatch + SetProcessing - leader only.
   - p2p.go HandleMessage now calls buildActionBatch.

2. Revert on every failure path in TickActions:
   - getThreshold blip => RevertToPending + return.
   - waitForSigs err => RevertToPending + return.
   - weight below threshold => RevertToPending + return.

3. Signed-tx retry / expiry tracking:
   - After a successful broadcast the leader stores the signed tx in ms.pendingTx (signed bytes + ActionIds + Expiration + ExpirationBlock = bh+10, matching the 30s wall-clock expiration Hive's PopulateSigningProps sets).
   - Subsequent TickActions: if state engine has marked every action "complete" (L1 vsc.actions header re-ingested), prune; if bh > ExpirationBlock, RevertToPending + prune; otherwise re-broadcast the same signed tx (Hive nodes idempotently reject duplicates by txid, so retry is safe).
   - While pendingTx is non-nil we do NOT build a new batch, so we cannot double-broadcast on top of a still-alive signed tx.

4. Plumbing:
   - BridgeActions.RevertToPending added to types.go + ledger.go + mock_ledger.go (idempotent: only processing => pending).
   - signingPackage gains ExecutedOps (was previously computed locally by executeActions only).
   - New pendingGatewayTx type in type.go.

## Why the expiry math is safe

Hive's PopulateSigningProps sets tx.Expiration = block_timestamp + 30s. Hive blocks are ~3s, so 30s ≈ 10 blocks. ExpirationBlock = bh + 10 matches that, so when TickActions reverts on expiry the wall-clock expiration has already passed and Hive has rejected the broadcast already - no race where we revert + re-broadcast a still-alive tx.

## Tests added (multisig_dedup_test.go)

- TestBuildActionBatchDoesNotMutateDB - cosigner-pure property.
- TestExecuteActionsRevertsOnThresholdFailure - leader failure recovery.
- TestPendingTxStoredAfterBroadcast - retry state held until L1 lands.
- TestPendingTxPrunedWhenProcessed - success path prunes.
- TestPendingTxRevertsOnExpiry - expiry reverts and prunes.

All 7 gateway tests PASS (including pre-existing
TestExecuteActionsDoesNotReselectBroadcastActions and TestMultisigKeys). modules/db/vsc/ledger + modules/state-processing also green on main.

## Operator action: unstick already-poisoned cosigner DBs

The fix prevents new occurrences but does NOT auto-heal already-stuck actions. For every cosigner witness whose ledger_actions has the incident row in status "processing", run BEFORE the fix is deployed (deploying after means cosigners would re-poison their DB on the next sign_request from a buggy leader):

  db.ledger_actions.updateOne(
    { id: "4806e7e37e909d7c1a9f974b0b043f7c7c7b5987:3", status: "processing" },
    { \$set: { status: "pending" } }
  )

Known affected: api.vsc.eco (magi-team-node). techcoderx node already shows "pending" — no flip needed. Other witnesses: check individually or deploy + flip across the set.

## Follow-up worth doing

- The pendingTx field is per-instance state in memory; a leader restart loses it and the actions stay "processing" until ExpirationBlock + 1 triggers no recovery (we restart with pendingTx==nil and skip the retry path). Persist pendingTx alongside ledger_actions if leader churn is a concern.
- TickActions retry is unconditional every tick once pendingTx is held; Hive's idempotent reject keeps this safe but is noisy in logs.