### PR TITLE
fix(security): reject malformed pipe-delimited PendingSpend (W-L12)

### DIFF
--- a/cmd/evm-mapping-bot/main.go
+++ b/cmd/evm-mapping-bot/main.go
@@ -798,7 +798,7 @@ type PendingSpend struct {
 
 func parsePendingSpend(nonce uint64, raw string) *PendingSpend {
 	fields := strings.Split(raw, "|")
-	if len(fields) < 6 {
+	if len(fields) != 7 {
 		return nil
 	}
 	ps := &PendingSpend{Nonce: nonce}


### PR DESCRIPTION
## Summary

  - `parsePendingSpend` now rejects any pipe-delimited string that doesn't have exactly 7 fields. The contract's
  `StorePendingSpend` always writes 7 fields (From|To|Asset|Amount|UnsignedTxHex|BlockHeight|TokenAddress). The old
  `len(fields) < 6` check accepted 8+ fields, meaning a token symbol containing `|` would shift all parsed fields —
  wrong amount, wrong address, wrong tx hex.

  ## Test plan

  - [x] Existing `TestSecurityAttack1_ParsePendingSpend_ExtraFields` covers this case
  - [x] Contract git history confirms 7 fields since seed commit (`1e2bfdc`)