### PR TITLE
Feat/pendulum devnet tests

### DIFF
--- a/docs/pendulum/devnet-test-scope.md
+++ b/docs/pendulum/devnet-test-scope.md
@@ -1,0 +1,242 @@
+# Pendulum end-to-end devnet test scope
+
+**Status:** scoping. No tests in this scope landed yet. The existing
+devnet tests on this branch (`fixes/pendulum-devnet-tests`) cover
+narrow PR-specific fixes (BLS proof-of-possession propagation,
+election consensus determinism, the PR #181 unstake guard, and the
+critical-audit pending-actions cursor); none of them exercise the
+pendulum pipeline.
+
+This document is the working spec for a follow-on test workstream
+that covers the pendulum pipeline end-to-end on a real multi-node
+docker devnet — feed publish → oracle window → settlement payload →
+reward distribution + bond reduction. It's a milestone plan you
+should treat as a strawman, not a contract: open questions are
+called out as **Q:**.
+
+## Why this needs devnet, not just unit
+
+Pendulum's unit-test coverage is strong (see [`README.md`](README.md)
+"Implemented" table). What unit tests cannot prove:
+
+- **Consensus determinism**: every node must compute identical
+  settlement payloads from the same oracle inputs. Float math, map
+  iteration, or BSON-vs-canonical drift in the settlement compose
+  path would diverge across nodes — only multi-node devnet exposes
+  this.
+- **Feed propagation timing**: the oracle window (`window.go`) and
+  moving average (`movingavg.go`) consume `feed_publish` L1 ops
+  produced by `cmd/feed-publisher`. Unit tests stub the input; only
+  devnet proves the published payload actually flows through Hive →
+  HAF → magid → oracle DB on every node.
+- **Slashing → bond reduction**: a node that misses attestations
+  must see its committee bond reduced via
+  `ApplyRewardReductionsToBonds`. The unit test
+  `TestApplyRewardReductionsToBonds_*` proves the math, but the
+  bare-key → `hive:`-namespace fix from `8130b95e` only matters in
+  the live ingest path where committee bonds are read from chain
+  state and reductions arrive keyed by bare account name from
+  `m.Account`. Devnet is the only place that loop closes.
+- **State-engine application**: `modules/state-processing/
+  pendulum_settlement.go` translates settlement payloads into ledger
+  writes. Cross-validation between what settlement produces and
+  what the state engine ingests is consensus-critical.
+
+## Pipeline to cover
+
+```
+                  cmd/feed-publisher                      Hive L1
+                          |                                  |
+                          v                                  v
+              broadcast feed_publish ops  --->  HAF stream ingests
+                                                            |
+                                                            v
+                                          state_engine.processFeedPublish
+                                                            |
+                                                            v
+                              incentive-pendulum/oracle (FeedTracker,
+                                  Window, MovingAvg, Geometry)
+                                                            |
+              committee bonds ----+        +--- pendulum.Quote / Split
+              (read from chain)   |        |    StabilizerMultiplier
+                                  v        v
+                          incentive-pendulum/settlement
+                        (compose.go, calculator.go, payload.go)
+                                                            |
+                                                            v
+                                 state-processing/pendulum_settlement
+                                       (apply payloads to ledger)
+                                                            |
+                                                            v
+                              ledger / committee bonds updated
+                                                            |
+                                                            v
+                          (next epoch) ApplyRewardReductionsToBonds
+                          drains slashed bonds further
+```
+
+Each arrow is a place an E2E test can plant an observable check.
+
+## Phase boundaries and milestones
+
+Test work is sized to roughly one milestone per session-day. Each
+milestone produces one focused devnet test plus whatever helper
+plumbing it needs.
+
+### M1 — Infrastructure bootstrap (1-2 days)
+
+Before any pendulum test can land, we need:
+
+- **Confirm feed-publisher inside devnet docker-compose.** It's
+  built by the Makefile (`cmd/feed-publisher`); need to verify
+  `tests/devnet/docker-compose.yml` or the generated nodes-override
+  starts it. If not, add it as a sidecar service so feeds flow
+  during tests.
+- **Settlement-result reader helper.** Devnet-side accessor that
+  reads the last N settlement payloads from a node's mongo
+  (collection TBD — likely `pendulum_settlements` based on
+  `modules/db/vsc/pendulum_settlements/` schema).
+- **Committee-bond reader helper.** Same pattern, reading the
+  per-account bond ledger at a given block height. Used by both
+  the happy-path test and the slashing test.
+- **Pendulum-aware test config.** Variant of `tssTestConfig()` that
+  also enables shorter pendulum settlement intervals and a fast
+  feed-publisher tick.
+
+Deliverable: helpers in a new file like `pendulum_helpers_test.go`,
+no test functions yet. Verified by spinning up the devnet and
+hand-checking the readers return non-empty data.
+
+### M2 — TestPendulumFeedPropagation (1-2 days)
+
+Cheapest pendulum-only test. Proves the feed-publish path is wired
+correctly end-to-end across every node.
+
+- Spin up devnet. Wait for genesis + first running election.
+- Wait until the feed-publisher has broadcast N feeds (verifiable
+  from L1 block contents via existing Hive helpers).
+- For each node, read the oracle DB / FeedTracker state.
+- Assert: every node has the same number of stored feed
+  observations, with the same price values per L1 block height.
+
+This is the pendulum equivalent of `TestBlsProofOfPossessionPropagation`:
+prove the L1 → ingest → store path round-trips identically per node.
+
+### M3 — TestPendulumSettlementHappyPath (2-3 days)
+
+The flagship test. Drives a full settlement cycle and verifies the
+output landed on every node deterministically.
+
+- Spin up devnet with enough nodes for a real committee (5+).
+- Let feeds run for at least one full pendulum settlement window
+  (Q: how long is that on devnet — what's the settlement interval
+  in `tssTestConfig`'s pendulum overrides?).
+- Wait for a settlement payload to land (epoch boundary in
+  pendulum_settlement.go).
+- For each node:
+    - Read the settlement payload from `pendulum_settlements`.
+    - Assert the payload byte-matches across nodes.
+    - Read committee bonds before/after settlement.
+    - Assert bond deltas match the settlement payload's
+      distributions to within rounding.
+- Sanity sweep: no node logged "settlement validation failed" or
+  "pendulum compose drift" patterns.
+
+### M4 — TestPendulumSlashingReductionApplied (2-3 days)
+
+The test that actually exercises the bare-key → `hive:`-namespace
+fix from `8130b95e`. Without slashing evidence in the oracle
+window, reductions never compute; this test makes that loop close.
+
+- Spin up devnet, let it settle one normal epoch as a baseline.
+- Stop one non-genesis node (`d.StopNode`) for a full window's
+  worth of feeds so it accumulates `OracleEvidence` of missed
+  attestations.
+- Restart the node.
+- Wait for the next settlement.
+- Read the settlement payload's `RewardReductionApplied` section.
+- Assert the stopped node appears with `Bps > 0`.
+- Read the node's committee bond before and after.
+- Assert the bond was reduced by `floor(orig * Bps / 10000)` (matches
+  the `MulDivFloorI64` formula in calculator.go).
+
+**Critical:** under the bug (`out[acc]` vs `out["hive:"+acc]`),
+`orig` was always 0 so this assertion would fail with `eff == orig`
+(no reduction applied) — exactly the regression signal.
+
+### M5 — TestPendulumStabilizerEngages (1-2 days, optional)
+
+Drives the oracle into a state where the stabilizer (m(s,r)) caps
+or pushes the fee. Less consensus-critical than M3/M4 but proves
+the §5 logic from the PDF works end-to-end. Defer if M1-M4 already
+took a week.
+
+## Out of scope for this workstream
+
+- The "Not implemented" entries in [`README.md`](README.md):
+  streaming swaps (§4/§12), redirect execution (§9), stabilizer
+  surplus settlement (§9/§12). Devnet tests cannot precede the
+  implementation.
+- Table 1 dollar-scenario reproduction. That's a deterministic
+  numeric regression — pure unit test territory, no devnet value.
+- Float vs fixed-point money rework (called out in README as a TODO).
+  Devnet tests should assume float consensus money for now and
+  follow the implementation if it changes.
+- Performance / throughput characterization. Out of scope for
+  correctness tests.
+
+## Open questions for the workstream owner
+
+**Q1 — feed-publisher topology.** Does devnet's docker-compose
+already include a feed-publisher sidecar, or does test code need
+to start one? Affects M1 sizing significantly.
+
+**Q2 — settlement interval on devnet.** What's the smallest sane
+pendulum settlement interval that still produces meaningful
+observation windows in test runtime? Need a `SysConfigOverrides`
+knob analogous to `RotateInterval` / `SignInterval` for TSS, scaled
+down from mainnet defaults.
+
+**Q3 — settlement collection name.** Confirm `pendulum_settlements`
+is the right collection on each node's mongo; if not, what is.
+
+**Q4 — committee bond storage location.** Bonds are referenced via
+`ReadCommitteeBonds` in calculator.go — where do they live on
+chain? Per-account ledger entries? A dedicated collection? This
+needs a code read before M1 can ship the bond reader helper.
+
+**Q5 — multi-version compat.** Should M3 also run as a multi-version
+test (some nodes on old code, some new), like the existing
+`TestTSSMultiVersion`? Probably yes long-term but adds 1-2 days
+per test — defer unless we expect a network with pendulum behind a
+hardfork gate.
+
+## Calibration
+
+These tests must match the operational shape of
+`tests/devnet/bls_pop_test.go` and `tests/devnet/review2_keystore_test.go`:
+
+- Skip on `testing.Short()`.
+- Use `startDevnet*` helpers, never inline lifecycle.
+- Per-node assertions surface as `t.Run` sub-tests so a single
+  failing node doesn't mask the others.
+- Log substrings (warnings, validation failures) get a final sweep
+  with `d.Logs` to catch class-of-bug failures even when the
+  numeric assertions happen to align.
+
+## Effort budget
+
+| Milestone | Days | Cumulative |
+|---|---|---|
+| M1 helpers + infra | 1-2 | 1-2 |
+| M2 FeedPropagation | 1-2 | 2-4 |
+| M3 SettlementHappyPath | 2-3 | 4-7 |
+| M4 SlashingReduction | 2-3 | 6-10 |
+| M5 StabilizerEngages | 1-2 (optional) | 7-12 |
+
+Total: **6-10 days** for core (M1-M4), **7-12 days** with M5.
+
+Devnet runtime per test is non-trivial (~10-30min each), so CI
+gating should be opt-in (workflow_dispatch + nightly). Each test
+runs under `go test -v -run ... -timeout 30m ./tests/devnet/`
+locally.

--- a/tests/devnet/bls_pop_test.go
+++ b/tests/devnet/bls_pop_test.go
@@ -115,22 +115,34 @@ func assertAllWitnessesHaveValidBlsPoP(t *testing.T, mongoURI, dbName string, wa
 
 	coll := client.Database(dbName).Collection("witnesses")
 
-	// `enabled:true` is the live announce. Drop disabled rows so an old
-	// pre-PoP record left over from a previous test reuse doesn't trip us.
+	// The `witnesses` collection is append-style: one row per announce, keyed by
+	// (account, height). A witness that re-announces (e.g. property change)
+	// leaves multiple `enabled:true` rows. We only care about the *latest*
+	// announce per account — that's the one the state engine's
+	// verifyAnnouncedBlsPoP ran on most recently and the one downstream
+	// consumers (elections, BLS circuit) read.
 	cursor, err := coll.Find(ctx, bson.M{"enabled": true},
-		options.Find().SetSort(bson.M{"account": 1}))
+		options.Find().SetSort(bson.D{
+			{Key: "account", Value: 1},
+			{Key: "height", Value: -1},
+		}))
 	if err != nil {
 		t.Fatalf("find witnesses in %s: %v", dbName, err)
 	}
 	defer cursor.Close(ctx)
 
-	seen := 0
+	checkedAccounts := make(map[string]struct{}, wantWitnesses)
 	for cursor.Next(ctx) {
 		var w witnesses.Witness
 		if err := cursor.Decode(&w); err != nil {
 			t.Fatalf("decode witness in %s: %v", dbName, err)
 		}
-		seen++
+		// height-desc sort means the first row we see per account is the
+		// latest announce; skip older rows for the same account.
+		if _, already := checkedAccounts[w.Account]; already {
+			continue
+		}
+		checkedAccounts[w.Account] = struct{}{}
 
 		// Find the DID-BLS / consensus key — the exact one the state
 		// engine's verifyAnnouncedBlsPoP looks up.
@@ -160,14 +172,15 @@ func assertAllWitnessesHaveValidBlsPoP(t *testing.T, mongoURI, dbName string, wa
 				dbName, w.Account, err)
 			continue
 		}
-		t.Logf("%s: witness %q has valid PoP (key=%s)", dbName, w.Account, truncateMid(string(blsKey.Key), 16))
+		t.Logf("%s: witness %q has valid PoP at height %d (key=%s)",
+			dbName, w.Account, w.Height, truncateMid(string(blsKey.Key), 16))
 	}
 	if err := cursor.Err(); err != nil {
 		t.Fatalf("cursor err in %s: %v", dbName, err)
 	}
 
-	if seen != wantWitnesses {
-		t.Errorf("%s: expected %d enabled witnesses, found %d", dbName, wantWitnesses, seen)
+	if got := len(checkedAccounts); got != wantWitnesses {
+		t.Errorf("%s: expected %d distinct enabled witness accounts, found %d", dbName, wantWitnesses, got)
 	}
 }
 

--- a/tests/devnet/bls_pop_test.go
+++ b/tests/devnet/bls_pop_test.go
@@ -1,0 +1,248 @@
+package devnet
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"vsc-node/lib/dids"
+	"vsc-node/modules/db/vsc/witnesses"
+
+	ethBls "github.com/protolambda/bls12-381-util"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// TestBlsProofOfPossessionPropagation verifies the end-to-end fix for the
+// rogue-key aggregate-forgery vulnerability described in the audit's B1
+// finding (deep audit CRIT) and closed by commit d47f87e5
+// ("proof of posession system in BLS announce").
+//
+// The fix has three moving pieces:
+//
+//  1. The announce payload (modules/announcements/announcements.go) now
+//     emits a BLS proof-of-possession (PoP) — a signature over a fixed
+//     domain tag concatenated with the announced BLS pubkey and the
+//     announcing Hive account.
+//  2. The witness schema (modules/db/vsc/witnesses/schema.go) carries a
+//     `pop` field on every consensus BLS key.
+//  3. The state engine (modules/state-processing/state_engine.go) calls
+//     dids.VerifyBlsPoP on ingest. Today this is warn-only — a missing or
+//     invalid PoP is logged but the witness is still stored — so the
+//     rollout can complete without dropping pre-PoP witnesses. A later
+//     change flips this to strict reject.
+//
+// The unit tests in lib/dids/bls_test.go already cover the crypto layer
+// (round-trip, wrong-account, wrong-key, malformed). This test fills the
+// integration gap: do real announcements published to Hive flow through
+// the announcement→ingest→Mongo path with a *valid* PoP attached to every
+// witness, and does dids.VerifyBlsPoP confirm them?
+//
+// Run with:
+//
+//	go test -v -run TestBlsProofOfPossessionPropagation -timeout 20m ./tests/devnet/
+func TestBlsProofOfPossessionPropagation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	cfg := tssTestConfig()
+	d, ctx := startDevnet(t, cfg, 15*time.Minute)
+
+	// Wait for keygen — by the time keygen completes, every witness has
+	// published its v2 announce (the one bearing the PoP) and the state
+	// engine has had ample time to ingest it. If a witness has not
+	// announced, keygen can't pick it.
+	t.Log("waiting for keygen to gate on full witness announce ingestion...")
+	keygen := waitForCommitment(t, d.MongoURI(), "keygen", 15*time.Minute)
+	t.Logf("keygen ready at block %d (epoch %d), all %d witnesses have announced",
+		keygen.BlockHeight, keygen.Epoch, cfg.Nodes)
+
+	// Verify each node's view of the witnesses collection independently.
+	// We don't rely on cross-node agreement — the ingest is deterministic,
+	// but we want a per-node failure to surface as a per-node assertion
+	// rather than be masked by the others.
+	for n := 1; n <= cfg.Nodes; n++ {
+		dbName := fmt.Sprintf("magi-%d", n)
+		t.Run(dbName, func(t *testing.T) {
+			assertAllWitnessesHaveValidBlsPoP(t, d.MongoURI(), dbName, cfg.Nodes)
+		})
+	}
+
+	// The state engine's verifyAnnouncedBlsPoP only WARNs on failure
+	// during rollout — it doesn't reject. Confirm no node has actually
+	// logged the warning, i.e. every announce carried a valid PoP. (If
+	// this ever starts failing, it means an announce flowed in without a
+	// valid PoP — investigate before flipping the rollout to strict.)
+	t.Run("no_pop_warnings_in_node_logs", func(t *testing.T) {
+		// Use a stable substring from the state_engine.go warn line.
+		const warnSubstr = "witness announce: BLS proof-of-possession check failed"
+		for n := 1; n <= cfg.Nodes; n++ {
+			logs, err := d.Logs(ctx, fmt.Sprintf("magi-%d", n))
+			if err != nil {
+				t.Logf("warning: could not read magi-%d logs: %v", n, err)
+				continue
+			}
+			if strings.Contains(logs, warnSubstr) {
+				// Surface the surrounding context so we can see WHY it
+				// failed without dumping the entire log buffer.
+				for _, line := range strings.Split(logs, "\n") {
+					if strings.Contains(line, warnSubstr) {
+						t.Errorf("magi-%d logged PoP failure: %s", n, line)
+					}
+				}
+			}
+		}
+	})
+}
+
+// assertAllWitnessesHaveValidBlsPoP queries the named node's witnesses
+// collection, requires exactly `wantWitnesses` records, and for each one
+// extracts the DID-BLS / consensus key and runs the same VerifyBlsPoP
+// check the state engine runs at ingest time. This catches drift between
+// the announcer (lib/dids GenerateBlsPoP) and the verifier (state_engine
+// + lib/dids VerifyBlsPoP), and confirms the on-disk schema field round-
+// trips through BSON intact.
+func assertAllWitnessesHaveValidBlsPoP(t *testing.T, mongoURI, dbName string, wantWitnesses int) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, _ := connectMongo(t, mongoURI)
+	defer client.Disconnect(ctx)
+
+	coll := client.Database(dbName).Collection("witnesses")
+
+	// `enabled:true` is the live announce. Drop disabled rows so an old
+	// pre-PoP record left over from a previous test reuse doesn't trip us.
+	cursor, err := coll.Find(ctx, bson.M{"enabled": true},
+		options.Find().SetSort(bson.M{"account": 1}))
+	if err != nil {
+		t.Fatalf("find witnesses in %s: %v", dbName, err)
+	}
+	defer cursor.Close(ctx)
+
+	seen := 0
+	for cursor.Next(ctx) {
+		var w witnesses.Witness
+		if err := cursor.Decode(&w); err != nil {
+			t.Fatalf("decode witness in %s: %v", dbName, err)
+		}
+		seen++
+
+		// Find the DID-BLS / consensus key — the exact one the state
+		// engine's verifyAnnouncedBlsPoP looks up.
+		var blsKey *witnesses.PostingJsonKeys
+		for i := range w.DidKeys {
+			k := &w.DidKeys[i]
+			if k.CryptoType == "DID-BLS" && k.Type == "consensus" {
+				blsKey = k
+				break
+			}
+		}
+		if blsKey == nil {
+			t.Errorf("%s: witness %q has no DID-BLS/consensus key in did_keys",
+				dbName, w.Account)
+			continue
+		}
+
+		// Three independent sub-checks so a failure points cleanly at
+		// the layer that broke (announce / schema / verify).
+		if blsKey.PoP == "" {
+			t.Errorf("%s: witness %q has empty pop field (announce or schema regression)",
+				dbName, w.Account)
+			continue
+		}
+		if err := dids.VerifyBlsPoP(dids.BlsDID(blsKey.Key), w.Account, blsKey.PoP); err != nil {
+			t.Errorf("%s: witness %q PoP fails VerifyBlsPoP: %v (account binding, key, or domain tag drift)",
+				dbName, w.Account, err)
+			continue
+		}
+		t.Logf("%s: witness %q has valid PoP (key=%s)", dbName, w.Account, truncateMid(string(blsKey.Key), 16))
+	}
+	if err := cursor.Err(); err != nil {
+		t.Fatalf("cursor err in %s: %v", dbName, err)
+	}
+
+	if seen != wantWitnesses {
+		t.Errorf("%s: expected %d enabled witnesses, found %d", dbName, wantWitnesses, seen)
+	}
+}
+
+// truncateMid keeps the first and last few chars of a long DID string for
+// readable log output; the full DID is ~75 chars of base64 noise.
+func truncateMid(s string, keep int) string {
+	if len(s) <= keep*2+3 {
+		return s
+	}
+	return s[:keep] + "..." + s[len(s)-keep:]
+}
+
+// TestBlsPoPRejectsRogueKeyAnnounce documents the property the warn-only
+// rollout is preparing for: an announce that carries a PoP signed by the
+// wrong key (the rogue-key attack precondition) MUST fail
+// dids.VerifyBlsPoP, so when the rollout flips to strict mode the rogue
+// announce will be rejected by the state engine.
+//
+// This is the unit-level equivalent of TestBlsPoPWrongKeyFails in
+// lib/dids/bls_test.go, but framed against the ingest-path verifier so a
+// future reader of the devnet test directory can find the
+// rogue-key-rejection guarantee at the layer where it'll matter on
+// mainnet.
+//
+// Once the warn-only rollout flips to strict, the body should also assert
+// (via a devnet harness change) that a witness ingested with an invalid
+// PoP is NOT written to the witnesses collection. Until then, this stays
+// at the crypto-layer assertion only.
+func TestBlsPoPRejectsRogueKeyAnnounce(t *testing.T) {
+	did1, priv1 := freshBlsKey(t, "rogue_key_seed_1_aaaaaaaa")
+	_, priv2 := freshBlsKey(t, "rogue_key_seed_2_bbbbbbbb")
+
+	// Real PoP from key1 verifies for did1/alice — sanity check.
+	pop1, err := dids.GenerateBlsPoP(priv1, "alice")
+	if err != nil {
+		t.Fatalf("generate pop1: %v", err)
+	}
+	if err := dids.VerifyBlsPoP(did1, "alice", pop1); err != nil {
+		t.Fatalf("sanity: own PoP must verify, got err: %v", err)
+	}
+
+	// PoP from key2 presented under did1 (the rogue-key precondition) MUST fail.
+	pop2, err := dids.GenerateBlsPoP(priv2, "alice")
+	if err != nil {
+		t.Fatalf("generate pop2: %v", err)
+	}
+	if err := dids.VerifyBlsPoP(did1, "alice", pop2); err == nil {
+		t.Fatal("verifier accepted a PoP signed by the wrong key — rogue-key defense is broken")
+	}
+
+	// Same key, wrong account — PoP must fail (account binding).
+	if err := dids.VerifyBlsPoP(did1, "mallory", pop1); err == nil {
+		t.Fatal("verifier accepted a PoP under a different account — account binding is broken")
+	}
+}
+
+// freshBlsKey deterministically derives a BLS keypair from a short
+// human-readable seed (padded to 32 bytes) and returns the matching DID.
+// Mirrors the helper in lib/dids/bls_test.go so this devnet test can
+// stand alone without the test_utils import cycle.
+func freshBlsKey(t *testing.T, seedStr string) (dids.BlsDID, *dids.BlsPrivKey) {
+	t.Helper()
+	var seed [32]byte
+	copy(seed[:], []byte(seedStr))
+
+	privKey := dids.BlsPrivKey{}
+	privKey.Deserialize(&seed)
+
+	pubKey, err := ethBls.SkToPk(&privKey)
+	if err != nil {
+		t.Fatalf("derive pubkey from seed %q: %v", seedStr, err)
+	}
+	did, err := dids.NewBlsDID(pubKey)
+	if err != nil {
+		t.Fatalf("derive DID from seed %q: %v", seedStr, err)
+	}
+	return did, &privKey
+}

--- a/tests/devnet/critical_audit_pending_cursor_test.go
+++ b/tests/devnet/critical_audit_pending_cursor_test.go
@@ -1,0 +1,279 @@
+package devnet
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// TestCriticalAuditPendingActionsCursor verifies the fix from
+// 8130b95e "pendulum critical-audit phase 1": the cursor loop in
+// actionsDb.GetPendingActionsByEpoch.
+//
+// Bug: the prior form used `if cursor.Next(...)` so the function
+// returned at most ONE pending action per call:
+//
+//	for cursor.Next(...) {   // <-- was: if cursor.Next(...)
+//	    record := ActionRecord{}
+//	    cursor.Decode(&record)
+//	    actionRecords = append(actionRecords, record)
+//	}
+//
+// The caller (state_engine.UpdateBalances) processes the slice in
+// one slot: it adds every entry to `completeIds`, writes one
+// LedgerRecord per entry with id="<actionId>#out" and
+// BlockHeight=endBlock, then ExecuteCompletes the lot. Under the
+// bug, only one of N pending unstakes for the same epoch could be
+// released per slot — the rest had to wait for subsequent slots,
+// where the same single-record query would dequeue another. That
+// staggered the release of unstakes that should have been atomic
+// at the epoch boundary, with two visible consequences:
+//
+//  1. The `#out` LedgerRecords for sibling unstakes land at
+//     different BlockHeights (different slots) rather than the same
+//     slot's `endBlock`.
+//  2. In the worst case the bug interacts with epoch transitions —
+//     if a new election lands between two slot-releases, the second
+//     unstake is now keyed off a different election epoch.
+//
+// This test detects (1): if both sibling unstakes are submitted
+// before the same election and queued for the same release epoch,
+// their `#out` ledger records must land at IDENTICAL BlockHeights
+// post-fix. Under the bug they'd differ by at least one slot.
+//
+// Test flow:
+//
+//  1. Spin up devnet.
+//  2. Wait until at least one running election has landed (epoch >= 1).
+//  3. Submit two consensus_unstake ops for the same target account
+//     in quick succession (both should be processed under the same
+//     election, so both get `data.epoch = currentEpoch + 5`).
+//  4. Wait for both to appear in ledger_actions with status="pending"
+//     and capture their action IDs.
+//  5. Verify both share the same `data.epoch` — otherwise the test
+//     setup didn't actually queue siblings; retry would be needed.
+//  6. Wait for the release boundary plus generous slack.
+//  7. Verify both actions have status="complete".
+//  8. Look up each action's `#out` LedgerRecord in the `ledger`
+//     collection and assert they have the same BlockHeight.
+//
+// If step 8 sees different BlockHeights, the fix is not in effect.
+func TestCriticalAuditPendingActionsCursor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	cfg := tssTestConfig()
+	d, ctx := startDevnetNoKey(t, cfg, 20*time.Minute)
+
+	// Wait until every node has ingested a running election. The unstake
+	// guard from PR #181 (#96) rejects pre-election unstakes, and we
+	// want a clean post-election baseline anyway.
+	t.Log("waiting for first running election (epoch >= 1) on every node...")
+	for n := 1; n <= cfg.Nodes; n++ {
+		nodeCtx, cancel := context.WithTimeout(ctx, 8*time.Minute)
+		if err := d.waitForElectionEpoch(nodeCtx, n, 1, 8*time.Minute); err != nil {
+			cancel()
+			t.Fatalf("magi-%d never ingested epoch >= 1: %v", n, err)
+		}
+		cancel()
+	}
+
+	// Pick a non-genesis witness to unstake from.
+	witnessIdx := 1
+	if cfg.GenesisNode == 1 {
+		witnessIdx = 2
+	}
+	targetAccount := fmt.Sprintf("%s%d", cfg.WitnessPrefix, witnessIdx)
+	hiveTarget := "hive:" + targetAccount
+
+	// Submit two sibling unstakes in quick succession. Hive block
+	// production is ~3s so both should land in the same L1 block or
+	// adjacent ones — well within the same election epoch.
+	t.Logf("submitting unstake A for %s", targetAccount)
+	if err := d.Unstake(ctx, targetAccount, "1.000"); err != nil {
+		t.Fatalf("broadcasting unstake A: %v", err)
+	}
+	time.Sleep(500 * time.Millisecond)
+	t.Logf("submitting unstake B for %s", targetAccount)
+	if err := d.Unstake(ctx, targetAccount, "1.000"); err != nil {
+		t.Fatalf("broadcasting unstake B: %v", err)
+	}
+
+	// Wait until both unstakes have landed as pending in ledger_actions
+	// on magi-1, and capture their {id, releaseEpoch} pairs.
+	t.Log("waiting for both unstakes to land as pending in ledger_actions...")
+	siblings, err := waitForTwoPendingUnstakes(ctx, d, 1, hiveTarget, 3*time.Minute)
+	if err != nil {
+		t.Fatalf("waiting for sibling unstakes: %v", err)
+	}
+	t.Logf("captured sibling action ids: %s (epoch %d) and %s (epoch %d)",
+		siblings[0].Id, siblings[0].ReleaseEpoch,
+		siblings[1].Id, siblings[1].ReleaseEpoch)
+
+	// Sanity: both must release on the same epoch boundary. Otherwise
+	// the test setup didn't actually queue siblings (e.g. an election
+	// landed between the two submissions), and the bug-detection
+	// assertion below wouldn't be meaningful.
+	if siblings[0].ReleaseEpoch != siblings[1].ReleaseEpoch {
+		t.Skipf("sibling unstakes ended up on different release epochs (%d vs %d); election landed between submissions — retry would be needed",
+			siblings[0].ReleaseEpoch, siblings[1].ReleaseEpoch)
+	}
+
+	releaseEpoch := siblings[0].ReleaseEpoch
+	t.Logf("both siblings queued for release at epoch %d", releaseEpoch)
+
+	// Wait until magi-1 has ingested an election with epoch >= releaseEpoch,
+	// then give state-engine a few extra slots to actually process the
+	// release. UpdateBalances runs every slot, so 4 slots is generous.
+	t.Logf("waiting for release epoch %d on magi-1...", releaseEpoch)
+	if err := d.waitForElectionEpoch(ctx, 1, releaseEpoch, 12*time.Minute); err != nil {
+		t.Fatalf("magi-1 never ingested release epoch %d: %v", releaseEpoch, err)
+	}
+	time.Sleep(45 * time.Second)
+
+	// Both action records should now be status="complete" on every node.
+	for n := 1; n <= cfg.Nodes; n++ {
+		for _, sib := range siblings {
+			rec, err := readActionById(ctx, d, n, sib.Id)
+			if err != nil {
+				t.Errorf("magi-%d: failed reading action %s: %v", n, sib.Id, err)
+				continue
+			}
+			if rec.Status != "complete" {
+				t.Errorf("magi-%d: action %s status=%q (expected complete) — release may have been deferred", n, sib.Id, rec.Status)
+			}
+		}
+	}
+
+	// Core fix assertion: both #out ledger records must share the same
+	// BlockHeight. Under the bug, the cursor returned only the first
+	// action per slot, so the second sibling's #out record would have
+	// been written at a later endBlock (next slot).
+	for n := 1; n <= cfg.Nodes; n++ {
+		bhA, errA := readOutLedgerBlockHeight(ctx, d, n, siblings[0].Id)
+		bhB, errB := readOutLedgerBlockHeight(ctx, d, n, siblings[1].Id)
+		if errA != nil || errB != nil {
+			t.Errorf("magi-%d: failed reading #out records (errA=%v errB=%v)", n, errA, errB)
+			continue
+		}
+		if bhA != bhB {
+			t.Errorf("magi-%d: sibling unstakes released at different BlockHeights (A=%d, B=%d) — cursor-loop fix not in effect",
+				n, bhA, bhB)
+		} else {
+			t.Logf("magi-%d: both siblings released at BlockHeight %d (atomic — fix in effect)", n, bhA)
+		}
+	}
+}
+
+type pendingUnstakeRecord struct {
+	Id           string
+	ReleaseEpoch uint64
+}
+
+// waitForTwoPendingUnstakes polls magi-N's ledger_actions for two
+// status=pending records of type unstake matching the target hive
+// account. Returns when at least 2 are found (the most recent two by
+// block_height ascending).
+func waitForTwoPendingUnstakes(ctx context.Context, d *Devnet, node int, hiveTarget string, timeout time.Duration) ([]pendingUnstakeRecord, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		recs, err := findPendingUnstakes(ctx, d, node, hiveTarget)
+		if err == nil && len(recs) >= 2 {
+			return recs[:2], nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(3 * time.Second):
+		}
+	}
+	return nil, fmt.Errorf("timed out waiting for two pending unstakes on magi-%d for %s", node, hiveTarget)
+}
+
+func findPendingUnstakes(ctx context.Context, d *Devnet, node int, hiveTarget string) ([]pendingUnstakeRecord, error) {
+	client, err := d.mongoClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer client.Disconnect(ctx)
+
+	coll := client.Database(d.nodeDbName(node)).Collection("ledger_actions")
+	queries := []bson.M{
+		{"status": "pending", "type": bson.M{"$regex": "unstake"}, "to": hiveTarget},
+		{"status": "pending", "type": bson.M{"$regex": "unstake"}, "from": hiveTarget},
+		{"status": "pending", "type": bson.M{"$regex": "unstake"}, "data.from": hiveTarget},
+	}
+	seen := map[string]pendingUnstakeRecord{}
+	for _, q := range queries {
+		cur, err := coll.Find(ctx, q, options.Find().SetSort(bson.D{{Key: "block_height", Value: 1}}))
+		if err != nil {
+			return nil, err
+		}
+		for cur.Next(ctx) {
+			var raw struct {
+				Id   string `bson:"id"`
+				Data struct {
+					Epoch uint64 `bson:"epoch"`
+				} `bson:"data"`
+			}
+			if err := cur.Decode(&raw); err != nil {
+				cur.Close(ctx)
+				return nil, err
+			}
+			seen[raw.Id] = pendingUnstakeRecord{Id: raw.Id, ReleaseEpoch: raw.Data.Epoch}
+		}
+		cur.Close(ctx)
+	}
+	out := make([]pendingUnstakeRecord, 0, len(seen))
+	for _, v := range seen {
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+type actionStatus struct {
+	Id     string `bson:"id"`
+	Status string `bson:"status"`
+}
+
+func readActionById(ctx context.Context, d *Devnet, node int, id string) (actionStatus, error) {
+	client, err := d.mongoClient(ctx)
+	if err != nil {
+		return actionStatus{}, err
+	}
+	defer client.Disconnect(ctx)
+
+	coll := client.Database(d.nodeDbName(node)).Collection("ledger_actions")
+	var rec actionStatus
+	if err := coll.FindOne(ctx, bson.M{"id": id}).Decode(&rec); err != nil {
+		return actionStatus{}, err
+	}
+	return rec, nil
+}
+
+// readOutLedgerBlockHeight finds the LedgerRecord written when a
+// consensus_unstake action releases — its id is "<actionId>#out". The
+// BlockHeight on that record is the slot endBlock at which the
+// release was processed.
+func readOutLedgerBlockHeight(ctx context.Context, d *Devnet, node int, actionId string) (uint64, error) {
+	client, err := d.mongoClient(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer client.Disconnect(ctx)
+
+	coll := client.Database(d.nodeDbName(node)).Collection("ledger")
+	var raw struct {
+		Id          string `bson:"id"`
+		BlockHeight uint64 `bson:"block_height"`
+	}
+	if err := coll.FindOne(ctx, bson.M{"id": actionId + "#out"}).Decode(&raw); err != nil {
+		return 0, fmt.Errorf("magi-%d: ledger record %s#out not found: %w", node, actionId, err)
+	}
+	return raw.BlockHeight, nil
+}

--- a/tests/devnet/election_consensus_test.go
+++ b/tests/devnet/election_consensus_test.go
@@ -1,0 +1,263 @@
+package devnet
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// TestElectionConsensusDeterminism asserts that every honest node in a
+// running devnet records byte-identical election bytes (the BLS-attested
+// `data` field plus the canonical weight/member arrays) for the same
+// election epoch.
+//
+// This is a baseline consensus-determinism check for the election
+// proposer path. It does not exercise any single fix: it catches the
+// *class* of bug where two honest nodes compute divergent election
+// results from the same witness set. Known instances of that class:
+//
+//   - PR #181 commit 6b0c01a4 (review4 HIGH #6): float64 arithmetic in
+//     `distWeight = math.Ceil((1 + opt/2) / n)` could round differently
+//     across CPU architectures / FP units. The fix promotes the math to
+//     integer. Note: the bug is *dormant* in the current tree because
+//     REQUIRED_ELECTION_MEMBERS is empty (see modules/election-proposer/
+//     election-proposer.go:222), so this test cannot prove the fix
+//     directly — but it WILL catch any reintroduction of float math (or
+//     any other non-determinism) once required members are populated.
+//
+//   - PR #181 commit 6b0c01a4 (review4 HIGH #40): map iteration order in
+//     `scoreMap()` building the `bannedNodes` slice. The method has no
+//     callers in the current tree, so the same dormancy caveat applies.
+//
+//   - Future variants where any non-deterministic operation (map iter,
+//     time.Now, rand, FP, BSON-vs-canonical-bytes drift) leaks into the
+//     election proposal path.
+//
+// What the test does:
+//
+//  1. Spins up a 5-node devnet with a fast election interval.
+//  2. Waits until every node has ingested at least one post-genesis
+//     election (epoch >= 1, produced by the running election-proposer
+//     rather than the one-shot genesis-elector binary).
+//  3. Reads each node's `elections` collection for the chosen epoch and
+//     compares the canonical fields byte-by-byte: `data` (the BLS-signed
+//     bytes), `weights`, `total_weight`, ordered `members`.
+//  4. Asserts no node logged an election-verification rejection or
+//     "election_result rejected" / "election cid mismatch" warning
+//     during the run.
+//
+// If this test ever fails, election consensus is broken — any divergence
+// in the `data` field means BLS signatures aggregated by different nodes
+// over different bytes, which would prevent the election from ever
+// landing in a finalised block.
+//
+// Run with:
+//
+//	go test -v -run TestElectionConsensusDeterminism -timeout 20m ./tests/devnet/
+func TestElectionConsensusDeterminism(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	cfg := tssTestConfig()
+	d, ctx := startDevnetNoKey(t, cfg, 15*time.Minute)
+
+	// Wait for every node to ingest at least one post-genesis election.
+	// Epoch 0 is the genesis election produced by the genesis-elector
+	// binary at devnet boot, which doesn't exercise the running
+	// election-proposer path — we want epoch >= 1.
+	const minEpoch = uint64(1)
+	t.Logf("waiting for every node to ingest at least one post-genesis election (epoch >= %d)...", minEpoch)
+	for n := 1; n <= cfg.Nodes; n++ {
+		nodeCtx, cancel := context.WithTimeout(ctx, 8*time.Minute)
+		if err := d.waitForElectionEpoch(nodeCtx, n, minEpoch, 8*time.Minute); err != nil {
+			cancel()
+			t.Fatalf("magi-%d never ingested epoch >= %d: %v", n, minEpoch, err)
+		}
+		cancel()
+	}
+
+	// Pick the lowest epoch present on every node. Higher epochs may not
+	// yet have propagated to all nodes evenly when this code runs; the
+	// lowest post-genesis epoch is the simplest cross-node comparison
+	// point that is guaranteed present everywhere.
+	epoch, err := lowestCommonElectionEpoch(ctx, d, cfg.Nodes, minEpoch)
+	if err != nil {
+		t.Fatalf("finding lowest common election epoch: %v", err)
+	}
+	t.Logf("comparing election bytes for epoch %d across %d nodes", epoch, cfg.Nodes)
+
+	// Fetch the canonical fields from every node for this epoch.
+	records := make([]canonicalElectionRecord, cfg.Nodes)
+	for n := 1; n <= cfg.Nodes; n++ {
+		rec, err := readCanonicalElection(ctx, d, n, epoch)
+		if err != nil {
+			t.Fatalf("reading election epoch %d from magi-%d: %v", epoch, n, err)
+		}
+		records[n-1] = rec
+	}
+
+	// Compare every node's record against magi-1. Any divergence is a
+	// consensus break — fail loudly and dump enough context to triage.
+	base := records[0]
+	for n := 2; n <= cfg.Nodes; n++ {
+		other := records[n-1]
+		if base.Data != other.Data {
+			t.Errorf("magi-%d election Data differs from magi-1 at epoch %d:\n  magi-1: %s\n  magi-%d: %s",
+				n, epoch, truncate(base.Data, 120), n, truncate(other.Data, 120))
+		}
+		if base.TotalWeight != other.TotalWeight {
+			t.Errorf("magi-%d total_weight=%d differs from magi-1 total_weight=%d at epoch %d",
+				n, other.TotalWeight, base.TotalWeight, epoch)
+		}
+		if !equalUint64s(base.Weights, other.Weights) {
+			t.Errorf("magi-%d weights differ from magi-1 at epoch %d:\n  magi-1: %v\n  magi-%d: %v",
+				n, epoch, base.Weights, n, other.Weights)
+		}
+		if !equalStrings(base.MemberAccounts, other.MemberAccounts) {
+			t.Errorf("magi-%d members differ from magi-1 at epoch %d:\n  magi-1: %v\n  magi-%d: %v",
+				n, epoch, base.MemberAccounts, n, other.MemberAccounts)
+		}
+	}
+
+	// Sanity: no node logged an election-verification rejection. If any
+	// node had rejected the proposal, the BLS aggregate would have come
+	// up short and the election would not have landed at all — so a
+	// successful read above already implies this. But surface log
+	// evidence too, in case future code paths log warnings without
+	// breaking the aggregate.
+	t.Run("no_election_rejection_warnings", func(t *testing.T) {
+		patterns := []string{
+			"election_result rejected",
+			"election cid mismatch",
+			"election verification failed",
+			"invalid election proposal",
+		}
+		for n := 1; n <= cfg.Nodes; n++ {
+			logs, err := d.Logs(ctx, fmt.Sprintf("magi-%d", n))
+			if err != nil {
+				t.Logf("warning: could not read magi-%d logs: %v", n, err)
+				continue
+			}
+			for _, pat := range patterns {
+				if strings.Contains(logs, pat) {
+					t.Errorf("magi-%d logs contain %q (election non-determinism leak?)", n, pat)
+				}
+			}
+		}
+	})
+}
+
+// canonicalElectionRecord is the subset of fields from a node's
+// `elections` collection that must be byte-identical across all honest
+// nodes for the same epoch.
+type canonicalElectionRecord struct {
+	Epoch          uint64
+	Data           string
+	TotalWeight    uint64
+	Weights        []uint64
+	MemberAccounts []string
+}
+
+// readCanonicalElection fetches the election record for `epoch` from the
+// named node and returns the canonical comparison fields. `members` is
+// stored as an array of {account, key} objects; we extract just the
+// `account` strings in their stored order (which IS the canonical order
+// the election proposer wrote them in).
+func readCanonicalElection(ctx context.Context, d *Devnet, node int, epoch uint64) (canonicalElectionRecord, error) {
+	client, err := d.mongoClient(ctx)
+	if err != nil {
+		return canonicalElectionRecord{}, err
+	}
+	defer client.Disconnect(ctx)
+
+	coll := client.Database(d.nodeDbName(node)).Collection("elections")
+	var raw struct {
+		Epoch       uint64   `bson:"epoch"`
+		Data        string   `bson:"data"`
+		TotalWeight uint64   `bson:"total_weight"`
+		Weights     []uint64 `bson:"weights"`
+		Members     []struct {
+			Account string `bson:"account"`
+		} `bson:"members"`
+	}
+	if err := coll.FindOne(ctx, bson.M{"epoch": epoch}).Decode(&raw); err != nil {
+		return canonicalElectionRecord{}, fmt.Errorf("finding election epoch %d on magi-%d: %w", epoch, node, err)
+	}
+	accounts := make([]string, len(raw.Members))
+	for i, m := range raw.Members {
+		accounts[i] = m.Account
+	}
+	return canonicalElectionRecord{
+		Epoch:          raw.Epoch,
+		Data:           raw.Data,
+		TotalWeight:    raw.TotalWeight,
+		Weights:        raw.Weights,
+		MemberAccounts: accounts,
+	}, nil
+}
+
+// lowestCommonElectionEpoch returns the lowest epoch >= minEpoch that
+// exists on every node. Used so we compare an election that is
+// guaranteed to be present everywhere rather than a high-water mark that
+// may not yet have propagated.
+func lowestCommonElectionEpoch(ctx context.Context, d *Devnet, nodes int, minEpoch uint64) (uint64, error) {
+	client, err := d.mongoClient(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer client.Disconnect(ctx)
+
+	for epoch := minEpoch; epoch < minEpoch+50; epoch++ {
+		present := 0
+		for n := 1; n <= nodes; n++ {
+			coll := client.Database(d.nodeDbName(n)).Collection("elections")
+			count, err := coll.CountDocuments(ctx, bson.M{"epoch": epoch})
+			if err != nil {
+				return 0, fmt.Errorf("counting epoch %d on magi-%d: %w", epoch, n, err)
+			}
+			if count > 0 {
+				present++
+			}
+		}
+		if present == nodes {
+			return epoch, nil
+		}
+	}
+	return 0, fmt.Errorf("no epoch in [%d, %d) present on all %d nodes", minEpoch, minEpoch+50, nodes)
+}
+
+func equalUint64s(a, b []uint64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/tests/devnet/pendulum_feed_propagation_test.go
+++ b/tests/devnet/pendulum_feed_propagation_test.go
@@ -1,0 +1,140 @@
+package devnet
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPendulumFeedPropagation is M2 of the pendulum E2E workstream
+// (docs/pendulum/devnet-test-scope.md). The cheapest pendulum test
+// in the series and the foundation M3/M4 build on.
+//
+// What it proves:
+//
+//  1. The feed-publisher sidecar (started by Devnet.Start alongside
+//     the magi nodes) is actually broadcasting `feed_publish` ops to
+//     the Hive L1 chain.
+//  2. Every magi node ingests those L1 blocks into its hive_blocks
+//     collection identically — i.e. the L1-stream observability
+//     under pendulum is consistent across all nodes.
+//
+// What it does NOT prove:
+//
+//   - That the oracle FeedTracker on each node converges to the
+//     same in-memory state. The tracker is in-memory after commit
+//     fe70b3f9 ("simplified price snapshots to just the current
+//     data") — there is no per-node oracle collection on this
+//     branch to read. The settlement-record check in M3 closes that
+//     loop indirectly: identical settlement bytes across nodes can
+//     only happen if every node's FeedTracker converged.
+//   - That settlement was actually produced. That's M3's job.
+//
+// Failure modes this catches:
+//
+//   - feed-publisher misconfigured (no feeds broadcast).
+//   - feed-publisher running but some nodes lag the L1 stream
+//     (uneven counts across nodes).
+//   - Feed payload ops not appearing in hive_blocks under the
+//     expected JSON key path (would surface as zero counts despite
+//     L1 actually carrying them — the hive_blocks regex sweep would
+//     return 0 while the feed-publisher log shows broadcasts).
+//
+// Run with:
+//
+//	go test -v -run TestPendulumFeedPropagation -timeout 15m ./tests/devnet/
+func TestPendulumFeedPropagation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	cfg := pendulumTestConfig()
+	d, ctx := startDevnetNoKey(t, cfg, 15*time.Minute)
+
+	// The feed-publisher's default tick interval is 240s (see
+	// cmd/feed-publisher/main.go header comment). Wait long enough
+	// that we expect to see at least 2-3 publishes if it's healthy.
+	// 8 minutes is generous and surfaces "publisher silently stuck"
+	// scenarios within the test timeout.
+	const waitDuration = 8 * time.Minute
+	t.Logf("waiting %s for feed-publisher to broadcast feed_publish ops to L1...", waitDuration)
+	select {
+	case <-ctx.Done():
+		t.Fatalf("ctx cancelled while waiting for feeds: %v", ctx.Err())
+	case <-time.After(waitDuration):
+	}
+
+	// Pick the L1 block range to count over. We scan from block 10
+	// (skip the devnet boot setup blocks) to "current head as seen
+	// by magi-1" — bounded so a flaky node lagging the stream
+	// surfaces clearly via differing counts.
+	headBlock, err := d.getLastProcessedBlock(ctx, 1)
+	if err != nil {
+		t.Fatalf("reading magi-1 head block: %v", err)
+	}
+	if headBlock < 20 {
+		t.Fatalf("magi-1 head block %d is suspiciously low — devnet didn't progress?", headBlock)
+	}
+	const fromBlock = uint64(10)
+	toBlock := headBlock
+	t.Logf("counting feed_publish ops across hive_blocks in [%d, %d]...", fromBlock, toBlock)
+
+	// Read feed_publish count from each node.
+	counts := make([]int64, cfg.Nodes)
+	for n := 1; n <= cfg.Nodes; n++ {
+		c, err := countHiveBlocksWithFeedPublishOps(ctx, d, n, fromBlock, toBlock)
+		if err != nil {
+			t.Errorf("magi-%d: counting feed_publish hive_blocks: %v", n, err)
+			continue
+		}
+		counts[n-1] = c
+		t.Logf("magi-%d: %d hive_blocks carry feed_publish in [%d, %d]", n, c, fromBlock, toBlock)
+	}
+
+	// Assertion 1: feed-publisher is producing feeds. If every node
+	// reports 0, the publisher is dead or misconfigured.
+	if counts[0] == 0 {
+		// Dump feed-publisher's logs so the operator can see why.
+		logs, _ := d.Logs(ctx, "feed-publisher")
+		if logs != "" {
+			t.Logf("feed-publisher logs:\n%s", truncateLogs(logs, 30))
+		}
+		t.Fatalf("magi-1 saw zero feed_publish hive_blocks in [%d, %d] — feed-publisher not broadcasting?", fromBlock, toBlock)
+	}
+
+	// Assertion 2: every node sees the SAME number. Divergence here
+	// means L1 ingest is inconsistent — a node fell behind, or the
+	// hive_blocks regex matches different things on different nodes
+	// due to schema drift across versions.
+	for n := 2; n <= cfg.Nodes; n++ {
+		if counts[n-1] != counts[0] {
+			t.Errorf("magi-%d feed_publish count=%d differs from magi-1 count=%d in [%d, %d]",
+				n, counts[n-1], counts[0], fromBlock, toBlock)
+		}
+	}
+
+	// Sanity sweep: no node logged feed-related errors. If the
+	// state-engine couldn't decode a feed_publish op, we'd see it in
+	// per-node logs even if counts at the hive_blocks layer match.
+	t.Run("no_feed_ingest_errors_in_node_logs", func(t *testing.T) {
+		patterns := []string{
+			"feed_publish: invalid",
+			"feed_publish decode failed",
+			"oracle: feed rejected",
+			"pendulum oracle: parse error",
+		}
+		for n := 1; n <= cfg.Nodes; n++ {
+			logs, err := d.Logs(ctx, fmt.Sprintf("magi-%d", n))
+			if err != nil {
+				t.Logf("warning: could not read magi-%d logs: %v", n, err)
+				continue
+			}
+			for _, pat := range patterns {
+				if strings.Contains(logs, pat) {
+					t.Errorf("magi-%d logs contain %q (feed ingest error)", n, pat)
+				}
+			}
+		}
+	})
+}

--- a/tests/devnet/pendulum_helpers_test.go
+++ b/tests/devnet/pendulum_helpers_test.go
@@ -1,0 +1,248 @@
+package devnet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"vsc-node/modules/common/params"
+	systemconfig "vsc-node/modules/common/system-config"
+)
+
+// -----------------------------------------------------------------
+// Shared helpers for the pendulum E2E devnet test workstream
+// (see docs/pendulum/devnet-test-scope.md).
+//
+// Calibration anchors:
+//   - bls_pop_test.go (per-node Mongo reads, strict cross-node
+//     equality, log-substring sweeps)
+//   - tss_helpers_test.go (config builder + startDevnet pattern)
+//
+// What lives here:
+//   - pendulumTestConfig: a Config sized for pendulum tests.
+//   - readLatestSettlementMarker / readSettlementMarkerForEpoch:
+//     direct Mongo reads against the per-node `pendulum_settlements`
+//     collection (schema in modules/db/vsc/pendulum_settlements).
+//   - waitForSettlementEpoch: poll until a settlement marker with
+//     epoch >= minEpoch lands on the named node.
+//   - readCommitteeBondAt: latest `hive_consensus` balance for an
+//     account at or before a target block, matching what
+//     incentive-pendulum/settlement.ReadCommitteeBonds resolves on
+//     the live node.
+//   - countHiveBlocksWithFeedPublishOps: counts hive_blocks ingested
+//     on a node that carry a feed_publish op — the observable proxy
+//     for "this node sees feeds landing" since the oracle's
+//     FeedTracker is in-memory (no persistent oracle collection on
+//     this branch after commit fe70b3f9/8b84dea1).
+//
+// What deliberately doesn't live here yet:
+//   - A "settlement payload reader" that returns the full
+//     DistributionEntry / RewardReductionApplied arrays. Those live
+//     inside the VSC block that carried the BlockTypePendulumSettlement
+//     op, and the GraphQL `SettlementRecord` projection (gated on
+//     `election { settlement }`) is the cleanest read path. M3 will
+//     add a GraphQL helper for that — for now M1 only exposes the
+//     summary marker.
+// -----------------------------------------------------------------
+
+// pendulumTestConfig builds a devnet Config suited for tests that
+// exercise the pendulum pipeline (feed publish → oracle window →
+// settlement → distribution → reduction).
+//
+// Choices:
+//   - 5 nodes: enough for a real committee with quorum, low enough
+//     to keep boot time bounded.
+//   - SkipFunding=false: pendulum needs HBD/HIVE flow to settle on,
+//     so we need the post-setup funding round. (TSS tests skip
+//     because keygen alone doesn't need contract fees.)
+//   - Fast ElectionInterval: settlement is currently election-aligned
+//     (BlockTypePendulumSettlement is emitted by the closing committee
+//     proposer), so faster elections give us settlements within a
+//     reasonable test runtime.
+//   - LogLevel includes "pendulum=trace" so settlement-related
+//     warnings show up in d.Logs sweeps.
+//
+// PendulumParams: there's no dedicated SysConfigOverrides knob on
+// this branch for pendulum settlement cadence — settlement is driven
+// by the election cycle in pendulum_settlement.go. If a future change
+// adds one, plumb it through here.
+func pendulumTestConfig() *Config {
+	cfg := DefaultConfig()
+	cfg.Nodes = 5
+	cfg.LogLevel = "error,pendulum=trace,oracle=trace"
+	cfg.SysConfigOverrides = &systemconfig.SysConfigOverrides{
+		ConsensusParams: &params.ConsensusParams{
+			ElectionInterval: 20, // ~60s per epoch on devnet
+		},
+	}
+	return cfg
+}
+
+// settlementMarkerDoc mirrors the BSON shape of
+// modules/db/vsc/pendulum_settlements/schema.go::SettlementMarker.
+// Stored in the per-node `pendulum_settlements` collection
+// (collectionName constant in settlements.go).
+type settlementMarkerDoc struct {
+	Epoch               uint64 `bson:"epoch"`
+	BlockHeight         uint64 `bson:"block_height"`
+	SnapshotRangeFrom   uint64 `bson:"snapshot_range_from"`
+	SnapshotRangeTo     uint64 `bson:"snapshot_range_to"`
+	TotalDistributedHBD int64  `bson:"total_distributed_hbd"`
+	ResidualHBD         int64  `bson:"residual_hbd"`
+}
+
+// readLatestSettlementMarker returns the highest-epoch settlement
+// marker recorded on the named node. Returns (nil, nil) — no error,
+// no record — if the collection is empty (pre-pendulum elections,
+// or first settlement still pending).
+func readLatestSettlementMarker(ctx context.Context, d *Devnet, node int) (*settlementMarkerDoc, error) {
+	client, err := d.mongoClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer client.Disconnect(ctx)
+
+	coll := client.Database(d.nodeDbName(node)).Collection("pendulum_settlements")
+	var rec settlementMarkerDoc
+	err = coll.FindOne(ctx, bson.M{},
+		options.FindOne().SetSort(bson.D{{Key: "epoch", Value: -1}})).Decode(&rec)
+	if err != nil {
+		// FindOne returns ErrNoDocuments when the collection is
+		// empty; callers treat that as "no settlement yet."
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("magi-%d: reading latest settlement marker: %w", node, err)
+	}
+	return &rec, nil
+}
+
+// readSettlementMarkerForEpoch returns the settlement marker for the
+// specific epoch on the named node, or (nil, nil) if no marker exists.
+// Used by M3 to fetch the same epoch across all nodes for byte-stable
+// comparison of fields the marker carries.
+func readSettlementMarkerForEpoch(ctx context.Context, d *Devnet, node int, epoch uint64) (*settlementMarkerDoc, error) {
+	client, err := d.mongoClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer client.Disconnect(ctx)
+
+	coll := client.Database(d.nodeDbName(node)).Collection("pendulum_settlements")
+	var rec settlementMarkerDoc
+	if err := coll.FindOne(ctx, bson.M{"epoch": epoch}).Decode(&rec); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("magi-%d: reading settlement marker epoch %d: %w", node, epoch, err)
+	}
+	return &rec, nil
+}
+
+// waitForSettlementEpoch polls the named node until a settlement
+// marker with Epoch >= minEpoch has been written, or timeout
+// elapses. Returns the marker found.
+func waitForSettlementEpoch(ctx context.Context, d *Devnet, node int, minEpoch uint64, timeout time.Duration) (*settlementMarkerDoc, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		rec, err := readLatestSettlementMarker(ctx, d, node)
+		if err != nil {
+			return nil, err
+		}
+		if rec != nil && rec.Epoch >= minEpoch {
+			return rec, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(5 * time.Second):
+		}
+	}
+	return nil, fmt.Errorf("magi-%d: no settlement marker with epoch >= %d within %s", node, minEpoch, timeout)
+}
+
+// readCommitteeBondAt returns the HIVE_CONSENSUS balance on the
+// named account at or before targetBlock — the same input
+// incentive-pendulum/settlement.ReadCommitteeBonds reads via
+// balanceDb.GetBalanceRecord. The account argument may be either
+// bare ("alice") or hive-prefixed ("hive:alice"); we normalise to
+// the storage form ("hive:alice") used by ledger_balances.
+func readCommitteeBondAt(ctx context.Context, d *Devnet, node int, account string, targetBlock uint64) (int64, error) {
+	client, err := d.mongoClient(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer client.Disconnect(ctx)
+
+	hiveAcc := account
+	if len(account) < 5 || account[:5] != "hive:" {
+		hiveAcc = "hive:" + account
+	}
+
+	coll := client.Database(d.nodeDbName(node)).Collection("ledger_balances")
+	var raw struct {
+		Account        string `bson:"account"`
+		BlockHeight    uint64 `bson:"block_height"`
+		HIVE_CONSENSUS int64  `bson:"hive_consensus"`
+	}
+	err = coll.FindOne(ctx,
+		bson.M{
+			"account":      hiveAcc,
+			"block_height": bson.M{"$lte": targetBlock},
+		},
+		options.FindOne().SetSort(bson.D{{Key: "block_height", Value: -1}}),
+	).Decode(&raw)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			// No balance record at or before targetBlock = bond is 0,
+			// matching how the live ReadCommitteeBonds treats a
+			// member with no balance history yet.
+			return 0, nil
+		}
+		return 0, fmt.Errorf("magi-%d: reading bond for %s at block %d: %w", node, hiveAcc, targetBlock, err)
+	}
+	return raw.HIVE_CONSENSUS, nil
+}
+
+// countHiveBlocksWithFeedPublishOps counts hive_blocks documents on
+// the named node whose embedded ops carry a `feed_publish` op type
+// with block_number in [fromBlock, toBlock]. Used by M2 as the
+// observable proxy for "feeds are reaching this node" since the
+// oracle FeedTracker is in-memory (no persistent oracle collection
+// on this branch).
+//
+// The hive_blocks document layout (modules/db/vsc/hive_blocks) puts
+// the block payload under `block`. Hive ops are stored as
+// {operations: [{type, value: {...}}]} per Hive's standard JSON
+// shape. The exact path may vary across pre-/post-HAF formats —
+// this helper does a loose substring scan rather than a strict
+// path lookup for that reason.
+func countHiveBlocksWithFeedPublishOps(ctx context.Context, d *Devnet, node int, fromBlock, toBlock uint64) (int64, error) {
+	client, err := d.mongoClient(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer client.Disconnect(ctx)
+
+	coll := client.Database(d.nodeDbName(node)).Collection("hive_blocks")
+	// $where is brittle but the hive_blocks schema mixes top-level
+	// and nested fields across versions; a regex over the serialised
+	// doc is the most robust cross-version count. The collection is
+	// indexed by block number, so the range filter is the cheap part.
+	count, err := coll.CountDocuments(ctx, bson.M{
+		"$and": []bson.M{
+			{"block.block_number": bson.M{"$gte": fromBlock, "$lte": toBlock}},
+			{"block": bson.M{"$regex": "feed_publish"}},
+		},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("magi-%d: counting feed_publish hive_blocks in [%d, %d]: %w", node, fromBlock, toBlock, err)
+	}
+	return count, nil
+}
+

--- a/tests/devnet/pendulum_settlement_happy_test.go
+++ b/tests/devnet/pendulum_settlement_happy_test.go
@@ -1,0 +1,200 @@
+package devnet
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPendulumSettlementHappyPath is M3 of the pendulum E2E
+// workstream (docs/pendulum/devnet-test-scope.md). The flagship test.
+//
+// Proves end-to-end determinism of the pendulum settlement path:
+//
+//  1. A settlement marker eventually lands in every node's
+//     `pendulum_settlements` collection.
+//  2. The marker's canonical fields (epoch, block_height,
+//     snapshot_range_from, snapshot_range_to, total_distributed_hbd,
+//     residual_hbd) are byte-identical across every node for the
+//     same epoch — i.e. settlement consensus actually converged.
+//  3. TotalDistributedHBD > 0 — at least one DistributionEntry was
+//     produced; the settlement didn't degenerate to a no-op.
+//  4. Snapshot range is well-formed (from <= to, both > 0).
+//
+// What's deferred to a follow-up (call it M3.5):
+//
+//   - Reading the full DistributionEntry / RewardReductionApplied
+//     arrays per node and asserting THEY also match byte-for-byte.
+//     Those live in the VSC block carrying the
+//     BlockTypePendulumSettlement op, not in pendulum_settlements
+//     (which is summary-only). The cleanest read path is the
+//     GraphQL `election { settlement }` projection
+//     (modules/gql/schema.graphql defines SettlementRecord +
+//     DistributionEntry). Adding a GraphQL settlement reader is
+//     itself a piece of helper work; M3 ships without it so we
+//     don't bundle two concerns in one milestone.
+//   - Verifying per-member HBD balance deltas match the marker's
+//     TotalDistributedHBD. This requires a separate HBD-balance
+//     reader (M1 only added the HIVE_CONSENSUS bond reader).
+//     Follow-up.
+//
+// Failure modes this catches:
+//
+//   - Non-deterministic settlement compose: marker.TotalDistributedHBD
+//     or BlockHeight differs across nodes (consensus break — the
+//     class of bug 8130b95e's deterministic-amount + namespace
+//     fixes guard against).
+//   - Settlement never lands: marker stays nil after the timeout
+//     (pendulum scheduler is wedged, or oracle window never produced
+//     usable inputs).
+//   - Settlement produces zero distribution: marker.TotalDistributedHBD
+//     == 0 (committee bond reader returned no bonds, fee inputs are
+//     all zero, or stabilizer suppressed everything).
+//
+// Run with:
+//
+//	go test -v -run TestPendulumSettlementHappyPath -timeout 25m ./tests/devnet/
+func TestPendulumSettlementHappyPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	cfg := pendulumTestConfig()
+	d, ctx := startDevnetNoKey(t, cfg, 20*time.Minute)
+
+	// Wait for every node to ingest at least one running election.
+	// Settlement is election-aligned: a closing committee proposer
+	// emits BlockTypePendulumSettlement when the epoch advances, so
+	// no settlement can land before epoch >= 1.
+	t.Log("waiting for first running election (epoch >= 1) on every node...")
+	for n := 1; n <= cfg.Nodes; n++ {
+		nodeCtx, cancel := context.WithTimeout(ctx, 8*time.Minute)
+		if err := d.waitForElectionEpoch(nodeCtx, n, 1, 8*time.Minute); err != nil {
+			cancel()
+			t.Fatalf("magi-%d never ingested epoch >= 1: %v", n, err)
+		}
+		cancel()
+	}
+
+	// Pendulum settlement seeds at the genesis committee transition
+	// then composes on subsequent committee transitions. Wait for a
+	// settlement marker with Epoch >= 1 on magi-1 first (any node;
+	// magi-1 is arbitrary). We give a generous timeout because the
+	// first composition can lag the first election by a full epoch.
+	t.Log("waiting for first settlement marker on magi-1 (epoch >= 1)...")
+	first, err := waitForSettlementEpoch(ctx, d, 1, 1, 12*time.Minute)
+	if err != nil {
+		// Dump magi-1 logs to surface why settlement isn't landing.
+		logs, _ := d.Logs(ctx, "magi-1")
+		if logs != "" {
+			t.Logf("magi-1 logs:\n%s", truncateLogs(logs, 40))
+		}
+		t.Fatalf("magi-1 never landed a settlement marker: %v", err)
+	}
+	targetEpoch := first.Epoch
+	t.Logf("settlement landed on magi-1: epoch=%d block_height=%d total_distributed=%d residual=%d snapshot=[%d, %d]",
+		first.Epoch, first.BlockHeight, first.TotalDistributedHBD, first.ResidualHBD,
+		first.SnapshotRangeFrom, first.SnapshotRangeTo)
+
+	// Wait for the same epoch's marker on every other node. Settlement
+	// propagation across nodes is fast (it rides on VSC block ingest),
+	// so 3 minutes is plenty.
+	t.Logf("waiting for same epoch %d on remaining nodes...", targetEpoch)
+	markers := make([]*settlementMarkerDoc, cfg.Nodes)
+	markers[0] = first
+	for n := 2; n <= cfg.Nodes; n++ {
+		nodeCtx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+		m, err := waitForSpecificSettlementEpoch(nodeCtx, d, n, targetEpoch, 3*time.Minute)
+		cancel()
+		if err != nil {
+			t.Fatalf("magi-%d never landed settlement marker for epoch %d: %v", n, targetEpoch, err)
+		}
+		markers[n-1] = m
+	}
+
+	// Assertion 1: well-formed marker on magi-1 (sanity baseline).
+	if first.TotalDistributedHBD <= 0 {
+		t.Errorf("settlement marker on magi-1 has total_distributed_hbd=%d (expected > 0) — settlement produced no rewards",
+			first.TotalDistributedHBD)
+	}
+	if first.SnapshotRangeTo == 0 || first.SnapshotRangeFrom > first.SnapshotRangeTo {
+		t.Errorf("settlement marker on magi-1 has malformed snapshot range [%d, %d]",
+			first.SnapshotRangeFrom, first.SnapshotRangeTo)
+	}
+	if first.BlockHeight == 0 {
+		t.Errorf("settlement marker on magi-1 has block_height=0 (expected nonzero)")
+	}
+
+	// Assertion 2: every field of the marker is identical across all
+	// nodes for the chosen epoch. Any divergence is a consensus break.
+	for n := 2; n <= cfg.Nodes; n++ {
+		m := markers[n-1]
+		if m.Epoch != first.Epoch {
+			t.Errorf("magi-%d epoch=%d differs from magi-1 epoch=%d", n, m.Epoch, first.Epoch)
+		}
+		if m.BlockHeight != first.BlockHeight {
+			t.Errorf("magi-%d block_height=%d differs from magi-1 block_height=%d", n, m.BlockHeight, first.BlockHeight)
+		}
+		if m.SnapshotRangeFrom != first.SnapshotRangeFrom {
+			t.Errorf("magi-%d snapshot_range_from=%d differs from magi-1 %d", n, m.SnapshotRangeFrom, first.SnapshotRangeFrom)
+		}
+		if m.SnapshotRangeTo != first.SnapshotRangeTo {
+			t.Errorf("magi-%d snapshot_range_to=%d differs from magi-1 %d", n, m.SnapshotRangeTo, first.SnapshotRangeTo)
+		}
+		if m.TotalDistributedHBD != first.TotalDistributedHBD {
+			t.Errorf("magi-%d total_distributed_hbd=%d differs from magi-1 %d (settlement amount diverged)",
+				n, m.TotalDistributedHBD, first.TotalDistributedHBD)
+		}
+		if m.ResidualHBD != first.ResidualHBD {
+			t.Errorf("magi-%d residual_hbd=%d differs from magi-1 %d", n, m.ResidualHBD, first.ResidualHBD)
+		}
+	}
+
+	// Sanity sweep: settlement-validation warnings would indicate the
+	// state engine rejected a settlement (consensus-affecting) even
+	// though the marker eventually wrote. Surface them as errors.
+	t.Run("no_settlement_validation_warnings", func(t *testing.T) {
+		patterns := []string{
+			"settlement validation failed",
+			"pendulum compose drift",
+			"settlement record mismatch",
+			"applyPendulumSettlement: invalid",
+		}
+		for n := 1; n <= cfg.Nodes; n++ {
+			logs, err := d.Logs(ctx, fmt.Sprintf("magi-%d", n))
+			if err != nil {
+				t.Logf("warning: could not read magi-%d logs: %v", n, err)
+				continue
+			}
+			for _, pat := range patterns {
+				if strings.Contains(logs, pat) {
+					t.Errorf("magi-%d logs contain %q (settlement consensus warning)", n, pat)
+				}
+			}
+		}
+	})
+}
+
+// waitForSpecificSettlementEpoch is like waitForSettlementEpoch but
+// waits for exactly `epoch`, not "epoch >= minEpoch". Used by M3 to
+// fetch the same epoch's marker from every node.
+func waitForSpecificSettlementEpoch(ctx context.Context, d *Devnet, node int, epoch uint64, timeout time.Duration) (*settlementMarkerDoc, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		m, err := readSettlementMarkerForEpoch(ctx, d, node, epoch)
+		if err != nil {
+			return nil, err
+		}
+		if m != nil {
+			return m, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(3 * time.Second):
+		}
+	}
+	return nil, fmt.Errorf("magi-%d: no settlement marker for epoch %d within %s", node, epoch, timeout)
+}

--- a/tests/devnet/pendulum_slashing_reduction_test.go
+++ b/tests/devnet/pendulum_slashing_reduction_test.go
@@ -1,0 +1,208 @@
+package devnet
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPendulumSlashingReductionApplied is M4 of the pendulum E2E
+// workstream (docs/pendulum/devnet-test-scope.md). The test that
+// closes the loop on the 8130b95e bare-key → "hive:" namespace fix
+// in incentive-pendulum/settlement/calculator.go.
+//
+// Background (from the 8130b95e commit):
+//
+//	The bond map (out) is keyed "hive:<account>" (see
+//	ReadCommitteeBonds / normalizeHiveAccount), but reductionBps is
+//	keyed by the bare account name (committee members are bare
+//	m.Account). Without normalizing here every lookup missed, orig
+//	was always 0, and the entire reward-reduction (penalty) system
+//	was silently inert.
+//
+// Pre-fix consequence: a node that missed oracle attestations would
+// still receive its FULL settlement reward, because
+// `out[acc]` (bare key) returned 0 instead of the actual bond. The
+// reduction computed to 0 too, eff == orig, no reduction applied.
+//
+// Devnet test approach:
+//
+//  1. Spin up devnet, wait for first settlement (baseline marker).
+//  2. Stop a non-genesis node for a window of feeds long enough to
+//     accumulate OracleEvidence (missed attestations).
+//  3. Restart the node.
+//  4. Wait for the next settlement marker.
+//  5. Observe the marker fields and confirm:
+//     - The marker still lands on every node (settlement didn't
+//       crash on the slashing path).
+//     - All nodes' markers byte-match (consensus held).
+//     - ResidualHBD > 0 on the post-stop settlement, OR
+//       TotalDistributedHBD has dropped vs the baseline. Either
+//       indicates the reduction system fired and rolled some
+//       portion of the reward to residual.
+//
+// Honest scope notes:
+//
+//   - This test does NOT byte-compare the per-account
+//     RewardReductionApplied array — that lives in the full
+//     settlement payload (VSC block, GraphQL projection), not in
+//     the pendulum_settlements summary. Doing so cleanly requires
+//     a GraphQL settlement reader that's been deferred to M3.5.
+//   - The slashing magnitude in a short devnet window is small —
+//     the test asserts a DIRECTIONAL signal (residual rose / total
+//     dropped) rather than a specific bps value. A pre-fix run
+//     would show ResidualHBD == baseline (no reduction applied to
+//     any node), which the test would flag.
+//   - If the devnet doesn't accumulate enough missed attestations
+//     to trigger any slashing in the test's runtime budget, the
+//     test t.Skip's with a clear message. That's a real outcome —
+//     we'd need a longer window or a SysConfigOverrides knob for
+//     slashing thresholds (see Q2 in the scope doc).
+//
+// Run with:
+//
+//	go test -v -run TestPendulumSlashingReductionApplied -timeout 35m ./tests/devnet/
+func TestPendulumSlashingReductionApplied(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	cfg := pendulumTestConfig()
+	d, ctx := startDevnetNoKey(t, cfg, 30*time.Minute)
+
+	// Pick a non-genesis node to stop.
+	stopNode := 1
+	if cfg.GenesisNode == 1 {
+		stopNode = 2
+	}
+
+	// Wait for every node to ingest at least one election so settlement
+	// becomes possible.
+	t.Log("waiting for first running election on every node...")
+	for n := 1; n <= cfg.Nodes; n++ {
+		nodeCtx, cancel := context.WithTimeout(ctx, 8*time.Minute)
+		if err := d.waitForElectionEpoch(nodeCtx, n, 1, 8*time.Minute); err != nil {
+			cancel()
+			t.Fatalf("magi-%d never ingested epoch >= 1: %v", n, err)
+		}
+		cancel()
+	}
+
+	// Establish a baseline settlement BEFORE the stop. This gives us
+	// "normal" residual/total values to compare the post-stop
+	// settlement against.
+	t.Log("waiting for baseline settlement marker on magi-1...")
+	baseline, err := waitForSettlementEpoch(ctx, d, 1, 1, 12*time.Minute)
+	if err != nil {
+		t.Fatalf("never landed a baseline settlement: %v", err)
+	}
+	baselineEpoch := baseline.Epoch
+	t.Logf("baseline settlement: epoch=%d total_distributed=%d residual=%d",
+		baseline.Epoch, baseline.TotalDistributedHBD, baseline.ResidualHBD)
+
+	// Stop the target node. We hold it stopped for ~3 minutes which
+	// is multiple feed-publisher ticks (default 240s) and several
+	// magi-block heartbeats — comfortably above whatever threshold
+	// the oracle uses to mark a member as missing attestations.
+	t.Logf("stopping magi-%d for 3 minutes to accumulate missed attestations...", stopNode)
+	if err := d.StopNode(ctx, stopNode); err != nil {
+		t.Fatalf("stopping magi-%d: %v", stopNode, err)
+	}
+	select {
+	case <-ctx.Done():
+		t.Fatalf("ctx cancelled while stopped: %v", ctx.Err())
+	case <-time.After(3 * time.Minute):
+	}
+	t.Logf("restarting magi-%d...", stopNode)
+	if err := d.StartNode(ctx, stopNode); err != nil {
+		t.Fatalf("restarting magi-%d: %v", stopNode, err)
+	}
+
+	// Give the restarted node a chance to catch up, then wait for the
+	// next settlement (epoch > baselineEpoch).
+	t.Log("waiting for restart catchup and next settlement...")
+	time.Sleep(30 * time.Second)
+	postStop, err := waitForSettlementEpoch(ctx, d, 1, baselineEpoch+1, 12*time.Minute)
+	if err != nil {
+		t.Fatalf("never landed a post-stop settlement marker on magi-1: %v", err)
+	}
+	t.Logf("post-stop settlement: epoch=%d total_distributed=%d residual=%d",
+		postStop.Epoch, postStop.TotalDistributedHBD, postStop.ResidualHBD)
+
+	// Wait for the same post-stop epoch to land on every node.
+	t.Logf("waiting for post-stop epoch %d on every node...", postStop.Epoch)
+	markers := make([]*settlementMarkerDoc, cfg.Nodes)
+	markers[0] = postStop
+	for n := 2; n <= cfg.Nodes; n++ {
+		nodeCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		m, err := waitForSpecificSettlementEpoch(nodeCtx, d, n, postStop.Epoch, 5*time.Minute)
+		cancel()
+		if err != nil {
+			t.Fatalf("magi-%d never landed post-stop epoch %d: %v", n, postStop.Epoch, err)
+		}
+		markers[n-1] = m
+	}
+
+	// Cross-node convergence: all nodes must agree on the post-stop
+	// marker. Divergence here = consensus break under slashing
+	// conditions (worse than the pre-fix bug — the fix should not
+	// have introduced non-determinism).
+	for n := 2; n <= cfg.Nodes; n++ {
+		m := markers[n-1]
+		if m.TotalDistributedHBD != postStop.TotalDistributedHBD ||
+			m.ResidualHBD != postStop.ResidualHBD ||
+			m.BlockHeight != postStop.BlockHeight {
+			t.Errorf("magi-%d post-stop marker diverges from magi-1: total=%d residual=%d block=%d vs total=%d residual=%d block=%d",
+				n, m.TotalDistributedHBD, m.ResidualHBD, m.BlockHeight,
+				postStop.TotalDistributedHBD, postStop.ResidualHBD, postStop.BlockHeight)
+		}
+	}
+
+	// Directional fix signal: post-stop residual should be > baseline
+	// residual OR post-stop total < baseline total. Either indicates
+	// the reduction system fired and rolled portion to residual /
+	// withheld from distribution. Under the pre-fix bug, neither
+	// would change because reductions never applied.
+	residualRose := postStop.ResidualHBD > baseline.ResidualHBD
+	totalDropped := postStop.TotalDistributedHBD < baseline.TotalDistributedHBD
+	if !residualRose && !totalDropped {
+		t.Logf("baseline: total=%d residual=%d", baseline.TotalDistributedHBD, baseline.ResidualHBD)
+		t.Logf("post-stop: total=%d residual=%d", postStop.TotalDistributedHBD, postStop.ResidualHBD)
+		t.Skipf("no observable slashing fingerprint between baseline and post-stop — devnet runtime budget may be too short to accumulate missed attestations, or slashing threshold not reached")
+	}
+
+	t.Logf("slashing fingerprint observed: residual_rose=%v total_dropped=%v", residualRose, totalDropped)
+
+	// Sanity sweep: log warnings that would indicate the slashing
+	// path itself errored (which would invalidate the test even if
+	// fingerprints look right).
+	t.Run("no_slashing_path_errors", func(t *testing.T) {
+		patterns := []string{
+			"ApplyRewardReductionsToBonds: panic",
+			"slashing: invalid",
+			"reduction lookup failed",
+			"bond read failed; member dropped from settlement",
+		}
+		for n := 1; n <= cfg.Nodes; n++ {
+			logs, err := d.Logs(ctx, fmt.Sprintf("magi-%d", n))
+			if err != nil {
+				t.Logf("warning: could not read magi-%d logs: %v", n, err)
+				continue
+			}
+			for _, pat := range patterns {
+				if strings.Contains(logs, pat) {
+					// The last one ("bond read failed") is a normal info
+					// message during stop windows; demote to Logf rather
+					// than Errorf.
+					if pat == "bond read failed; member dropped from settlement" {
+						t.Logf("magi-%d info: %q (expected during stop window)", n, pat)
+						continue
+					}
+					t.Errorf("magi-%d logs contain %q (slashing path error)", n, pat)
+				}
+			}
+		}
+	})
+}

--- a/tests/devnet/pr181_unstake_zero_epoch_test.go
+++ b/tests/devnet/pr181_unstake_zero_epoch_test.go
@@ -1,0 +1,215 @@
+package devnet
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// TestPR181ConsensusUnstakeRejectedBeforeFirstElection verifies the
+// fix from PR #181 commit 30848bbd (review4 HIGH #96).
+//
+// Bug:
+//
+//	electionResult := se.GetElectionInfo(tx.Self.BlockHeight - 1)
+//	params := ledgerSystem.ConsensusParams{
+//	    ...
+//	    ElectionEpoch: electionResult.Epoch + 5,  // <-- zero on failure
+//	}
+//
+// GetElectionInfo swallows the underlying DB error and returns a
+// zero-value ElectionResult. An unstake processed in a window where
+// the election lookup yields Epoch=0 would then lock for "5 epochs
+// from epoch 0" — i.e. epoch 5 — regardless of the current real
+// epoch. At any current epoch > 5 the lock is already expired and
+// the unstake auto-unlocks immediately (or never locks at all).
+//
+// Fix:
+//
+//	if electionResult.Epoch == 0 && tx.Self.BlockHeight > 1 {
+//	    return TxResult{
+//	        Success: false,
+//	        Ret:     "election lookup unavailable; retry unstake later",
+//	        RcUsed:  50,
+//	    }
+//	}
+//
+// The fix refuses the tx so the user resubmits once the lookup
+// recovers, instead of locking under a stale zero epoch.
+//
+// Devnet-exercisable window:
+//
+//   - genesis-elector produces the genesis election with Epoch=0 at
+//     boot.
+//   - The running election proposer first emits a real election at
+//     block ~ElectionInterval (60s after boot in this config).
+//   - Any consensus_unstake whose containing L1 block is ingested by
+//     magid in that pre-election window has
+//     `electionResult.Epoch == 0 && BlockHeight > 1` — the exact guard
+//     condition.
+//
+// Test:
+//
+//  1. Spins up devnet (no TSS key needed — this exercises the state
+//     engine, not TSS).
+//  2. Submits a consensus_unstake immediately, in the pre-election
+//     window.
+//  3. Waits until every node has ingested epoch >= 1.
+//  4. Submits a second consensus_unstake post-election.
+//  5. Waits a few blocks for both to settle.
+//  6. Queries each node's `ledger_actions` collection for the target
+//     account. We expect exactly ONE action of type "unstake": the
+//     post-election one. The pre-election one must NOT have produced
+//     an action record (the guard rejected it).
+//
+// Failure-mode honesty: this test cannot specifically inject a
+// transient Mongo failure on `GetElectionByHeight` — that's the
+// underlying root-cause path the comment describes. It exploits the
+// natural boot-window where electionResult.Epoch==0 is the only state
+// the lookup can return. Together with the unit tests of the new code
+// path, this gives end-to-end evidence the guard rejects in a real
+// devnet exactly when it should.
+func TestPR181ConsensusUnstakeRejectedBeforeFirstElection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	cfg := tssTestConfig()
+	d, ctx := startDevnetNoKey(t, cfg, 15*time.Minute)
+
+	// Use a non-genesis witness so we don't interfere with block production.
+	// WitnessPrefix defaults to "magi.test" -> "magi.test1" etc.
+	witnessIdx := 1
+	if cfg.GenesisNode == 1 {
+		witnessIdx = 2
+	}
+	targetAccount := fmt.Sprintf("%s%d", cfg.WitnessPrefix, witnessIdx)
+
+	// Submit the early unstake immediately — racing against the running
+	// election proposer's first epoch (~ElectionInterval blocks away). We
+	// expect this to land in an L1 block whose ingested BlockHeight on
+	// magid is > 1 but before any post-genesis election has been
+	// processed.
+	earlyAmount := "1.000"
+	t.Logf("submitting early consensus_unstake for %s (%s) in pre-election window", targetAccount, earlyAmount)
+	if err := d.Unstake(ctx, targetAccount, earlyAmount); err != nil {
+		t.Fatalf("broadcasting early unstake: %v", err)
+	}
+
+	// Wait for the first running election (epoch >= 1) on every node, so
+	// we know the pre-election window has definitively closed.
+	t.Log("waiting for first running election (epoch >= 1) on every node...")
+	for n := 1; n <= cfg.Nodes; n++ {
+		nodeCtx, cancel := context.WithTimeout(ctx, 8*time.Minute)
+		if err := d.waitForElectionEpoch(nodeCtx, n, 1, 8*time.Minute); err != nil {
+			cancel()
+			t.Fatalf("magi-%d never ingested epoch >= 1: %v", n, err)
+		}
+		cancel()
+	}
+
+	// Give magid extra blocks to fully process the early unstake either
+	// way (recorded as rejected, or accepted under the buggy code path).
+	time.Sleep(15 * time.Second)
+
+	// Snapshot how many unstake actions exist after the pre-election
+	// window. Under the fix this should be 0; under the bug it would be 1.
+	earlyCounts := make([]int64, cfg.Nodes)
+	for n := 1; n <= cfg.Nodes; n++ {
+		c, err := countUnstakeActions(ctx, d, n, targetAccount)
+		if err != nil {
+			t.Fatalf("counting early unstake actions on magi-%d: %v", n, err)
+		}
+		earlyCounts[n-1] = c
+		t.Logf("magi-%d: %d unstake action(s) recorded after pre-election window (expect 0)", n, c)
+	}
+
+	// Now submit a second unstake — this one must succeed because epoch >= 1
+	// is in place.
+	laterAmount := "2.000"
+	t.Logf("submitting later consensus_unstake for %s (%s) post-election", targetAccount, laterAmount)
+	if err := d.Unstake(ctx, targetAccount, laterAmount); err != nil {
+		t.Fatalf("broadcasting later unstake: %v", err)
+	}
+
+	// Wait a generous window for the later unstake's L1 op to be ingested,
+	// processed, and recorded in ledger_actions.
+	time.Sleep(30 * time.Second)
+
+	// Verify post-state: each node should have exactly one MORE unstake
+	// action than it had after the pre-election window — the late one.
+	for n := 1; n <= cfg.Nodes; n++ {
+		c, err := countUnstakeActions(ctx, d, n, targetAccount)
+		if err != nil {
+			t.Fatalf("counting final unstake actions on magi-%d: %v", n, err)
+		}
+		expected := earlyCounts[n-1] + 1
+		if c != expected {
+			t.Errorf("magi-%d: expected %d unstake actions after post-election unstake, got %d", n, expected, c)
+		}
+	}
+
+	// Final guard: ensure earlyCounts was 0 everywhere. If it was >= 1, the
+	// early unstake was NOT rejected — the fix is not in effect on this
+	// node. We assert this AFTER the late-unstake step so we still get the
+	// "+1 happens correctly" signal as a sanity check on the happy path.
+	for n := 1; n <= cfg.Nodes; n++ {
+		if earlyCounts[n-1] != 0 {
+			t.Errorf("magi-%d: %d unstake action(s) recorded from the pre-election submission — guard did not reject", n, earlyCounts[n-1])
+		}
+	}
+}
+
+// countUnstakeActions returns the number of `ledger_actions` records on
+// the given node whose `type` indicates consensus_unstake and whose
+// owning account matches `account`. The exact bson layout is:
+//
+//	{ id: ..., type: "unstake" or contains "unstake", to/from: "hive:<account>", ... }
+//
+// We filter loosely on `type` containing "unstake" to be robust to small
+// schema tweaks (e.g. "consensus_unstake" vs "unstake").
+func countUnstakeActions(ctx context.Context, d *Devnet, node int, account string) (int64, error) {
+	client, err := d.mongoClient(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer client.Disconnect(ctx)
+
+	coll := client.Database(d.nodeDbName(node)).Collection("ledger_actions")
+	hiveAcc := "hive:" + account
+
+	// Try multiple plausible filters; the action record may key the account
+	// on `to`, `from`, or carry it in the `data` subdoc. Count the union.
+	queries := []bson.M{
+		{"type": bson.M{"$regex": "unstake"}, "to": hiveAcc},
+		{"type": bson.M{"$regex": "unstake"}, "from": hiveAcc},
+		{"type": bson.M{"$regex": "unstake"}, "data.from": hiveAcc},
+	}
+	seen := map[string]struct{}{}
+	for _, q := range queries {
+		cur, err := coll.Find(ctx, q, options.Find().SetProjection(bson.M{"id": 1}))
+		if err != nil {
+			return 0, fmt.Errorf("find on magi-%d: %w", node, err)
+		}
+		for cur.Next(ctx) {
+			var doc struct {
+				Id string `bson:"id"`
+			}
+			if err := cur.Decode(&doc); err != nil {
+				cur.Close(ctx)
+				return 0, fmt.Errorf("decode on magi-%d: %w", node, err)
+			}
+			seen[doc.Id] = struct{}{}
+		}
+		cur.Close(ctx)
+	}
+	return int64(len(seen)), nil
+}
+
+// silence the unused-import linter if mongo isn't referenced directly elsewhere
+var _ = mongo.ErrNoDocuments


### PR DESCRIPTION
Adds 6 docker-multi-node devnet tests covering parts of the pendulum pipeline + recent fixes. All honestly scoped — limits documented per test header.

Tests
- TestElectionConsensusDeterminism — cross-node byte-equality on  election bytes (catches future float/map-iter drift; PR #181 #6   dormant until REQUIRED_ELECTION_MEMBERS populated)
- TestPR181ConsensusUnstakeRejectedBeforeFirstElection — review4   HIGH #96 zero-epoch guard (depends on PR #181 merging first) 
- TestCriticalAuditPendingActionsCursor — 8130b95e cursor loop:  sibling unstakes release at identical BlockHeights
- TestPendulumFeedPropagation — feed-publisher → hive_blocks  ingest converges across nodes
- TestPendulumSettlementHappyPath — SettlementMarker fields  byte-identical across nodes for the same epoch
- TestPendulumSlashingReductionApplied — stop-restart drives the  reduction path; asserts directional fingerprint (residual_hbd rose OR total_distributed_hbd dropped)

Plus
- tests/devnet/pendulum_helpers_test.go — pendulumTestConfig,  settlement reader, bond reader, feed-block counter
- docs/pendulum/devnet-test-scope.md — M1–M5 plan + 5 open Qs

Runtime: ~10–30 min per test, opt-in (workflow_dispatch /nightly). Not added to default CI.

Deliberately omitted
- TWAB / state-processing error-swallow fixes — unit-sufficient
- M5 stabilizer activation — hard to drive on devnet, optional
- Per-account DistributionEntry byte-equality — deferred to M3.5
  (needs GraphQL settlement reader)

Branch is clean off `pendulum`; PR #181 fix commits not included.
