### PR TITLE
fix(security): cross-ref audit safety fixes — gateway auth, election-…

### DIFF
--- a/modules/election-proposer/election-proposer.go
+++ b/modules/election-proposer/election-proposer.go
@@ -878,7 +878,7 @@ func (ep *electionProposer) HoldElection(blk uint64, options ...ElectionOptions)
 			})
 		}()
 
-		ep.sigChannels[ep.signingInfo.epoch] = make(chan *signResponse)
+		ep.sigChannels[ep.signingInfo.epoch] = make(chan *signResponse, 32)
 
 		log.Info("waiting for signatures",
 			"block_height", anchorBh,

--- a/modules/election-proposer/p2p.go
+++ b/modules/election-proposer/p2p.go
@@ -58,54 +58,22 @@ func (d *electionProposer) stopP2P() error {
 	return d.service.Close()
 }
 
-// ValidateMessage implements libp2p.PubSubServiceParams.
+// ValidateMessage rejects structurally invalid messages and messages arriving
+// after the election proposer has been GC'd (prevents the weak.Pointer nil
+// deref in HandleMessage — finding W-M4). Full BLS authentication of
+// sign_response happens downstream in AddAndVerify; sign_request only
+// triggers deterministic computation guarded by epoch/existence checks.
 func (s p2pSpec) ValidateMessage(ctx context.Context, from peer.ID, msg *pubsub.Message, parsedMsg p2pMessage) bool {
-
+	if parsedMsg.Type != "sign_request" && parsedMsg.Type != "sign_response" {
+		return false
+	}
+	if parsedMsg.Op != "hold_election" {
+		return false
+	}
+	if s.electionProposer.Value() == nil {
+		return false
+	}
 	return true
-	// switch parsedMsg := parsedMsg.(type) {
-	// case p2pMessageElectionProposal:
-	// 	return s.ValidateMessage(ctx, from, msg, p2pMessageElectionProposal(parsedMsg))
-	// case p2pMessageElectionSignature:
-	// 	proposer := s.electionProposer.Value()
-	// 	if proposer == nil {
-	// 		return false
-	// 	}
-	// 	fromStr := from.String()
-	// 	res, err := proposer.witnesses.GetWitnessesByPeerId(fromStr)
-
-	// 	fmt.Println("res, err", res, err)
-	// 	if err != nil {
-	// 		return false
-	// 	}
-
-	// 	if len(res) != 1 {
-	// 		return false
-	// 	}
-
-	// 	key, err := res[0].ConsensusKey()
-	// 	fmt.Println("key, err", res, err)
-	// 	if err != nil {
-	// 		return false
-	// 	}
-
-	// 	// err = proposer.circuit.AddAndVerifyRaw(key, electionData.Signature)
-	// 	electionHeader, _, err := proposer.GenerateElection()
-
-	// 	fmt.Println("electionHeader, _, err", electionHeader, err)
-	// 	if err != nil {
-	// 		return false
-	// 	}
-
-	// 	cid, err := electionHeader.Cid()
-	// 	if err != nil {
-	// 		return false
-	// 	}
-
-	// 	// Ensure that the signature is valid.
-	// 	return blsu.Verify(key.Identifier(), cid.Bytes(), &parsedMsg.Signature)
-	// default:
-	// 	return false
-	// }
 }
 
 // HandleMessage implements libp2p.PubSubServiceParams.
@@ -116,8 +84,11 @@ func (s p2pSpec) HandleMessage(
 	send libp2p.SendFunc[p2pMessage],
 ) error {
 	ep := s.electionProposer.Value()
+	if ep == nil {
+		return nil
+	}
 	if msg.Type == "sign_request" {
-		if s.electionProposer.Value().bh == 0 {
+		if ep.bh == 0 {
 			log.Verbose("sign_request: skipping (local bh=0, not yet synced)", "from", from.String())
 			return nil
 		}
@@ -240,8 +211,11 @@ func (s p2pSpec) HandleMessage(
 
 			// err = s.electionProposer.waitCheckBh(ROTATION_INTERVAL, signResp.BlockHeight)
 
-			if ep.sigChannels[signResp.Epoch] != nil {
-				ep.sigChannels[signResp.Epoch] <- &signResp
+			if ch := ep.sigChannels[signResp.Epoch]; ch != nil {
+				select {
+				case ch <- &signResp:
+				default:
+				}
 			}
 		}
 	}

--- a/modules/gateway/multisig.go
+++ b/modules/gateway/multisig.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"vsc-node/lib/hive"
 	"vsc-node/lib/utils"
@@ -68,6 +69,9 @@ type MultiSig struct {
 	msgMu sync.Mutex
 
 	bh uint64
+
+	electionPeerIDs   atomic.Pointer[map[string]bool]
+	lastElectionEpoch uint64
 }
 
 func (ms *MultiSig) Init() error {
@@ -163,6 +167,21 @@ func (ms *MultiSig) BlockTick(bh uint64, headHeight *uint64) {
 	// bh+20 < *headHeight is the same predicate without the underflow.
 	if bh+20 < *headHeight {
 		return
+	}
+
+	if ms.electionPeerIDs.Load() == nil || bh%ACTION_INTERVAL == 0 {
+		election, err := ms.electionDb.GetElectionByHeight(bh)
+		if err == nil && election.Epoch != ms.lastElectionEpoch {
+			peerIDs := make(map[string]bool, len(election.Members))
+			for _, member := range election.Members {
+				w, _ := ms.witnessDb.GetWitnessAtHeight(member.Account, &bh)
+				if w != nil && w.PeerId != "" {
+					peerIDs[w.PeerId] = true
+				}
+			}
+			ms.electionPeerIDs.Store(&peerIDs)
+			ms.lastElectionEpoch = election.Epoch
+		}
 	}
 
 	if bh%ROTATION_INTERVAL == 0 || bh%ACTION_INTERVAL == 0 {

--- a/modules/gateway/p2p.go
+++ b/modules/gateway/p2p.go
@@ -34,9 +34,17 @@ type p2pSpec struct {
 	ms *MultiSig
 }
 
-// ValidateMessage implements libp2p.PubSubServiceParams.
-func (p2pSpec) ValidateMessage(ctx context.Context, from peer.ID, msg *pubsub.Message, parsedMsg p2pMessage) bool {
-	// Can add a blacklist for spammers or ignore previously seen messages.
+// ValidateMessage rejects sign_request messages from peers not in the current
+// election. Prevents unauthenticated peers from triggering expensive signing
+// work on every witness (finding S7).
+func (s p2pSpec) ValidateMessage(ctx context.Context, from peer.ID, msg *pubsub.Message, parsedMsg p2pMessage) bool {
+	if parsedMsg.Type == "sign_request" {
+		allowed := s.ms.electionPeerIDs.Load()
+		if allowed == nil {
+			return false
+		}
+		return (*allowed)[from.String()]
+	}
 	return true
 }
 

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -326,6 +326,9 @@ func (r *queryResolver) FindTransaction(ctx context.Context, filterOptions *Tran
 	if paginateErr != nil {
 		return nil, paginateErr
 	}
+	if err := ValidateBlockRange(filterOptions.FromBlock, filterOptions.ToBlock); err != nil {
+		return nil, err
+	}
 
 	return r.Transactions.FindTransactions(filterOptions.ByIds, filterOptions.ByID, filterOptions.ByAccount, filterOptions.ByContract, filterOptions.ByStatus, filterOptions.ByType, filterOptions.ByLedgerToFrom, filterOptions.ByLedgerTypes, (*uint64)(filterOptions.FromBlock), (*uint64)(filterOptions.ToBlock), offset, limit)
 }
@@ -338,6 +341,9 @@ func (r *queryResolver) FindContractOutput(ctx context.Context, filterOptions *C
 	offset, limit, paginateErr := Paginate(filterOptions.Offset, filterOptions.Limit)
 	if paginateErr != nil {
 		return nil, paginateErr
+	}
+	if err := ValidateBlockRange(filterOptions.FromBlock, filterOptions.ToBlock); err != nil {
+		return nil, err
 	}
 	return r.ContractsState.FindOutputs(filterOptions.ByID, filterOptions.ByInput, filterOptions.ByContract, (*uint64)(filterOptions.FromBlock), (*uint64)(filterOptions.ToBlock), offset, limit)
 }
@@ -354,6 +360,9 @@ func (r *queryResolver) FindLedgerTXs(ctx context.Context, filterOptions *Ledger
 	if filterOptions.ByTxID != nil && utf8.RuneCountInString(*filterOptions.ByTxID) < 40 {
 		return nil, fmt.Errorf("invalid tx id")
 	}
+	if err := ValidateBlockRange(filterOptions.FromBlock, filterOptions.ToBlock); err != nil {
+		return nil, err
+	}
 	return r.Ledger.GetLedgersTsRange(filterOptions.ByToFrom, filterOptions.ByTxID, filterOptions.ByTypes, filterOptions.ByAsset, (*uint64)(filterOptions.FromBlock), (*uint64)(filterOptions.ToBlock), offset, limit)
 }
 
@@ -368,6 +377,9 @@ func (r *queryResolver) FindLedgerActions(ctx context.Context, filterOptions *Le
 	}
 	if filterOptions.ByTxID != nil && utf8.RuneCountInString(*filterOptions.ByTxID) < 40 {
 		return nil, fmt.Errorf("invalid tx id")
+	}
+	if err := ValidateBlockRange(filterOptions.FromBlock, filterOptions.ToBlock); err != nil {
+		return nil, err
 	}
 	return r.Actions.GetActionsRange(filterOptions.ByTxID, filterOptions.ByActionID, filterOptions.ByAccount, filterOptions.ByTypes, filterOptions.ByAsset, filterOptions.ByStatus, (*uint64)(filterOptions.FromBlock), (*uint64)(filterOptions.ToBlock), offset, limit)
 }
@@ -671,6 +683,9 @@ func (r *queryResolver) FindLedgerClaims(ctx context.Context, filterOptions *Led
 	if err != nil {
 		return nil, err
 	}
+	if err := ValidateBlockRange(filterOptions.FromBlock, filterOptions.ToBlock); err != nil {
+		return nil, err
+	}
 	return r.InterestClaims.FindClaims((*uint64)(filterOptions.FromBlock), (*uint64)(filterOptions.ToBlock), offset, limit)
 }
 
@@ -681,6 +696,9 @@ func (r *queryResolver) FindTssCommitments(ctx context.Context, filterOptions *T
 	}
 	off, lim, err := Paginate(filterOptions.Offset, filterOptions.Limit)
 	if err != nil {
+		return nil, err
+	}
+	if err := ValidateBlockRange(filterOptions.FromBlock, filterOptions.ToBlock); err != nil {
 		return nil, err
 	}
 	return r.TssCommitments.FindCommitments(filterOptions.ByKeyID, filterOptions.ByTypes, (*uint64)(filterOptions.ByEpoch), (*uint64)(filterOptions.FromBlock), (*uint64)(filterOptions.ToBlock), off, lim)

--- a/modules/gql/gqlgen/utils.go
+++ b/modules/gql/gqlgen/utils.go
@@ -27,6 +27,16 @@ func Paginate(offset *int, limit *int) (int, int, error) {
 	return offset_result, limit_result, nil
 }
 
+// ValidateBlockRange returns an error if both fromBlock and toBlock are
+// provided and fromBlock > toBlock. Without this check the DB query silently
+// returns an empty result set (MongoDB $gte/$lte on an impossible range).
+func ValidateBlockRange(fromBlock *model.Uint64, toBlock *model.Uint64) error {
+	if fromBlock != nil && toBlock != nil && *fromBlock > *toBlock {
+		return fmt.Errorf("fromBlock (%d) must not exceed toBlock (%d)", *fromBlock, *toBlock)
+	}
+	return nil
+}
+
 // Parse optional height, falling back to math.MaxInt64 if not specified
 func ParseHeight(height *model.Uint64) uint64 {
 	var blockHeight uint64 = math.MaxInt64


### PR DESCRIPTION
- Gateway sign_request authentication (S7 HIGH): ValidateMessage now rejects sign_request messages from peers not in
  the current election. Prevents unauthenticated peers from triggering expensive signing work on every witness. Uses an
  atomic.Pointer cache of election member peer IDs, rebuilt from the election DB on epoch change. Fail-closed when cache
   is nil (node syncing).
  - Election-proposer hardening (W-M4 + WM-M7): ValidateMessage rejects structurally invalid messages and prevents
  weak.Pointer nil deref (W-M4). HandleMessage nil-guards the ep pointer and uses ep.bh instead of a redundant Value()
  call (TOCTOU fix). Channel send made non-blocking to prevent goroutine/semaphore leak under load. Signature collection
   channel buffered to 32.
  - GQL block range validation (M-5): New ValidateBlockRange helper returns an error when fromBlock > toBlock. Applied
  to all 6 resolvers that accept block range filters. Previously returned silent empty results.

  Test plan

  - TestTSSReshareHappyPath — 5-node devnet, full keygen + reshare cycle (318s)
  - TestBlameExcludesNodeOnRetry — partition + blame + reshare recovery (575s)
  - TestEdgeLeaderCrashDuringBLS — leader crash mid-BLS collection (807s)
  - TestEdgeNodeRestartMidCycle — node restart + nil-cache sync window (677s)
  - gofmt -e clean on all 6 files
  - 5-agent adversarial review (Trail of Bits style) — 0 ship-blockers remaining