### PR TITLE
fix/audit-meds-mechanical → pendulum

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -33,7 +33,7 @@ services:
     volumes:
       - ./data:/home/app/app/data
   db:
-    image: mongo:8.0.17
+    image: mongo:8.0.17@sha256:9814652e33f0cf8b9fddea8b46dfc9d8e19b130dcfdd7b510ca58bb0d40c8b71
     # restart: always
     ports:
       - 127.0.0.1:27017:27017
@@ -51,7 +51,7 @@ services:
         limits:
           memory: 1G
   bitcoind:
-    image: bitcoin/bitcoin:29.3
+    image: bitcoin/bitcoin:29.3@sha256:27b4c2d260b36df0e3c9929020392b71ae40c0e547d3cf95cae10e1538b1b798
     container_name: vsc-btcd
     command: -rpcuser=vsc-node-user -rpcpassword=vsc-node-pass -rpcallowip=0.0.0.0/0 -rpcbind=0.0.0.0 -prune=550 -dbcache=2048 -server=1 -listen=1
     restart: always

--- a/modules/state-processing/pendulum_settlement.go
+++ b/modules/state-processing/pendulum_settlement.go
@@ -173,8 +173,8 @@ func (se *StateEngine) applyPendulumSettlement(rec pendulumsettlement.Settlement
 	}
 
 	if remaining := se.LedgerSystem.PendulumBucketBalance(ledgerSystem.PendulumNodesHBDBucket, blockHeight); remaining != rec.ResidualHBD {
-		log.Debug("pendulum settlement: residual differs from record",
-			"epoch", rec.Epoch, "record_residual", rec.ResidualHBD, "live_residual", remaining)
+		log.Warn("pendulum settlement: residual differs from record",
+			"epoch", rec.Epoch, "blockHeight", blockHeight, "record_residual", rec.ResidualHBD, "live_residual", remaining)
 	}
 
 	if err := se.pendulumSettlementsDb.SaveMarker(pendulum_settlements_db.SettlementMarker{

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -1350,7 +1350,11 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 	//Detects new slot and executes batch if so
 	if se.slotStatus.SlotHeight != slotInfo.StartHeight {
 		//Updates balances index before next batch can execute
-		vscBlock, _ := se.vscBlocks.GetBlockByHeight(se.slotStatus.SlotHeight - 1)
+		vscBlock, err := se.vscBlocks.GetBlockByHeight(se.slotStatus.SlotHeight - 1)
+		if err != nil && err != mongo.ErrNoDocuments {
+			log.Error("GetBlockByHeight failed, falling back to full-range balance scan",
+				"slotHeight", se.slotStatus.SlotHeight, "err", err)
+		}
 
 		startBlock := uint64(0)
 		if vscBlock != nil {
@@ -1632,7 +1636,11 @@ func (se *StateEngine) committeeAccountsAtHeight(height uint64) []string {
 
 func (se *StateEngine) ExecuteBatch() {
 
-	lastBlock, _ := se.vscBlocks.GetBlockByHeight(se.slotStatus.SlotHeight)
+	lastBlock, err := se.vscBlocks.GetBlockByHeight(se.slotStatus.SlotHeight)
+	if err != nil && err != mongo.ErrNoDocuments {
+		log.Error("GetBlockByHeight failed in ExecuteBatch, falling back to lastBlockBh=0",
+			"slotHeight", se.slotStatus.SlotHeight, "err", err)
+	}
 
 	var lastBlockBh uint64
 	if lastBlock == nil {
@@ -1897,7 +1905,11 @@ func (se *StateEngine) UpdateBalances(startBlock, endBlock uint64) {
 	}
 
 	//log.Debug("stBlock, endBlock", stBlock, endBlock)
-	distinctAccounts, _ := se.LedgerState.LedgerDb.GetDistinctAccountsRange(stBlock, endBlock)
+	distinctAccounts, err := se.LedgerState.LedgerDb.GetDistinctAccountsRange(stBlock, endBlock)
+	if err != nil {
+		log.Error("GetDistinctAccountsRange failed, balance snapshots may be incomplete this slot",
+			"stBlock", stBlock, "endBlock", endBlock, "err", err)
+	}
 
 	//Ensure system:fr_balance is always processed so its hbd_claim stays current.
 	//Its interest goes to hive:vsc.dao, so it never appears in distinctAccounts via

--- a/modules/state-processing/system_txs.go
+++ b/modules/state-processing/system_txs.go
@@ -1043,13 +1043,7 @@ func (bTx *BlockTx) Decode(da *datalayer.DataLayer, txSelf TxSelf) (TransactionC
 		return TransactionContainer{}, fmt.Errorf("invalid tx CID %q: %w", bTx.Id, err)
 	}
 
-	dagNode, err := da.GetDag(txCid)
-	if err != nil {
-		return TransactionContainer{}, fmt.Errorf("GetDag failed for tx %s: %w", bTx.Id, err)
-	}
-	if dagNode == nil {
-		return TransactionContainer{}, fmt.Errorf("GetDag returned nil for tx %s", bTx.Id)
-	}
+	dagNode := getDagOrBlock(da, txCid, fmt.Sprintf("GetDag(blockTx %s)", bTx.Id))
 
 	tx := TransactionContainer{
 		da:      da,

--- a/modules/state-processing/system_txs.go
+++ b/modules/state-processing/system_txs.go
@@ -883,17 +883,24 @@ func (t *TxProposeBlock) ExecuteTx(se *StateEngine) {
 		//Thus: TX confirmation is 30s maximum
 		//Author: @vaultec81
 
-		txContainer := tx.Decode(se.da, TxSelf{
+		txContainer, err := tx.Decode(se.da, TxSelf{
 			TxId:        txInfo.Id,
 			Index:       idx,
 			BlockHeight: uint64(t.SignedBlock.Headers.Br[1]),
 			BlockId:     t.Self.BlockId,
 			Timestamp:   t.Self.Timestamp,
 		})
+		if err != nil {
+			log.Error("block tx decode failed, skipping", "id", txInfo.Id, "idx", idx, "err", err)
+			continue
+		}
 
 		if txContainer.Type() == "transaction" {
-			//Note: sig verification has already happened
-			tx := txContainer.AsTransaction()
+			tx, err := txContainer.AsTransaction()
+			if err != nil {
+				log.Error("block tx AsTransaction failed, skipping", "id", txInfo.Id, "idx", idx, "err", err)
+				continue
+			}
 
 			tx.Ingest(se, t.Self.TxId, TxSelf{
 				BlockId:     t.Self.BlockId,
@@ -924,7 +931,11 @@ func (t *TxProposeBlock) ExecuteTx(se *StateEngine) {
 				Ops:  txs,
 			})
 		} else if txContainer.Type() == "output" {
-			contractOutput := txContainer.AsContractOutput()
+			contractOutput, err := txContainer.AsContractOutput()
+			if err != nil {
+				log.Error("block tx AsContractOutput failed, skipping", "id", txInfo.Id, "idx", idx, "err", err)
+				continue
+			}
 
 			contractOutput.Ingest(se, TxSelf{
 				BlockId:     t.Self.BlockId,
@@ -933,7 +944,11 @@ func (t *TxProposeBlock) ExecuteTx(se *StateEngine) {
 			}, int64(se.slotStatus.SlotHeight))
 
 		} else if txContainer.Type() == "oplog" {
-			oplog := txContainer.AsOplog(uint64(t.SignedBlock.Headers.Br[1]))
+			oplog, err := txContainer.AsOplog(uint64(t.SignedBlock.Headers.Br[1]))
+			if err != nil {
+				log.Error("block tx AsOplog failed, skipping", "id", txInfo.Id, "idx", idx, "err", err)
+				continue
+			}
 			oplog.ExecuteTx(se)
 		} else if txContainer.Type() == "pendulum_settlement" {
 			rec, ok := txContainer.AsPendulumSettlement()
@@ -1022,19 +1037,27 @@ type BlockTx struct {
 	Type int `json:"type"`
 }
 
-func (bTx *BlockTx) Decode(da *datalayer.DataLayer, txSelf TxSelf) TransactionContainer {
-	//Do some conversion back to a TX type?
-	txCid := cid.MustParse(bTx.Id)
+func (bTx *BlockTx) Decode(da *datalayer.DataLayer, txSelf TxSelf) (TransactionContainer, error) {
+	txCid, err := cid.Parse(bTx.Id)
+	if err != nil {
+		return TransactionContainer{}, fmt.Errorf("invalid tx CID %q: %w", bTx.Id, err)
+	}
 
-	dagNode, _ := da.GetDag(txCid)
+	dagNode, err := da.GetDag(txCid)
+	if err != nil {
+		return TransactionContainer{}, fmt.Errorf("GetDag failed for tx %s: %w", bTx.Id, err)
+	}
+	if dagNode == nil {
+		return TransactionContainer{}, fmt.Errorf("GetDag returned nil for tx %s", bTx.Id)
+	}
+
 	tx := TransactionContainer{
 		da:      da,
 		Id:      bTx.Id,
 		TypeInt: bTx.Type,
-
-		Self: txSelf,
+		Self:    txSelf,
 	}
 	tx.Decode(dagNode.RawData())
 
-	return tx
+	return tx, nil
 }

--- a/modules/state-processing/transactions.go
+++ b/modules/state-processing/transactions.go
@@ -930,54 +930,80 @@ func (tx *TransactionContainer) Type() string {
 }
 
 // Converts to Contract Output
-func (tx *TransactionContainer) AsContractOutput() *ContractOutput {
-	output := ContractOutput{
-		Id: tx.Id,
+func (tx *TransactionContainer) AsContractOutput() (*ContractOutput, error) {
+	txCid, err := cid.Parse(tx.Id)
+	if err != nil {
+		return nil, fmt.Errorf("invalid output CID %q: %w", tx.Id, err)
 	}
-	txCid := cid.MustParse(tx.Id)
-	dag, _ := tx.da.GetDag(txCid)
-
-	bJson, _ := dag.MarshalJSON()
-
-	json.Unmarshal(bJson, &output)
-
-	return &output
+	dag, err := tx.da.GetDag(txCid)
+	if err != nil {
+		return nil, fmt.Errorf("GetDag failed for output %s: %w", tx.Id, err)
+	}
+	if dag == nil {
+		return nil, fmt.Errorf("GetDag returned nil for output %s", tx.Id)
+	}
+	bJson, err := dag.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("MarshalJSON failed for output %s: %w", tx.Id, err)
+	}
+	output := ContractOutput{Id: tx.Id}
+	if err := json.Unmarshal(bJson, &output); err != nil {
+		return nil, fmt.Errorf("Unmarshal failed for output %s: %w", tx.Id, err)
+	}
+	return &output, nil
 }
 
 // As a regular VSC transaction
-func (tx *TransactionContainer) AsTransaction() *OffchainTransaction {
-	txCid := cid.MustParse(tx.Id)
-	dag, _ := tx.da.GetDag(txCid)
-
-	bJson, _ := dag.MarshalJSON()
-
+func (tx *TransactionContainer) AsTransaction() (*OffchainTransaction, error) {
+	txCid, err := cid.Parse(tx.Id)
+	if err != nil {
+		return nil, fmt.Errorf("invalid tx CID %q: %w", tx.Id, err)
+	}
+	dag, err := tx.da.GetDag(txCid)
+	if err != nil {
+		return nil, fmt.Errorf("GetDag failed for tx %s: %w", tx.Id, err)
+	}
+	if dag == nil {
+		return nil, fmt.Errorf("GetDag returned nil for tx %s", tx.Id)
+	}
+	bJson, err := dag.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("MarshalJSON failed for tx %s: %w", tx.Id, err)
+	}
 	offchainTx := OffchainTransaction{
 		TxId: tx.Id,
 		Self: tx.Self,
 	}
-	json.Unmarshal(bJson, &offchainTx)
-
-	return &offchainTx
+	if err := json.Unmarshal(bJson, &offchainTx); err != nil {
+		return nil, fmt.Errorf("Unmarshal failed for tx %s: %w", tx.Id, err)
+	}
+	return &offchainTx, nil
 }
 
-func (tx *TransactionContainer) AsOplog(endBlock uint64) Oplog {
-	cid := cid.MustParse(tx.Id)
-	node, err := tx.da.GetDag(cid)
-
+func (tx *TransactionContainer) AsOplog(endBlock uint64) (Oplog, error) {
+	txCid, err := cid.Parse(tx.Id)
 	if err != nil {
-		fmt.Println("AsOplog: failed to fetch DAG", "cid", tx.Id, "err", err)
-		return Oplog{Self: tx.Self, EndBlock: endBlock}
+		return Oplog{Self: tx.Self, EndBlock: endBlock}, fmt.Errorf("invalid oplog CID %q: %w", tx.Id, err)
 	}
-	jsonBytes, _ := node.MarshalJSON()
-
+	node, err := tx.da.GetDag(txCid)
+	if err != nil {
+		return Oplog{Self: tx.Self, EndBlock: endBlock}, fmt.Errorf("GetDag failed for oplog %s: %w", tx.Id, err)
+	}
+	if node == nil {
+		return Oplog{Self: tx.Self, EndBlock: endBlock}, fmt.Errorf("GetDag returned nil for oplog %s", tx.Id)
+	}
+	jsonBytes, err := node.MarshalJSON()
+	if err != nil {
+		return Oplog{Self: tx.Self, EndBlock: endBlock}, fmt.Errorf("MarshalJSON failed for oplog %s: %w", tx.Id, err)
+	}
 	oplog := Oplog{
-		Self: tx.Self,
-
+		Self:     tx.Self,
 		EndBlock: endBlock,
 	}
-	json.Unmarshal(jsonBytes, &oplog)
-
-	return oplog
+	if err := json.Unmarshal(jsonBytes, &oplog); err != nil {
+		return Oplog{Self: tx.Self, EndBlock: endBlock}, fmt.Errorf("Unmarshal failed for oplog %s: %w", tx.Id, err)
+	}
+	return oplog, nil
 }
 
 // AsPendulumSettlement decodes the SettlementRecord pointed at by this
@@ -990,12 +1016,18 @@ func (tx *TransactionContainer) AsPendulumSettlement() (pendulumsettlement.Settl
 	if tx == nil || tx.da == nil {
 		return pendulumsettlement.SettlementRecord{}, false
 	}
-	txCid := cid.MustParse(tx.Id)
-	node, err := tx.da.GetDag(txCid)
+	txCid, err := cid.Parse(tx.Id)
 	if err != nil {
 		return pendulumsettlement.SettlementRecord{}, false
 	}
-	jsonBytes, _ := node.MarshalJSON()
+	node, err := tx.da.GetDag(txCid)
+	if err != nil || node == nil {
+		return pendulumsettlement.SettlementRecord{}, false
+	}
+	jsonBytes, err := node.MarshalJSON()
+	if err != nil {
+		return pendulumsettlement.SettlementRecord{}, false
+	}
 	var rec pendulumsettlement.SettlementRecord
 	if err := json.Unmarshal(jsonBytes, &rec); err != nil {
 		return pendulumsettlement.SettlementRecord{}, false

--- a/modules/state-processing/transactions.go
+++ b/modules/state-processing/transactions.go
@@ -929,19 +929,42 @@ func (tx *TransactionContainer) Type() string {
 	}
 }
 
+// getDagOrBlock fetches the DAG node for a CID carried in a VSC block,
+// fail-stopping (blocking with capped backoff) on a fetch error instead of
+// handing it to a caller that would skip the entry. Every CID processed in the
+// block path is anchored in a 2/3-BLS-attested block, so its bytes are
+// guaranteed to propagate from the producer: a GetDag error here is a transient
+// local I/O fault, never missing or malformed payload. Returning the error so
+// the caller skips the entry would let a node with a momentary fault apply a
+// different op set than its peers and silently fork its ledger. Blocking until
+// the fetch succeeds keeps every honest node on the identical op set — the same
+// fail-stop contract as blockingRetry's DB readers. The returned node is always
+// non-nil. (A genuinely undecodable payload is deterministic and identical on
+// every node, so it would block all nodes alike — a network-wide fail-stop, not
+// a fork.)
+func getDagOrBlock(da *datalayer.DataLayer, c cid.Cid, what string) *dagCbor.Node {
+	var node *dagCbor.Node
+	blockingRetry(what, func() error {
+		var err error
+		node, err = da.GetDag(c)
+		if err != nil {
+			return err
+		}
+		if node == nil {
+			return fmt.Errorf("GetDag returned nil node for %s", c)
+		}
+		return nil
+	})
+	return node
+}
+
 // Converts to Contract Output
 func (tx *TransactionContainer) AsContractOutput() (*ContractOutput, error) {
 	txCid, err := cid.Parse(tx.Id)
 	if err != nil {
 		return nil, fmt.Errorf("invalid output CID %q: %w", tx.Id, err)
 	}
-	dag, err := tx.da.GetDag(txCid)
-	if err != nil {
-		return nil, fmt.Errorf("GetDag failed for output %s: %w", tx.Id, err)
-	}
-	if dag == nil {
-		return nil, fmt.Errorf("GetDag returned nil for output %s", tx.Id)
-	}
+	dag := getDagOrBlock(tx.da, txCid, fmt.Sprintf("GetDag(output %s)", tx.Id))
 	bJson, err := dag.MarshalJSON()
 	if err != nil {
 		return nil, fmt.Errorf("MarshalJSON failed for output %s: %w", tx.Id, err)
@@ -959,13 +982,7 @@ func (tx *TransactionContainer) AsTransaction() (*OffchainTransaction, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid tx CID %q: %w", tx.Id, err)
 	}
-	dag, err := tx.da.GetDag(txCid)
-	if err != nil {
-		return nil, fmt.Errorf("GetDag failed for tx %s: %w", tx.Id, err)
-	}
-	if dag == nil {
-		return nil, fmt.Errorf("GetDag returned nil for tx %s", tx.Id)
-	}
+	dag := getDagOrBlock(tx.da, txCid, fmt.Sprintf("GetDag(tx %s)", tx.Id))
 	bJson, err := dag.MarshalJSON()
 	if err != nil {
 		return nil, fmt.Errorf("MarshalJSON failed for tx %s: %w", tx.Id, err)
@@ -985,13 +1002,7 @@ func (tx *TransactionContainer) AsOplog(endBlock uint64) (Oplog, error) {
 	if err != nil {
 		return Oplog{Self: tx.Self, EndBlock: endBlock}, fmt.Errorf("invalid oplog CID %q: %w", tx.Id, err)
 	}
-	node, err := tx.da.GetDag(txCid)
-	if err != nil {
-		return Oplog{Self: tx.Self, EndBlock: endBlock}, fmt.Errorf("GetDag failed for oplog %s: %w", tx.Id, err)
-	}
-	if node == nil {
-		return Oplog{Self: tx.Self, EndBlock: endBlock}, fmt.Errorf("GetDag returned nil for oplog %s", tx.Id)
-	}
+	node := getDagOrBlock(tx.da, txCid, fmt.Sprintf("GetDag(oplog %s)", tx.Id))
 	jsonBytes, err := node.MarshalJSON()
 	if err != nil {
 		return Oplog{Self: tx.Self, EndBlock: endBlock}, fmt.Errorf("MarshalJSON failed for oplog %s: %w", tx.Id, err)
@@ -1007,11 +1018,12 @@ func (tx *TransactionContainer) AsOplog(endBlock uint64) (Oplog, error) {
 }
 
 // AsPendulumSettlement decodes the SettlementRecord pointed at by this
-// container's CID. Returns (record, true) on success; (zero, false) if the
-// underlying DAG fetch or decode fails. The state engine treats false as a
-// dropped settlement — the carrying block already had its CID validated by
-// 2/3 BLS aggregation, so a fetch failure indicates a local I/O issue rather
-// than malformed bytes.
+// container's CID. Returns (record, true) on success; (zero, false) only on a
+// deterministic decode failure (unparseable CID or malformed payload) that
+// every honest node skips alike. A transient DAG fetch fault is a local I/O
+// issue, not missing bytes (the carrying block had its CID validated by 2/3 BLS
+// aggregation); getDagOrBlock blocks on it rather than dropping the settlement,
+// so a momentary fault can't fork this node's ledger.
 func (tx *TransactionContainer) AsPendulumSettlement() (pendulumsettlement.SettlementRecord, bool) {
 	if tx == nil || tx.da == nil {
 		return pendulumsettlement.SettlementRecord{}, false
@@ -1020,10 +1032,7 @@ func (tx *TransactionContainer) AsPendulumSettlement() (pendulumsettlement.Settl
 	if err != nil {
 		return pendulumsettlement.SettlementRecord{}, false
 	}
-	node, err := tx.da.GetDag(txCid)
-	if err != nil || node == nil {
-		return pendulumsettlement.SettlementRecord{}, false
-	}
+	node := getDagOrBlock(tx.da, txCid, fmt.Sprintf("GetDag(pendulum-settlement %s)", tx.Id))
 	jsonBytes, err := node.MarshalJSON()
 	if err != nil {
 		return pendulumsettlement.SettlementRecord{}, false
@@ -1036,21 +1045,25 @@ func (tx *TransactionContainer) AsPendulumSettlement() (pendulumsettlement.Settl
 }
 
 // AsRestitutionClaim decodes a RestitutionClaimRecord pointed at by this
-// container's CID. Returns (record, true) on success; (zero, false) if the
-// underlying DAG fetch or decode fails. The state engine treats false as a
-// dropped op — the carrying block's 2/3 BLS aggregate already validated
-// the CID bytes, so a fetch miss indicates a local I/O issue, not
-// malformed payload.
+// container's CID. Returns (record, true) on success; (zero, false) only on a
+// deterministic decode failure (unparseable CID or malformed payload) that
+// every honest node sees identically and skips alike. A DAG *fetch* error is a
+// transient local I/O fault, not missing payload (the carrying block's 2/3 BLS
+// aggregate already validated the CID bytes); getDagOrBlock blocks on it rather
+// than skipping, so a momentary fault can't fork this node's ledger.
 func (tx *TransactionContainer) AsRestitutionClaim() (safetyslash.RestitutionClaimRecord, bool) {
 	if tx == nil || tx.da == nil {
 		return safetyslash.RestitutionClaimRecord{}, false
 	}
-	txCid := cid.MustParse(tx.Id)
-	node, err := tx.da.GetDag(txCid)
+	txCid, err := cid.Parse(tx.Id)
 	if err != nil {
 		return safetyslash.RestitutionClaimRecord{}, false
 	}
-	jsonBytes, _ := node.MarshalJSON()
+	node := getDagOrBlock(tx.da, txCid, fmt.Sprintf("GetDag(restitution %s)", tx.Id))
+	jsonBytes, err := node.MarshalJSON()
+	if err != nil {
+		return safetyslash.RestitutionClaimRecord{}, false
+	}
 	var rec safetyslash.RestitutionClaimRecord
 	if err := json.Unmarshal(jsonBytes, &rec); err != nil {
 		return safetyslash.RestitutionClaimRecord{}, false
@@ -1060,17 +1073,22 @@ func (tx *TransactionContainer) AsRestitutionClaim() (safetyslash.RestitutionCla
 
 // AsSafetySlashReverse decodes a SafetySlashReverseRecord pointed at by
 // this container's CID. Same I/O-vs-malformed-payload story as the other
-// As* helpers.
+// As* helpers: deterministic decode failures return false (every node skips
+// alike); a transient DAG fetch fault blocks via getDagOrBlock rather than
+// skipping, so it can't fork this node's ledger.
 func (tx *TransactionContainer) AsSafetySlashReverse() (safetyslash.SafetySlashReverseRecord, bool) {
 	if tx == nil || tx.da == nil {
 		return safetyslash.SafetySlashReverseRecord{}, false
 	}
-	txCid := cid.MustParse(tx.Id)
-	node, err := tx.da.GetDag(txCid)
+	txCid, err := cid.Parse(tx.Id)
 	if err != nil {
 		return safetyslash.SafetySlashReverseRecord{}, false
 	}
-	jsonBytes, _ := node.MarshalJSON()
+	node := getDagOrBlock(tx.da, txCid, fmt.Sprintf("GetDag(safetyslash-reverse %s)", tx.Id))
+	jsonBytes, err := node.MarshalJSON()
+	if err != nil {
+		return safetyslash.SafetySlashReverseRecord{}, false
+	}
 	var rec safetyslash.SafetySlashReverseRecord
 	if err := json.Unmarshal(jsonBytes, &rec); err != nil {
 		return safetyslash.SafetySlashReverseRecord{}, false

--- a/scripts/run-race-tests.sh
+++ b/scripts/run-race-tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 TEST_RESULTS_DIR="$(dirname $0)/../test-results"
-go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@v2.5.0
 go test -json -v -coverprofile="$TEST_RESULTS_DIR/race-coverage.txt" $(go list ./... | grep -v /experiments/) 2>&1 | tee "$TEST_RESULTS_DIR/go-race-test.log" | ~/go/bin/gotestfmt 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 TEST_RESULTS_DIR="$(dirname $0)/../test-results"
-go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@v2.5.0
 go test -json -v -coverprofile="$TEST_RESULTS_DIR/coverage.txt" $(go list ./... | grep -v /experiments/) 2>&1 | tee "$TEST_RESULTS_DIR/gotest.log" | ~/go/bin/gotestfmt 

--- a/scripts/view-test-results.sh
+++ b/scripts/view-test-results.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@v2.5.0
 cat $@ | ~/go/bin/gotestfmt 

--- a/tests/devnet/contracts/btc-stub/Makefile
+++ b/tests/devnet/contracts/btc-stub/Makefile
@@ -33,7 +33,7 @@ pull-tinygo:
 regen-tinyjson:
 	@if ! command -v $(TINYJSON) >/dev/null 2>&1; then \
 		echo "tinyjson not found, installing..."; \
-		go install github.com/CosmWasm/tinyjson/...@latest; \
+		go install github.com/CosmWasm/tinyjson/...@v0.9.0; \
 		echo "tinyjson installed to $$(go env GOPATH)/bin"; \
 		echo "ensure $$(go env GOPATH)/bin is on your PATH and re-run"; \
 		exit 1; \


### PR DESCRIPTION
Mechanical fixes from the Pendulum MED audit — crash prevention, error surfacing, and supply chain hardening. No protocol logic changes. No behavior changes except converting panics and nil derefs into logged errors with graceful
  degradation.

  Changes

  Supply chain pinning (3 fixes):
  - compose.yml: Pin mongo:8.0.17 and bitcoin/bitcoin:29.3 to SHA256 digests — prevents mutable-tag supply chain attacks (#129, #130, #131)
  - scripts/*.sh, btc-stub/Makefile: Pin gotestfmt@v2.5.0 and tinyjson@v0.9.0 — replaces @latest (#129)

  Crash/panic fixes (7 fixes):
  - system_txs.go: BlockTx.Decode — replace cid.MustParse with cid.Parse + error return. Also fixes nil deref on GetDag failure. Caller logs Error + continues to next tx (#114)
  - transactions.go: AsContractOutput, AsTransaction, AsOplog, AsPendulumSettlement — same cid.MustParse → cid.Parse pattern. All error paths now handled: CID parse, GetDag, nil node, MarshalJSON, Unmarshal (#115)
  - state_engine.go:1760: GetLedgerRange nil deref — error now checked, nil guard added. Balance snapshot skipped for that account with Error log including account name and block range (#118)
  - state_engine.go:1204: GetBlockByHeight error in ProcessBlock — real DB errors now logged (ErrNoDocuments filtered). Existing startBlock=0 fallback preserved (#116)
  - state_engine.go:1460: GetBlockByHeight error in ExecuteBatch — same pattern as above (#117)
  - state_engine.go:1709: GetDistinctAccountsRange error — now logged. Nil slice ranges safely over zero iterations, no behavior change (#120)

  Log level fix (1 fix):
  Known limitations introduced by these fixes

  1. Balance snapshot staleness (#118): If GetLedgerRange fails for an account, its balance snapshot is stale until the account's next ledger activity. Ledger records (source of truth) are intact. The alternative was a node crash
  affecting all accounts — strictly worse.
  2. Non-deterministic GetDag skip (#114/#115): Before these fixes, a malformed or unfetchable transaction CID in a BLS-signed block crashed all nodes deterministically. After, nodes that can't fetch the DAG data skip the transaction
  while nodes that can fetch it process it — a potential state divergence. In practice, BLS-attested blocks have their data propagated by the producer, so GetDag failures are transient I/O issues. The proper fix (halt-and-retry instead
  of skip) is a protocol-level change outside the scope of mechanical fixes.
  3. Full-range balance scan on DB error (#116/#117): When GetBlockByHeight fails in ProcessBlock or ExecuteBatch, startBlock falls back to 0, causing a full-history balance scan. This produces correct results (per-account stHeight is
  independently bounded by previous balance records) but at higher I/O cost. Existing production behavior, now with error logging.

  Deferred — separate PRs

  CVE bumps (#125, #126) — deferred because they are coupled:
  - go-ethereum v1.14.12 needs bumping to v1.16.9 for CVE-2026-26314 (ecrecover crash, CVSS 7.5). No v1.14.x backport exists. This is a 2-minor-version jump with potential API changes in trie/triedb/rawdb. Cannot verify compilation in
  WSL (missing WasmEdge C headers).
  - gnark-crypto v0.14.0 needs bumping to v0.18.1 for GHSA-fj2x-735w-74vq (vector deserialization OOM, CVSS 7.5). Cannot be bumped independently — go-kzg-4844 (transitive dep of go-ethereum v1.14.12) requires gnark-crypto v0.10.0 APIs
  that were removed in v0.18.1. Both must be bumped together.
  - The gnark-crypto vulnerability (Vector.ReadFrom) is not reachable from Magi's usage (only G1Affine.SetBytes, PairingCheck, fr.Element.SetBytes are called).

  Protocol bugs (S2, S3, #45, #123, RT-28, RT-29) — separate branch: