### PR TITLE
Apply F1-F7 fixes scoped to go-vsc-node only

### DIFF
--- a/lib/dids/eth.go
+++ b/lib/dids/eth.go
@@ -523,9 +523,11 @@ func (e *EthProvider) Sign(block blocks.Block) (string, error) {
 	}
 
 	dataHash, err := computeEIP712Hash(payload.Data)
+	if err != nil {
+		return "", fmt.Errorf("failed to compute EIP-712 hash: %v", err)
+	}
 
 	sig, err := ethCrypto.Sign(dataHash, e.Priv)
-
 	if err != nil {
 		return "", fmt.Errorf("failed to sign data hash: %v", err)
 	}

--- a/modules/gateway/multisig.go
+++ b/modules/gateway/multisig.go
@@ -259,7 +259,7 @@ func (ms *MultiSig) TickKeyRotation(bh uint64) {
 		tx.AddSig(sig)
 	}
 
-	if weight == uint64(threshold) {
+	if weight >= uint64(threshold) {
 		rotationId, err := ms.hiveCreator.Broadcast(tx)
 
 		fmt.Println("Rotation txId", rotationId, err)
@@ -314,7 +314,7 @@ func (ms *MultiSig) TickActions(bh uint64) {
 		tx.AddSig(sig)
 	}
 
-	if weight == uint64(threshold) {
+	if weight >= uint64(threshold) {
 		rotationId, err := ms.hiveCreator.Broadcast(tx)
 
 		fmt.Println("Actions txId", rotationId, err)
@@ -369,7 +369,7 @@ func (ms *MultiSig) TickSyncFr(bh uint64) {
 		tx.AddSig(sig)
 	}
 
-	if weight == uint64(threshold) {
+	if weight >= uint64(threshold) {
 		rotationId, err := ms.hiveCreator.Broadcast(tx)
 
 		fmt.Println("SyncFr txId", rotationId, err)


### PR DESCRIPTION
review5-fixes-for-tibfox 2026-05-31 was a 5-fix follow-up review. Only 2 of the 5 land on a clean upstream/develop base in this repo:

F7 (small) — lib/dids/eth.go EthDID.Sign called computeEIP712Hash then immediately ethCrypto.Sign without checking the first err. The vars were shadowed (`dataHash, err := ...`, then `sig, err := ...`), so a hash- compute failure would proceed to sign nil/garbage. Now checks the first err.

Gateway broadcast gate >= (still-open minor from the same review round) — TickKeyRotation / TickActions / TickSyncFr broadcast on `weight == uint64(threshold)`. Fine under unit weights, fragile under stake- weighted: a signer of weight 2 can push from threshold-1 to threshold+1, skipping the equality and never broadcasting. `>=` fires on first cross. 3 sites in modules/gateway/multisig.go.

Other wetransfer fixes — why not in this commit:

- F1 (zk-header propose/execute timelock) — lives in zk-header-verifier repo, applied there at tibfox/review5 26a9ac3.
- F2 monitor side — lives in account-mapping repo, applied there at tibfox/review5 12678a2.
- F2 bot side — would touch cmd/evm-mapping-bot/main.go, but that directory does not exist on upstream/develop (the bot lives on the feature/evm-mapping-bot branch). Needs to ride alongside whatever brings the bot onto develop.
- F3 (account-mapping expireWithdrawal proof mandatory) — lives in account-mapping repo, applied there at tibfox/review5 12678a2.
- F4 (gateway dedup by signer-index, not bytes) — upstream/develop already has the equivalent dedup via signedByPubKey at multisig.go:868 and IsLowS rejection in RecoverPublicKey. Applying F4 on top would duplicate the invariant.

Build: lib/dids + modules/gateway clean; full ./... has only the three pre-existing develop bugs (oracle/threadsafe, env_tinyjson, wasm/e2e runtime build constraints) — not regressions.