### PR TITLE
review5 evm-mapping-bot integration

### DIFF
--- a/cmd/evm-mapping-bot/main.go
+++ b/cmd/evm-mapping-bot/main.go
@@ -1,0 +1,1934 @@
+package main
+
+// EVM Mapping Bot — standalone runner for Ethereum deposit scanning,
+// withdrawal TX assembly, broadcast, and confirmSpend submission.
+//
+// Uses go-vsc-node's transaction-pool and dids packages for L2 submission.
+// Signs transactions with an secp256k1 key (BOT_ETH_PRIVKEY env var).
+//
+// Usage:
+//   evm-mapping-bot  (configure via env vars)
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"vsc-node/lib/dids"
+	"vsc-node/modules/db/vsc/contracts"
+	transactionpool "vsc-node/modules/transaction-pool"
+
+	ethCrypto "github.com/ethereum/go-ethereum/crypto"
+	"golang.org/x/crypto/sha3"
+)
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+type EVMBotConfig struct {
+	EthRPC         string
+	VaultAddress   string            // 0x... lowercase
+	Tokens         map[string]string // address → symbol (lowercase keys)
+	ContractID     string
+	GraphQLURLs    []string
+	PollInterval   time.Duration
+	Network        string
+	CheckpointFile string
+	NetID          string // vsc-mainnet or vsc-testnet
+	RcLimit        uint64
+}
+
+// l2Submitter handles L2 transaction signing and submission.
+type l2Submitter struct {
+	ethKey *ecdsa.PrivateKey
+	did    dids.EthDID
+	gql    *vscGraphQL
+	cfg    EVMBotConfig
+	mu     sync.Mutex // serializes L2 submissions for nonce ordering
+}
+
+func main() {
+	cfg := parseConfig()
+
+	// Initialize L2 signing key
+	ethKey, did := initEthKey()
+
+	slog.Info("evm-mapping-bot starting",
+		"rpc", cfg.EthRPC,
+		"vault", cfg.VaultAddress,
+		"contract", cfg.ContractID,
+		"tokens", len(cfg.Tokens),
+		"network", cfg.Network,
+		"netId", cfg.NetID,
+		"did", did.String(),
+	)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	if err := RunLoop(ctx, cfg, ethKey, did); err != nil && err != context.Canceled {
+		slog.Error("bot exited with error", "err", err)
+		os.Exit(1)
+	}
+	slog.Info("bot shut down cleanly")
+}
+
+func parseConfig() EVMBotConfig {
+	rcLimit := uint64(10000)
+	if v := os.Getenv("RC_LIMIT"); v != "" {
+		if parsed, err := strconv.ParseUint(v, 10, 64); err == nil {
+			rcLimit = parsed
+		}
+	}
+
+	cfg := EVMBotConfig{
+		EthRPC:         envOrDefault("ETH_RPC", "http://localhost:8545"),
+		VaultAddress:   strings.ToLower(envOrDefault("VAULT_ADDRESS", "")),
+		ContractID:     envOrDefault("CONTRACT_ID", ""),
+		PollInterval:   12 * time.Second,
+		Network:        envOrDefault("NETWORK", "mainnet"),
+		Tokens:         map[string]string{},
+		GraphQLURLs:    strings.Split(envOrDefault("GRAPHQL_URLS", "https://api.vsc.eco/api/v1/graphql"), ","),
+		CheckpointFile: envOrDefault("CHECKPOINT_FILE", "evm-bot-checkpoint.json"),
+		NetID:          envOrDefault("NET_ID", "vsc-mainnet"),
+		RcLimit:        rcLimit,
+	}
+
+	if cfg.Network == "mainnet" {
+		cfg.Tokens["0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"] = "usdc"
+	}
+
+	if cfg.VaultAddress == "" || cfg.ContractID == "" {
+		slog.Error("VAULT_ADDRESS and CONTRACT_ID must be set")
+		os.Exit(1)
+	}
+
+	return cfg
+}
+
+// initEthKey loads or generates the secp256k1 private key for L2 signing.
+func initEthKey() (*ecdsa.PrivateKey, dids.EthDID) {
+	keyHex := os.Getenv("BOT_ETH_PRIVKEY")
+	if keyHex != "" {
+		priv, err := ethCrypto.HexToECDSA(keyHex)
+		if err != nil {
+			slog.Error("invalid BOT_ETH_PRIVKEY", "err", err)
+			os.Exit(1)
+		}
+		addr := ethCrypto.PubkeyToAddress(priv.PublicKey).Hex()
+		did := dids.NewEthDID(addr)
+		slog.Info("loaded L2 signing key from BOT_ETH_PRIVKEY", "did", did.String())
+		return priv, did
+	}
+
+	// Auto-generate
+	priv, err := ethCrypto.GenerateKey()
+	if err != nil {
+		slog.Error("failed to generate signing key", "err", err)
+		os.Exit(1)
+	}
+	addr := ethCrypto.PubkeyToAddress(priv.PublicKey).Hex()
+	did := dids.NewEthDID(addr)
+	privHex := hex.EncodeToString(ethCrypto.FromECDSA(priv))
+	slog.Warn("generated new L2 signing key — fund this DID with HBD before the bot can submit transactions",
+		"did", did.String(),
+		"privkey_hex", privHex,
+	)
+	slog.Warn("set BOT_ETH_PRIVKEY to persist this key across restarts")
+	return priv, did
+}
+
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoint — persists last scanned block + sent withdrawal TXs to disk.
+// On restart, the bot resumes from its last checkpoint. Deposits already
+// submitted are idempotent (contract's o-{height} observed list deduplicates).
+// ---------------------------------------------------------------------------
+
+type Checkpoint struct {
+	LastScannedBlock uint64            `json:"last_scanned_block"`
+	SentWithdrawals  map[string]SentTx `json:"sent_withdrawals"`
+	BlockRetries     map[uint64]int    `json:"block_retries,omitempty"`
+	mu               sync.Mutex
+}
+
+const blockRetryAlertThreshold = 10
+
+type SentTx struct {
+	SignedTxHex string `json:"signed_tx_hex"`
+	TxHash      string `json:"tx_hash"`
+	Nonce       uint64 `json:"nonce"`
+	SentAt      int64  `json:"sent_at"`
+}
+
+func loadCheckpoint(path string) *Checkpoint {
+	cp := &Checkpoint{
+		SentWithdrawals: make(map[string]SentTx),
+		BlockRetries:    make(map[uint64]int),
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cp
+	}
+	json.Unmarshal(data, cp)
+	if cp.SentWithdrawals == nil {
+		cp.SentWithdrawals = make(map[string]SentTx)
+	}
+	if cp.BlockRetries == nil {
+		cp.BlockRetries = make(map[uint64]int)
+	}
+	return cp
+}
+
+func (cp *Checkpoint) save(path string) {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	data, err := json.MarshalIndent(cp, "", "  ")
+	if err != nil {
+		slog.Error("checkpoint marshal failed", "err", err)
+		return
+	}
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+		slog.Error("checkpoint write failed", "path", tmpPath, "err", err)
+		return
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		slog.Error("checkpoint rename failed", "err", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Ethereum RPC client — thin wrapper for JSON-RPC calls.
+// ---------------------------------------------------------------------------
+
+type ethRPC struct {
+	url    string
+	client *http.Client
+}
+
+func newEthRPC(url string) *ethRPC {
+	return &ethRPC{url: url, client: &http.Client{Timeout: 30 * time.Second}}
+}
+
+func (e *ethRPC) call(method string, params string) (json.RawMessage, error) {
+	body := fmt.Sprintf(`{"jsonrpc":"2.0","method":"%s","params":[%s],"id":1}`, method, params)
+	resp, err := e.client.Post(e.url, "application/json", strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+
+	var result struct {
+		Result json.RawMessage        `json:"result"`
+		Error  *struct{ Message string } `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("malformed rpc response: %w", err)
+	}
+	if result.Error != nil {
+		return nil, fmt.Errorf("rpc error: %s", result.Error.Message)
+	}
+	if result.Result == nil || string(result.Result) == "null" {
+		return nil, fmt.Errorf("null result from %s", method)
+	}
+	return result.Result, nil
+}
+
+func (e *ethRPC) getFinalizedBlock() (uint64, error) {
+	data, err := e.call("eth_getBlockByNumber", `"finalized", false`)
+	if err != nil {
+		return 0, err
+	}
+	var block struct {
+		Number string `json:"number"`
+	}
+	json.Unmarshal(data, &block)
+	return hexToUint64(block.Number), nil
+}
+
+func (e *ethRPC) getBlockWithTxs(height uint64) (json.RawMessage, error) {
+	return e.call("eth_getBlockByNumber", fmt.Sprintf(`"0x%x", true`, height))
+}
+
+func (e *ethRPC) getReceipt(txHash string) (json.RawMessage, error) {
+	return e.call("eth_getTransactionReceipt", fmt.Sprintf(`"%s"`, txHash))
+}
+
+func (e *ethRPC) broadcastTx(signedTxHex string) (string, error) {
+	data, err := e.call("eth_sendRawTransaction", fmt.Sprintf(`"0x%s"`, signedTxHex))
+	if err != nil {
+		return "", err
+	}
+	var txHash string
+	json.Unmarshal(data, &txHash)
+	return txHash, nil
+}
+
+// ---------------------------------------------------------------------------
+// VSC GraphQL client — queries contract state and submits L2 transactions.
+// ---------------------------------------------------------------------------
+
+type vscGraphQL struct {
+	urls   []string
+	client *http.Client
+}
+
+func newVSCGraphQL(urls []string) *vscGraphQL {
+	return &vscGraphQL{urls: urls, client: &http.Client{Timeout: 30 * time.Second}}
+}
+
+func (g *vscGraphQL) query(ctx context.Context, gqlQuery string, variables map[string]interface{}) (json.RawMessage, error) {
+	body, _ := json.Marshal(map[string]interface{}{
+		"query":     gqlQuery,
+		"variables": variables,
+	})
+
+	var lastErr error
+	for _, url := range g.urls {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := g.client.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		raw, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			lastErr = fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
+			continue
+		}
+
+		var result struct {
+			Data   json.RawMessage `json:"data"`
+			Errors []struct {
+				Message string `json:"message"`
+			} `json:"errors"`
+		}
+		if err := json.Unmarshal(raw, &result); err != nil {
+			lastErr = fmt.Errorf("decode: %w", err)
+			continue
+		}
+		if len(result.Errors) > 0 {
+			return nil, fmt.Errorf("graphql error: %s", result.Errors[0].Message)
+		}
+		return result.Data, nil
+	}
+	return nil, fmt.Errorf("all graphql endpoints failed: %w", lastErr)
+}
+
+// fetchContractState reads keys from the EVM mapping contract's state.
+func (g *vscGraphQL) fetchContractState(ctx context.Context, contractID string, keys []string) (map[string]string, error) {
+	data, err := g.query(ctx,
+		`query GetState($contractId: String!, $keys: [String!]!, $encoding: String) {
+			getStateByKeys(contractId: $contractId, keys: $keys, encoding: $encoding)
+		}`,
+		map[string]interface{}{
+			"contractId": contractID,
+			"keys":       keys,
+			"encoding":   "raw",
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var parsed struct {
+		GetStateByKeys json.RawMessage `json:"getStateByKeys"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return nil, fmt.Errorf("decode state: %w", err)
+	}
+
+	result := make(map[string]string)
+
+	var obj map[string]string
+	if json.Unmarshal(parsed.GetStateByKeys, &obj) == nil {
+		return obj, nil
+	}
+
+	var arr []string
+	if json.Unmarshal(parsed.GetStateByKeys, &arr) == nil {
+		for i, v := range arr {
+			if i < len(keys) {
+				result[keys[i]] = v
+			}
+		}
+		return result, nil
+	}
+
+	return result, nil
+}
+
+// fetchTssSignatures queries getTssRequests for completed signatures.
+func (g *vscGraphQL) fetchTssSignatures(ctx context.Context, keyID string, msgHexList []string) (map[string]TssSignature, error) {
+	data, err := g.query(ctx,
+		`query GetTssRequests($keyId: String!, $msgHex: [String!]!) {
+			getTssRequests(keyId: $keyId, msgHex: $msgHex) {
+				msg
+				sig
+				status
+			}
+		}`,
+		map[string]interface{}{
+			"keyId":  keyID,
+			"msgHex": msgHexList,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var parsed struct {
+		GetTssRequests []struct {
+			Msg    string `json:"msg"`
+			Sig    string `json:"sig"`
+			Status string `json:"status"`
+		} `json:"getTssRequests"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return nil, fmt.Errorf("decode tss: %w", err)
+	}
+
+	out := make(map[string]TssSignature)
+	for _, r := range parsed.GetTssRequests {
+		if r.Status != "complete" {
+			continue
+		}
+		sigBytes, err := hex.DecodeString(r.Sig)
+		if err != nil {
+			slog.Warn("invalid signature hex from TSS", "msg", r.Msg, "err", err)
+			continue
+		}
+		out[r.Msg] = TssSignature{Bytes: sigBytes}
+	}
+	return out, nil
+}
+
+type TssSignature struct {
+	Bytes []byte
+}
+
+// FetchAccountNonce queries the VSC node for the next unused nonce of a given
+// account (did:pkh:eip155:1:0x...). Used as the nonce header on L2 txs.
+func (g *vscGraphQL) FetchAccountNonce(ctx context.Context, account string) (uint64, error) {
+	reqBody, _ := json.Marshal(map[string]any{
+		"query":     `query($a: String!){ getAccountNonce(account: $a){ nonce } }`,
+		"variables": map[string]any{"a": account},
+	})
+
+	var lastErr error
+	for _, url := range g.urls {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := g.client.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		raw, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			lastErr = fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
+			continue
+		}
+
+		var result struct {
+			Data struct {
+				GetAccountNonce struct {
+					Nonce uint64 `json:"nonce"`
+				} `json:"getAccountNonce"`
+			} `json:"data"`
+			Errors []struct {
+				Message string `json:"message"`
+			} `json:"errors"`
+		}
+		if err := json.Unmarshal(raw, &result); err != nil {
+			lastErr = fmt.Errorf("decode nonce: %w", err)
+			continue
+		}
+		if len(result.Errors) > 0 {
+			return 0, fmt.Errorf("graphql error: %s", result.Errors[0].Message)
+		}
+		return result.Data.GetAccountNonce.Nonce, nil
+	}
+	return 0, fmt.Errorf("all graphql endpoints failed (FetchAccountNonce): %w", lastErr)
+}
+
+// SubmitTransactionV1 submits a signed VSC L2 transaction via the node's
+// submitTransactionV1 mutation and returns the resulting CID tx ID.
+func (g *vscGraphQL) SubmitTransactionV1(ctx context.Context, txB64, sigB64 string) (string, error) {
+	reqBody, _ := json.Marshal(map[string]any{
+		"query":     `query($tx: String!, $sig: String!){ submitTransactionV1(tx: $tx, sig: $sig){ id } }`,
+		"variables": map[string]any{"tx": txB64, "sig": sigB64},
+	})
+
+	var lastErr error
+	for _, url := range g.urls {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := g.client.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		raw, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			lastErr = fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
+			continue
+		}
+
+		var result struct {
+			Data struct {
+				SubmitTransactionV1 struct {
+					ID *string `json:"id"`
+				} `json:"submitTransactionV1"`
+			} `json:"data"`
+			Errors []struct {
+				Message string `json:"message"`
+			} `json:"errors"`
+		}
+		if err := json.Unmarshal(raw, &result); err != nil {
+			lastErr = fmt.Errorf("decode submit: %w", err)
+			continue
+		}
+		if len(result.Errors) > 0 {
+			return "", fmt.Errorf("graphql error: %s", result.Errors[0].Message)
+		}
+		if result.Data.SubmitTransactionV1.ID == nil {
+			return "", fmt.Errorf("submitTransactionV1 returned nil id")
+		}
+		return *result.Data.SubmitTransactionV1.ID, nil
+	}
+	return "", fmt.Errorf("all graphql endpoints failed (SubmitTransactionV1): %w", lastErr)
+}
+
+// ---------------------------------------------------------------------------
+// L2 contract call — mirrors mapper.Bot.callContractL2
+// ---------------------------------------------------------------------------
+
+// callContractL2 submits a vsc.call contract invocation through the VSC L2
+// transaction pool using the bot's did:pkh:eip155 identity.
+func (s *l2Submitter) callContractL2(
+	ctx context.Context,
+	contractID string,
+	action string,
+	payload json.RawMessage,
+) (string, error) {
+	// Serialize concurrent L2 submissions for nonce ordering.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	did := s.did
+
+	nonce, err := s.gql.FetchAccountNonce(ctx, did.String())
+	if err != nil {
+		return "", fmt.Errorf("fetch L2 nonce: %w", err)
+	}
+
+	rcLimit := s.cfg.RcLimit
+	call := &transactionpool.VscContractCall{
+		ContractId: contractID,
+		Action:     action,
+		Payload:    string(payload),
+		RcLimit:    uint(rcLimit),
+		Intents:    []contracts.Intent{},
+		Caller:     did.String(),
+		NetId:      s.cfg.NetID,
+	}
+	op, err := call.SerializeVSC()
+	if err != nil {
+		return "", fmt.Errorf("serialize L2 op: %w", err)
+	}
+
+	vscTx := transactionpool.VSCTransaction{
+		Ops:     []transactionpool.VSCTransactionOp{op},
+		Nonce:   nonce,
+		NetId:   s.cfg.NetID,
+		RcLimit: rcLimit,
+	}
+
+	crafter := transactionpool.TransactionCrafter{
+		Identity: dids.NewEthProvider(s.ethKey),
+		Did:      did,
+	}
+	sTx, err := crafter.SignFinal(vscTx)
+	if err != nil {
+		return "", fmt.Errorf("sign L2 tx: %w", err)
+	}
+
+	if len(sTx.Tx) > transactionpool.MAX_TX_SIZE {
+		slog.Error("L2 transaction exceeds maximum size",
+			"action", action,
+			"cbor_size", len(sTx.Tx),
+			"limit", transactionpool.MAX_TX_SIZE,
+		)
+		return "", fmt.Errorf("L2 tx too large: %d bytes (limit %d)", len(sTx.Tx), transactionpool.MAX_TX_SIZE)
+	}
+
+	txID, err := s.gql.SubmitTransactionV1(
+		ctx,
+		base64.URLEncoding.EncodeToString(sTx.Tx),
+		base64.URLEncoding.EncodeToString(sTx.Sig),
+	)
+	if err != nil {
+		return "", fmt.Errorf("broadcast L2 tx: %w", err)
+	}
+
+	slog.Info("L2 tx broadcast",
+		"id", txID,
+		"action", action,
+		"nonce", nonce,
+		"cbor_size", len(sTx.Tx),
+		"did", did.String(),
+	)
+	return txID, nil
+}
+
+// callWithRetry submits an L2 contract call with retry logic.
+// Retries up to maxAttempts times on broadcast failure with exponential backoff.
+func (s *l2Submitter) callWithRetry(
+	ctx context.Context,
+	contractID string,
+	action string,
+	payload json.RawMessage,
+	maxAttempts int,
+) error {
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		_, err := s.callContractL2(ctx, contractID, action, payload)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		slog.Warn("L2 submission failed",
+			"action", action,
+			"attempt", attempt,
+			"maxAttempts", maxAttempts,
+			"err", err,
+		)
+		if attempt < maxAttempts {
+			backoff := time.Duration(attempt) * 2 * time.Second
+			select {
+			case <-time.After(backoff):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+	return fmt.Errorf("all %d L2 submission attempts failed: %w", maxAttempts, lastErr)
+}
+
+// ---------------------------------------------------------------------------
+// Deposit scanning
+// ---------------------------------------------------------------------------
+
+// TransferEventSig is keccak256("Transfer(address,address,uint256)")
+const TransferEventSig = "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+
+type detectedDeposit struct {
+	BlockHeight  uint64
+	TxIndex      int
+	LogIndex     int    // -1 for native ETH
+	TxHash       string
+	DepositType  string // "eth" or "erc20"
+	TokenAddress string
+}
+
+type blockScanResult struct {
+	Deposits []detectedDeposit
+	BlockRaw json.RawMessage // full block JSON for proof construction
+}
+
+func scanBlock(rpc *ethRPC, height uint64, vaultAddr string, tokens map[string]string) (*blockScanResult, error) {
+	blockHex := fmt.Sprintf("0x%x", height)
+	blockData, err := rpc.call("eth_getBlockByNumber", fmt.Sprintf(`"%s", true`, blockHex))
+	if err != nil {
+		return nil, fmt.Errorf("fetch block %d: %w", height, err)
+	}
+
+	var block struct {
+		Transactions []struct {
+			Hash  string `json:"hash"`
+			From  string `json:"from"`
+			To    string `json:"to"`
+			Value string `json:"value"`
+		} `json:"transactions"`
+	}
+	if err := json.Unmarshal(blockData, &block); err != nil {
+		return nil, fmt.Errorf("parse block %d: %w", height, err)
+	}
+
+	result := &blockScanResult{BlockRaw: blockData}
+	vaultLower := strings.ToLower(vaultAddr)
+
+	// Detect ETH deposits: direct transfers to vault
+	for i, tx := range block.Transactions {
+		if strings.ToLower(tx.To) == vaultLower && hexToUint64(tx.Value) > 0 {
+			result.Deposits = append(result.Deposits, detectedDeposit{
+				BlockHeight: height,
+				TxIndex:     i,
+				LogIndex:    -1,
+				TxHash:      tx.Hash,
+				DepositType: "eth",
+			})
+		}
+	}
+
+	// Detect ERC-20 deposits: Transfer events to vault
+	for tokenAddr := range tokens {
+		vaultPadded := "0x000000000000000000000000" + strings.TrimPrefix(vaultLower, "0x")
+		logsParams := fmt.Sprintf(
+			`{"fromBlock":"0x%x","toBlock":"0x%x","address":"%s","topics":["0x%s",null,"%s"]}`,
+			height, height, tokenAddr, TransferEventSig, vaultPadded,
+		)
+		logsData, err := rpc.call("eth_getLogs", logsParams)
+		if err != nil {
+			slog.Warn("eth_getLogs failed", "token", tokenAddr, "block", height, "err", err)
+			continue
+		}
+
+		var logs []struct {
+			TransactionIndex string `json:"transactionIndex"`
+			TransactionHash  string `json:"transactionHash"`
+			LogIndex         string `json:"logIndex"`
+		}
+		json.Unmarshal(logsData, &logs)
+
+		for _, log := range logs {
+			result.Deposits = append(result.Deposits, detectedDeposit{
+				BlockHeight:  height,
+				TxIndex:      int(hexToUint64(log.TransactionIndex)),
+				LogIndex:     int(hexToUint64(log.LogIndex)),
+				TxHash:       log.TransactionHash,
+				DepositType:  "erc20",
+				TokenAddress: tokenAddr,
+			})
+		}
+	}
+
+	return result, nil
+}
+
+// buildMapPayload constructs the JSON for a "map" contract call.
+func buildMapPayload(deposit detectedDeposit, receiptRLP []byte, proofNodes [][]byte) json.RawMessage {
+	proofHex := ""
+	for _, node := range proofNodes {
+		proofHex += hex.EncodeToString(node)
+	}
+
+	txData := map[string]interface{}{
+		"block_height":     deposit.BlockHeight,
+		"tx_index":         deposit.TxIndex,
+		"raw_hex":          hex.EncodeToString(receiptRLP),
+		"merkle_proof_hex": proofHex,
+		"deposit_type":     deposit.DepositType,
+	}
+	if deposit.DepositType == "erc20" {
+		txData["log_index"] = deposit.LogIndex
+		txData["token_address"] = deposit.TokenAddress
+	}
+
+	payload := map[string]interface{}{
+		"tx_data":      txData,
+		"instructions": []string{},
+	}
+	data, _ := json.Marshal(payload)
+	return data
+}
+
+// ---------------------------------------------------------------------------
+// Withdrawal pipeline — getTssRequests → AttachSignature → broadcast
+// ---------------------------------------------------------------------------
+
+// PendingSpend mirrors the contract's PendingSpend stored at state key d-{nonce}.
+type PendingSpend struct {
+	Nonce         uint64
+	From          string
+	To            string
+	Asset         string
+	Amount        int64
+	UnsignedTxHex string
+	BlockHeight   uint64
+	TokenAddress  string
+}
+
+func parsePendingSpend(nonce uint64, raw string) *PendingSpend {
+	fields := strings.Split(raw, "|")
+	if len(fields) < 6 {
+		return nil
+	}
+	ps := &PendingSpend{Nonce: nonce}
+	ps.From = fields[0]
+	ps.To = fields[1]
+	ps.Asset = fields[2]
+	ps.Amount, _ = strconv.ParseInt(fields[3], 10, 64)
+	if ps.Amount <= 0 {
+		return nil
+	}
+	ps.UnsignedTxHex = fields[4]
+	if ps.UnsignedTxHex == "" {
+		return nil
+	}
+	ps.BlockHeight, _ = strconv.ParseUint(fields[5], 10, 64)
+	if len(fields) >= 7 {
+		ps.TokenAddress = fields[6]
+	}
+	return ps
+}
+
+// parseDERSignature extracts r, s from a DER-encoded ECDSA signature.
+func parseDERSignature(der []byte) (r, s []byte, err error) {
+	if len(der) < 8 || der[0] != 0x30 {
+		return nil, nil, fmt.Errorf("not a DER signature: len=%d", len(der))
+	}
+	seqLen := int(der[1])
+	if seqLen+2 > len(der) {
+		return nil, nil, fmt.Errorf("DER sequence length %d exceeds data length %d", seqLen, len(der))
+	}
+	pos := 2
+
+	if pos >= len(der) || der[pos] != 0x02 {
+		return nil, nil, fmt.Errorf("missing INTEGER tag for r at pos %d", pos)
+	}
+	pos++
+	if pos >= len(der) {
+		return nil, nil, fmt.Errorf("truncated DER: no r length byte")
+	}
+	rLen := int(der[pos])
+	pos++
+	if pos+rLen > len(der) {
+		return nil, nil, fmt.Errorf("r length %d exceeds remaining %d bytes", rLen, len(der)-pos)
+	}
+	r = der[pos : pos+rLen]
+	pos += rLen
+
+	if pos >= len(der) || der[pos] != 0x02 {
+		return nil, nil, fmt.Errorf("missing INTEGER tag for s at pos %d", pos)
+	}
+	pos++
+	if pos >= len(der) {
+		return nil, nil, fmt.Errorf("truncated DER: no s length byte")
+	}
+	sLen := int(der[pos])
+	pos++
+	if pos+sLen > len(der) {
+		return nil, nil, fmt.Errorf("s length %d exceeds remaining %d bytes", sLen, len(der)-pos)
+	}
+	s = der[pos : pos+sLen]
+
+	for len(r) > 1 && r[0] == 0 {
+		r = r[1:]
+	}
+	for len(s) > 1 && s[0] == 0 {
+		s = s[1:]
+	}
+
+	r = padLeft(r, 32)
+	s = padLeft(s, 32)
+
+	return r, s, nil
+}
+
+func padLeft(b []byte, size int) []byte {
+	if len(b) >= size {
+		return b[len(b)-size:]
+	}
+	padded := make([]byte, size)
+	copy(padded[size-len(b):], b)
+	return padded
+}
+
+// attachSignatureToTx creates a signed EIP-1559 TX from the unsigned TX bytes + (v, r, s).
+func attachSignatureToTx(unsignedTxHex string, v byte, r, s []byte) (string, error) {
+	unsignedBytes, err := hex.DecodeString(unsignedTxHex)
+	if err != nil {
+		return "", fmt.Errorf("decode unsigned tx: %w", err)
+	}
+
+	if len(unsignedBytes) < 2 {
+		return "", fmt.Errorf("unsigned tx too short: %d bytes", len(unsignedBytes))
+	}
+	if unsignedBytes[0] != 0x02 {
+		return "", fmt.Errorf("not an EIP-1559 tx (type prefix 0x%x)", unsignedBytes[0])
+	}
+
+	rlpPayload := unsignedBytes[1:] // strip 0x02 prefix
+
+	contentStart, contentLen, err := decodeRLPListHeader(rlpPayload)
+	if err != nil {
+		return "", fmt.Errorf("decode unsigned RLP: %w", err)
+	}
+	content := rlpPayload[contentStart : contentStart+contentLen]
+
+	vRLP := encodeRLPByte(v)
+	rRLP := encodeRLPBytes(r)
+	sRLP := encodeRLPBytes(s)
+
+	signedContent := make([]byte, 0, len(content)+len(vRLP)+len(rRLP)+len(sRLP))
+	signedContent = append(signedContent, content...)
+	signedContent = append(signedContent, vRLP...)
+	signedContent = append(signedContent, rRLP...)
+	signedContent = append(signedContent, sRLP...)
+
+	signedRLP := encodeRLPList(signedContent)
+
+	signedTx := make([]byte, 0, 1+len(signedRLP))
+	signedTx = append(signedTx, 0x02)
+	signedTx = append(signedTx, signedRLP...)
+
+	return hex.EncodeToString(signedTx), nil
+}
+
+// computeSighash computes keccak256 of the unsigned EIP-1559 TX (0x02 || RLP).
+func computeSighash(unsignedTxHex string) (string, error) {
+	unsignedBytes, err := hex.DecodeString(unsignedTxHex)
+	if err != nil {
+		return "", err
+	}
+	hash := keccak256(unsignedBytes)
+	return hex.EncodeToString(hash), nil
+}
+
+// ---------------------------------------------------------------------------
+// Minimal RLP helpers — just enough for signature attachment.
+// ---------------------------------------------------------------------------
+
+func decodeRLPListHeader(data []byte) (contentStart int, contentLen int, err error) {
+	if len(data) == 0 {
+		return 0, 0, fmt.Errorf("empty data")
+	}
+	b := data[0]
+	if b >= 0xc0 && b <= 0xf7 {
+		length := int(b - 0xc0)
+		if 1+length > len(data) {
+			return 0, 0, fmt.Errorf("short-form list length %d exceeds data length %d", length, len(data))
+		}
+		return 1, length, nil
+	}
+	if b >= 0xf8 {
+		lenOfLen := int(b - 0xf7)
+		if len(data) < 1+lenOfLen {
+			return 0, 0, fmt.Errorf("truncated list length")
+		}
+		var length int
+		for i := 0; i < lenOfLen; i++ {
+			length = (length << 8) | int(data[1+i])
+		}
+		if 1+lenOfLen+length > len(data) {
+			return 0, 0, fmt.Errorf("long-form list length %d exceeds data length %d", length, len(data))
+		}
+		return 1 + lenOfLen, length, nil
+	}
+	return 0, 0, fmt.Errorf("not an RLP list: prefix 0x%x", b)
+}
+
+func encodeRLPByte(v byte) []byte {
+	if v == 0 {
+		return []byte{0x80} // empty bytes
+	}
+	if v < 0x80 {
+		return []byte{v}
+	}
+	return []byte{0x81, v}
+}
+
+func encodeRLPBytes(b []byte) []byte {
+	stripped := b
+	for len(stripped) > 0 && stripped[0] == 0 {
+		stripped = stripped[1:]
+	}
+	if len(stripped) == 0 {
+		return []byte{0x80}
+	}
+	if len(stripped) == 1 && stripped[0] < 0x80 {
+		return []byte{stripped[0]}
+	}
+	if len(stripped) <= 55 {
+		out := make([]byte, 1+len(stripped))
+		out[0] = 0x80 + byte(len(stripped))
+		copy(out[1:], stripped)
+		return out
+	}
+	lenBytes := encodeLength(len(stripped))
+	out := make([]byte, 1+len(lenBytes)+len(stripped))
+	out[0] = 0xb7 + byte(len(lenBytes))
+	copy(out[1:], lenBytes)
+	copy(out[1+len(lenBytes):], stripped)
+	return out
+}
+
+func encodeRLPList(content []byte) []byte {
+	if len(content) <= 55 {
+		out := make([]byte, 1+len(content))
+		out[0] = 0xc0 + byte(len(content))
+		copy(out[1:], content)
+		return out
+	}
+	lenBytes := encodeLength(len(content))
+	out := make([]byte, 1+len(lenBytes)+len(content))
+	out[0] = 0xf7 + byte(len(lenBytes))
+	copy(out[1:], lenBytes)
+	copy(out[1+len(lenBytes):], content)
+	return out
+}
+
+func encodeLength(n int) []byte {
+	if n < 256 {
+		return []byte{byte(n)}
+	}
+	if n < 65536 {
+		return []byte{byte(n >> 8), byte(n)}
+	}
+	return []byte{byte(n >> 16), byte(n >> 8), byte(n)}
+}
+
+// ---------------------------------------------------------------------------
+// Keccak256
+// ---------------------------------------------------------------------------
+
+func keccak256(data []byte) []byte {
+	h := sha3.NewLegacyKeccak256()
+	h.Write(data)
+	return h.Sum(nil)
+}
+
+// ---------------------------------------------------------------------------
+// Receipt proof construction for confirmSpend.
+// ---------------------------------------------------------------------------
+
+type receiptForProof struct {
+	Status            string `json:"status"`
+	CumulativeGasUsed string `json:"cumulativeGasUsed"`
+	LogsBloom         string `json:"logsBloom"`
+	TransactionHash   string `json:"transactionHash"`
+	TransactionIndex  string `json:"transactionIndex"`
+	Type              string `json:"type"`
+	Logs              []struct {
+		Address string   `json:"address"`
+		Topics  []string `json:"topics"`
+		Data    string   `json:"data"`
+	} `json:"logs"`
+}
+
+func buildConfirmSpendPayload(rpc *ethRPC, txHash string, blockHeight uint64, txIndex int) (json.RawMessage, error) {
+	blockData, err := rpc.call("eth_getBlockByNumber", fmt.Sprintf(`"0x%x", false`, blockHeight))
+	if err != nil {
+		return nil, fmt.Errorf("fetch block %d for confirmSpend: %w", blockHeight, err)
+	}
+
+	var block struct {
+		Transactions []string `json:"transactions"`
+	}
+	if err := json.Unmarshal(blockData, &block); err != nil {
+		return nil, fmt.Errorf("parse block %d: %w", blockHeight, err)
+	}
+
+	allReceipts := make([]receiptForProof, len(block.Transactions))
+	for i, hash := range block.Transactions {
+		rData, err := rpc.getReceipt(hash)
+		if err != nil {
+			return nil, fmt.Errorf("fetch receipt %d/%d: %w", i, len(block.Transactions), err)
+		}
+		if err := json.Unmarshal(rData, &allReceipts[i]); err != nil {
+			return nil, fmt.Errorf("parse receipt %d: %w", i, err)
+		}
+	}
+
+	encodedReceipts := make([][]byte, len(allReceipts))
+	for i := range allReceipts {
+		encodedReceipts[i] = encodeReceiptRLP(&allReceipts[i])
+	}
+
+	keys := make([][]byte, len(encodedReceipts))
+	for i := range keys {
+		keys[i] = rlpEncodeUint64(uint64(i))
+	}
+
+	_, proofNodes, targetRLP := buildMPTProof(keys, encodedReceipts, txIndex)
+	if proofNodes == nil {
+		return nil, fmt.Errorf("proof construction failed: txIndex %d out of range (block has %d txs)", txIndex, len(encodedReceipts))
+	}
+
+	proofHex := ""
+	for _, node := range proofNodes {
+		proofHex += hex.EncodeToString(node)
+	}
+
+	payload := map[string]interface{}{
+		"tx_data": map[string]interface{}{
+			"block_height":     blockHeight,
+			"tx_index":         txIndex,
+			"raw_hex":          hex.EncodeToString(targetRLP),
+			"merkle_proof_hex": proofHex,
+		},
+	}
+
+	data, _ := json.Marshal(payload)
+	return data, nil
+}
+
+func encodeReceiptRLP(r *receiptForProof) []byte {
+	status := hexToUint64(r.Status)
+	cumGas := hexToUint64(r.CumulativeGasUsed)
+	bloom := hexToBytes(r.LogsBloom)
+
+	logItems := make([][]byte, len(r.Logs))
+	for i, log := range r.Logs {
+		addr := hexToBytes(log.Address)
+		topicItems := make([][]byte, len(log.Topics))
+		for j, t := range log.Topics {
+			topicItems[j] = encodeRLPBytes(hexToBytes(t))
+		}
+		topicsList := encodeRLPList(concatBytes(topicItems...))
+		data := hexToBytes(log.Data)
+		logItems[i] = encodeRLPList(concatBytes(
+			encodeRLPBytes(addr),
+			topicsList,
+			encodeRLPBytes(data),
+		))
+	}
+	logsList := encodeRLPList(concatBytes(logItems...))
+
+	receiptBody := concatBytes(
+		encodeRLPByte(byte(status)),
+		rlpEncodeUint64Bytes(cumGas),
+		encodeRLPBytes(bloom),
+		logsList,
+	)
+	receiptRLP := encodeRLPList(receiptBody)
+
+	txType := hexToUint64(r.Type)
+	if txType > 0 {
+		typed := make([]byte, 1+len(receiptRLP))
+		typed[0] = byte(txType)
+		copy(typed[1:], receiptRLP)
+		return typed
+	}
+	return receiptRLP
+}
+
+func rlpEncodeUint64(v uint64) []byte {
+	if v == 0 {
+		return []byte{0x80}
+	}
+	if v < 128 {
+		return []byte{byte(v)}
+	}
+	var buf [8]byte
+	i := 7
+	for v > 0 {
+		buf[i] = byte(v)
+		v >>= 8
+		i--
+	}
+	b := buf[i+1:]
+	out := make([]byte, 1+len(b))
+	out[0] = 0x80 + byte(len(b))
+	copy(out[1:], b)
+	return out
+}
+
+func rlpEncodeUint64Bytes(v uint64) []byte {
+	return rlpEncodeUint64(v)
+}
+
+// ---------------------------------------------------------------------------
+// Inline MPT trie — ported from monitor/trie.go.
+// ---------------------------------------------------------------------------
+
+func rlpEncodeRaw(b []byte) []byte {
+	if len(b) == 1 && b[0] <= 0x7f {
+		return b
+	}
+	if len(b) <= 55 {
+		out := make([]byte, 1+len(b))
+		out[0] = 0x80 + byte(len(b))
+		copy(out[1:], b)
+		return out
+	}
+	lenBytes := encodeLength(len(b))
+	out := make([]byte, 1+len(lenBytes)+len(b))
+	out[0] = 0xb7 + byte(len(lenBytes))
+	copy(out[1:], lenBytes)
+	copy(out[1+len(lenBytes):], b)
+	return out
+}
+
+func rlpEncodeRawList(items ...[]byte) []byte {
+	var payload []byte
+	for _, item := range items {
+		payload = append(payload, item...)
+	}
+	return encodeRLPList(payload)
+}
+
+type mptNode interface {
+	mptHash() []byte
+	mptEncode() []byte
+}
+
+type mptLeaf struct {
+	keyNibbles []byte
+	value      []byte
+}
+
+type mptBranch struct {
+	children [16]mptNode
+	value    []byte
+}
+
+type mptExtension struct {
+	keyNibbles []byte
+	child      mptNode
+}
+
+func (n *mptLeaf) mptEncode() []byte {
+	compact := nibblesToCompact(n.keyNibbles, true)
+	return rlpEncodeRawList(rlpEncodeRaw(compact), rlpEncodeRaw(n.value))
+}
+
+func (n *mptLeaf) mptHash() []byte {
+	enc := n.mptEncode()
+	if len(enc) < 32 {
+		return enc
+	}
+	return keccak256(enc)
+}
+
+func (n *mptBranch) mptEncode() []byte {
+	items := make([][]byte, 17)
+	for i := 0; i < 16; i++ {
+		if n.children[i] == nil {
+			items[i] = rlpEncodeRaw(nil)
+		} else {
+			childEnc := n.children[i].mptEncode()
+			if len(childEnc) < 32 {
+				items[i] = childEnc
+			} else {
+				items[i] = rlpEncodeRaw(keccak256(childEnc))
+			}
+		}
+	}
+	items[16] = rlpEncodeRaw(n.value)
+	return rlpEncodeRawList(items...)
+}
+
+func (n *mptBranch) mptHash() []byte {
+	return keccak256(n.mptEncode())
+}
+
+func (n *mptExtension) mptEncode() []byte {
+	compact := nibblesToCompact(n.keyNibbles, false)
+	childEnc := n.child.mptEncode()
+	var childRef []byte
+	if len(childEnc) < 32 {
+		childRef = childEnc
+	} else {
+		childRef = rlpEncodeRaw(keccak256(childEnc))
+	}
+	return rlpEncodeRawList(rlpEncodeRaw(compact), childRef)
+}
+
+func (n *mptExtension) mptHash() []byte {
+	return keccak256(n.mptEncode())
+}
+
+func nibblesToCompact(nibbles []byte, isLeaf bool) []byte {
+	var prefix byte
+	if isLeaf {
+		prefix = 2
+	}
+	odd := len(nibbles) % 2
+	if odd == 1 {
+		prefix |= 1
+	}
+	var compact []byte
+	if odd == 1 {
+		compact = append(compact, (prefix<<4)|nibbles[0])
+		for i := 1; i < len(nibbles); i += 2 {
+			compact = append(compact, (nibbles[i]<<4)|nibbles[i+1])
+		}
+	} else {
+		compact = append(compact, prefix<<4)
+		for i := 0; i < len(nibbles); i += 2 {
+			compact = append(compact, (nibbles[i]<<4)|nibbles[i+1])
+		}
+	}
+	return compact
+}
+
+func keyToNibbles(key []byte) []byte {
+	nibbles := make([]byte, len(key)*2)
+	for i, b := range key {
+		nibbles[i*2] = b >> 4
+		nibbles[i*2+1] = b & 0x0f
+	}
+	return nibbles
+}
+
+func mptBuildTrie(keys [][]byte, values [][]byte) mptNode {
+	if len(keys) == 0 {
+		return nil
+	}
+	nibbleKeys := make([][]byte, len(keys))
+	for i, k := range keys {
+		nibbleKeys[i] = keyToNibbles(k)
+	}
+	return mptBuildNode(nibbleKeys, values, 0)
+}
+
+func mptBuildNode(keys [][]byte, values [][]byte, depth int) mptNode {
+	if len(keys) == 0 {
+		return nil
+	}
+	if len(keys) == 1 {
+		return &mptLeaf{keyNibbles: keys[0][depth:], value: values[0]}
+	}
+	commonLen := mptCommonPrefixLen(keys, depth)
+	if commonLen > 0 {
+		return &mptExtension{
+			keyNibbles: keys[0][depth : depth+commonLen],
+			child:      mptBuildNode(keys, values, depth+commonLen),
+		}
+	}
+	branch := &mptBranch{}
+	for nibble := byte(0); nibble < 16; nibble++ {
+		var subKeys [][]byte
+		var subVals [][]byte
+		for i, k := range keys {
+			if depth < len(k) && k[depth] == nibble {
+				subKeys = append(subKeys, k)
+				subVals = append(subVals, values[i])
+			}
+		}
+		if len(subKeys) > 0 {
+			branch.children[nibble] = mptBuildNode(subKeys, subVals, depth+1)
+		}
+	}
+	for i, k := range keys {
+		if len(k) == depth {
+			branch.value = values[i]
+		}
+	}
+	return branch
+}
+
+func mptCommonPrefixLen(keys [][]byte, depth int) int {
+	if len(keys) <= 1 {
+		return 0
+	}
+	first := keys[0]
+	maxLen := len(first) - depth
+	for _, k := range keys[1:] {
+		kLen := len(k) - depth
+		if kLen < maxLen {
+			maxLen = kLen
+		}
+	}
+	common := 0
+	for i := 0; i < maxLen; i++ {
+		match := true
+		for _, k := range keys[1:] {
+			if k[depth+i] != first[depth+i] {
+				match = false
+				break
+			}
+		}
+		if !match {
+			break
+		}
+		common++
+	}
+	return common
+}
+
+func mptGenerateProof(root mptNode, key []byte) [][]byte {
+	nibbles := keyToNibbles(key)
+	var proof [][]byte
+	mptCollectProof(root, nibbles, 0, &proof)
+	return proof
+}
+
+func mptCollectProof(node mptNode, nibbles []byte, depth int, proof *[][]byte) {
+	if node == nil {
+		return
+	}
+	*proof = append(*proof, node.mptEncode())
+	switch n := node.(type) {
+	case *mptLeaf:
+		// leaf is terminal
+	case *mptBranch:
+		if depth < len(nibbles) {
+			child := n.children[nibbles[depth]]
+			if child != nil {
+				mptCollectProof(child, nibbles, depth+1, proof)
+			}
+		}
+	case *mptExtension:
+		mptCollectProof(n.child, nibbles, depth+len(n.keyNibbles), proof)
+	}
+}
+
+func mptTrieRoot(root mptNode) []byte {
+	if root == nil {
+		return keccak256(rlpEncodeRaw(nil))
+	}
+	return root.mptHash()
+}
+
+func buildMPTProof(keys, values [][]byte, targetIndex int) (root []byte, proof [][]byte, targetValue []byte) {
+	if targetIndex < 0 || targetIndex >= len(values) || len(keys) != len(values) {
+		return nil, nil, nil
+	}
+	trie := mptBuildTrie(keys, values)
+	root = mptTrieRoot(trie)
+	targetKey := rlpEncodeUint64(uint64(targetIndex))
+	proof = mptGenerateProof(trie, targetKey)
+	targetValue = values[targetIndex]
+	return root, proof, targetValue
+}
+
+// ---------------------------------------------------------------------------
+// RunLoop — the main bot loop.
+// ---------------------------------------------------------------------------
+
+func RunLoop(ctx context.Context, cfg EVMBotConfig, ethKey *ecdsa.PrivateKey, did dids.EthDID) error {
+	rpc := newEthRPC(cfg.EthRPC)
+	gql := newVSCGraphQL(cfg.GraphQLURLs)
+	cp := loadCheckpoint(cfg.CheckpointFile)
+
+	submitter := &l2Submitter{
+		ethKey: ethKey,
+		did:    did,
+		gql:    gql,
+		cfg:    cfg,
+	}
+
+	// TSS key ID follows the UTXO bot's pattern: "{contractId}-main"
+	tssKeyID := cfg.ContractID + "-main"
+
+	slog.Info("loaded checkpoint", "lastBlock", cp.LastScannedBlock, "pendingTxs", len(cp.SentWithdrawals))
+
+	for {
+		select {
+		case <-ctx.Done():
+			cp.save(cfg.CheckpointFile)
+			return ctx.Err()
+		default:
+		}
+
+		loopCtx, loopCancel := context.WithTimeout(ctx, 60*time.Second)
+
+		err := runOnce(loopCtx, rpc, gql, submitter, cp, cfg, tssKeyID)
+		if err != nil {
+			slog.Error("loop tick failed", "err", err)
+		}
+
+		loopCancel()
+
+		cp.save(cfg.CheckpointFile)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(cfg.PollInterval):
+		}
+	}
+}
+
+func runOnce(
+	ctx context.Context,
+	rpc *ethRPC,
+	gql *vscGraphQL,
+	submitter *l2Submitter,
+	cp *Checkpoint,
+	cfg EVMBotConfig,
+	tssKeyID string,
+) error {
+	// ---------------------------------------------------------------
+	// STEP 1: Get finalized block height from Ethereum
+	// ---------------------------------------------------------------
+	finalized, err := rpc.getFinalizedBlock()
+	if err != nil {
+		return fmt.Errorf("get finalized block: %w", err)
+	}
+
+	if finalized <= cp.LastScannedBlock && len(cp.SentWithdrawals) == 0 {
+		return nil // nothing to do
+	}
+
+	// ---------------------------------------------------------------
+	// STEP 2: Check contract's last ingested block height.
+	// ---------------------------------------------------------------
+	contractHeight, err := fetchContractLastHeight(ctx, gql, cfg.ContractID)
+	if err != nil {
+		slog.Warn("couldn't fetch contract height, proceeding with deposits only up to finalized", "err", err)
+		contractHeight = finalized
+	}
+
+	// ---------------------------------------------------------------
+	// STEP 3: Scan new blocks for deposits
+	// ---------------------------------------------------------------
+	scanUpTo := finalized
+	if contractHeight < scanUpTo {
+		scanUpTo = contractHeight
+	}
+	const maxBlocksPerTick = 100
+	if scanUpTo > cp.LastScannedBlock+maxBlocksPerTick {
+		scanUpTo = cp.LastScannedBlock + maxBlocksPerTick
+	}
+
+	for h := cp.LastScannedBlock + 1; h <= scanUpTo; h++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		result, err := scanBlock(rpc, h, cfg.VaultAddress, cfg.Tokens)
+		if err != nil {
+			slog.Error("scan block failed", "block", h, "err", err)
+			break // stop scanning, retry next tick
+		}
+
+		if len(result.Deposits) == 0 {
+			cp.mu.Lock()
+			cp.LastScannedBlock = h
+			cp.mu.Unlock()
+			continue
+		}
+
+		slog.Info("deposits detected", "block", h, "count", len(result.Deposits))
+
+		// ---------------------------------------------------------------
+		// STEP 4: Build proofs and submit map calls.
+		// If ANY deposit fails after retries, do NOT advance the checkpoint.
+		// The entire block will be retried next tick. Re-submissions of
+		// already-processed deposits are harmless — the L2 layer accepts
+		// them and the contract deduplicates via the observed block list.
+		// ---------------------------------------------------------------
+		blockFailed := false
+		for _, dep := range result.Deposits {
+			payload := buildMapPayloadFromRPC(ctx, rpc, dep, h)
+			if payload == nil {
+				slog.Error("failed to build map payload", "block", h, "tx", dep.TxHash)
+				blockFailed = true
+				continue
+			}
+
+			if err := submitter.callWithRetry(ctx, cfg.ContractID, "map", payload, 3); err != nil {
+				slog.Error("map submission failed — block checkpoint will NOT advance",
+					"block", h, "tx", dep.TxHash, "err", err)
+				blockFailed = true
+			}
+		}
+
+		if blockFailed {
+			cp.mu.Lock()
+			cp.BlockRetries[h]++
+			retries := cp.BlockRetries[h]
+			cp.mu.Unlock()
+
+			if retries >= blockRetryAlertThreshold {
+				slog.Error("CRITICAL: block has been failing for multiple ticks — manual intervention required",
+					"block", h,
+					"retries", retries,
+					"minutes_stuck", retries*int(cfg.PollInterval.Seconds())/60,
+				)
+			} else {
+				slog.Warn("one or more deposits failed in block, will retry next tick",
+					"block", h, "retries", retries)
+			}
+			break
+		}
+
+		cp.mu.Lock()
+		delete(cp.BlockRetries, h)
+		cp.mu.Unlock()
+
+		cp.mu.Lock()
+		cp.LastScannedBlock = h
+		cp.mu.Unlock()
+	}
+
+	// ---------------------------------------------------------------
+	// STEP 5: Handle withdrawals
+	// ---------------------------------------------------------------
+	handleWithdrawals(ctx, rpc, gql, cp, cfg, tssKeyID)
+
+	// ---------------------------------------------------------------
+	// STEP 6: Handle confirmations
+	// ---------------------------------------------------------------
+	handleConfirmations(ctx, rpc, gql, submitter, cp, cfg)
+
+	return nil
+}
+
+func handleWithdrawals(
+	ctx context.Context,
+	rpc *ethRPC,
+	gql *vscGraphQL,
+	cp *Checkpoint,
+	cfg EVMBotConfig,
+	tssKeyID string,
+) {
+	state, err := gql.fetchContractState(ctx, cfg.ContractID, []string{"n", "np"})
+	if err != nil {
+		slog.Debug("fetch nonce state failed", "err", err)
+		return
+	}
+
+	confirmedNonce, _ := strconv.ParseUint(state["n"], 10, 64)
+	pendingNonce, _ := strconv.ParseUint(state["np"], 10, 64)
+
+	if pendingNonce <= confirmedNonce {
+		return
+	}
+
+	nonceKey := strconv.FormatUint(confirmedNonce, 10)
+	if _, alreadySent := cp.SentWithdrawals[nonceKey]; alreadySent {
+		return
+	}
+
+	spendKey := "d-" + nonceKey
+	spendState, err := gql.fetchContractState(ctx, cfg.ContractID, []string{spendKey})
+	if err != nil {
+		slog.Warn("fetch pending spend failed", "nonce", confirmedNonce, "err", err)
+		return
+	}
+
+	spendData, ok := spendState[spendKey]
+	if !ok || spendData == "" {
+		slog.Warn("pending spend not found in contract state", "nonce", confirmedNonce)
+		return
+	}
+
+	ps := parsePendingSpend(confirmedNonce, spendData)
+	if ps == nil {
+		slog.Error("failed to parse pending spend", "nonce", confirmedNonce, "raw", spendData)
+		return
+	}
+
+	sighash, err := computeSighash(ps.UnsignedTxHex)
+	if err != nil {
+		slog.Error("compute sighash failed", "nonce", confirmedNonce, "err", err)
+		return
+	}
+
+	slog.Info("pending withdrawal found, checking for TSS signature",
+		"nonce", confirmedNonce,
+		"asset", ps.Asset,
+		"amount", ps.Amount,
+		"to", ps.To,
+		"sighash", sighash,
+	)
+
+	signatures, err := gql.fetchTssSignatures(ctx, tssKeyID, []string{sighash})
+	if err != nil {
+		slog.Warn("fetch TSS signatures failed", "err", err)
+		return
+	}
+
+	sig, found := signatures[sighash]
+	if !found {
+		slog.Debug("TSS signature not ready yet", "sighash", sighash)
+		return
+	}
+
+	r, s, err := parseDERSignature(sig.Bytes)
+	if err != nil {
+		slog.Error("parse DER signature failed", "err", err)
+		return
+	}
+
+	var v byte = 0
+
+	signedTxHex, err := attachSignatureToTx(ps.UnsignedTxHex, v, r, s)
+	if err != nil {
+		slog.Error("attach signature failed", "err", err)
+		return
+	}
+
+	txHash, err := rpc.broadcastTx(signedTxHex)
+	if err != nil {
+		slog.Debug("broadcast with v=0 failed, trying v=1", "err", err)
+		v = 1
+		signedTxHex, err = attachSignatureToTx(ps.UnsignedTxHex, v, r, s)
+		if err != nil {
+			slog.Error("attach signature v=1 failed", "err", err)
+			return
+		}
+		txHash, err = rpc.broadcastTx(signedTxHex)
+		if err != nil {
+			slog.Error("broadcast failed with both v values", "err", err)
+			return
+		}
+	}
+
+	slog.Info("withdrawal TX broadcast to Ethereum",
+		"txHash", txHash,
+		"nonce", confirmedNonce,
+		"asset", ps.Asset,
+		"amount", ps.Amount,
+		"to", ps.To,
+	)
+
+	cp.mu.Lock()
+	cp.SentWithdrawals[nonceKey] = SentTx{
+		SignedTxHex: signedTxHex,
+		TxHash:     txHash,
+		Nonce:      confirmedNonce,
+		SentAt:     time.Now().Unix(),
+	}
+	cp.mu.Unlock()
+}
+
+func handleConfirmations(
+	ctx context.Context,
+	rpc *ethRPC,
+	gql *vscGraphQL,
+	submitter *l2Submitter,
+	cp *Checkpoint,
+	cfg EVMBotConfig,
+) {
+	cp.mu.Lock()
+	sent := make(map[string]SentTx)
+	for k, v := range cp.SentWithdrawals {
+		sent[k] = v
+	}
+	cp.mu.Unlock()
+
+	if len(sent) == 0 {
+		return
+	}
+
+	for nonceKey, stx := range sent {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		receiptData, err := rpc.getReceipt(stx.TxHash)
+		if err != nil {
+			slog.Debug("receipt not available yet", "txHash", stx.TxHash, "err", err)
+			continue
+		}
+
+		var receipt struct {
+			Status           string `json:"status"`
+			BlockNumber      string `json:"blockNumber"`
+			TransactionIndex string `json:"transactionIndex"`
+		}
+		if err := json.Unmarshal(receiptData, &receipt); err != nil {
+			slog.Warn("parse receipt failed", "txHash", stx.TxHash, "err", err)
+			continue
+		}
+
+		blockNum := hexToUint64(receipt.BlockNumber)
+		txIndex := int(hexToUint64(receipt.TransactionIndex))
+		status := hexToUint64(receipt.Status)
+
+		finalized, err := rpc.getFinalizedBlock()
+		if err != nil {
+			continue
+		}
+		if blockNum > finalized {
+			slog.Debug("TX mined but not yet finalized", "txHash", stx.TxHash, "block", blockNum, "finalized", finalized)
+			continue
+		}
+
+		contractHeight, err := fetchContractLastHeight(ctx, gql, cfg.ContractID)
+		if err != nil || contractHeight < blockNum {
+			slog.Debug("contract hasn't ingested confirmation block yet",
+				"txHash", stx.TxHash,
+				"block", blockNum,
+				"contractHeight", contractHeight,
+			)
+			continue
+		}
+
+		if status == 1 {
+			slog.Info("withdrawal TX confirmed successfully on L1",
+				"txHash", stx.TxHash,
+				"block", blockNum,
+			)
+		} else {
+			slog.Warn("withdrawal TX REVERTED on L1 — contract will refund user",
+				"txHash", stx.TxHash,
+				"block", blockNum,
+				"status", status,
+			)
+		}
+
+		payload, err := buildConfirmSpendPayload(rpc, stx.TxHash, blockNum, txIndex)
+		if err != nil {
+			slog.Error("build confirmSpend payload failed", "txHash", stx.TxHash, "err", err)
+			continue
+		}
+
+		// Submit confirmSpend via L2 with retry.
+		if err := submitter.callWithRetry(ctx, cfg.ContractID, "confirmSpend", payload, 3); err != nil {
+			slog.Error("confirmSpend submission failed", "txHash", stx.TxHash, "err", err)
+			// Check if nonce already advanced (another instance confirmed it).
+			// If so, clear the stale entry to stop perpetual retries.
+			state, qErr := gql.fetchContractState(ctx, cfg.ContractID, []string{"n"})
+			if qErr == nil {
+				confirmedNonce, _ := strconv.ParseUint(state["n"], 10, 64)
+				if confirmedNonce > stx.Nonce {
+					slog.Info("nonce already advanced past this withdrawal — clearing stale entry",
+						"txHash", stx.TxHash, "staleNonce", stx.Nonce, "confirmedNonce", confirmedNonce)
+					cp.mu.Lock()
+					delete(cp.SentWithdrawals, nonceKey)
+					cp.mu.Unlock()
+				}
+			}
+			continue
+		}
+
+		cp.mu.Lock()
+		delete(cp.SentWithdrawals, nonceKey)
+		cp.mu.Unlock()
+
+		slog.Info("confirmSpend submitted", "txHash", stx.TxHash, "nonce", stx.Nonce)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func fetchContractLastHeight(ctx context.Context, gql *vscGraphQL, contractID string) (uint64, error) {
+	state, err := gql.fetchContractState(ctx, contractID, []string{"h"})
+	if err != nil {
+		return 0, err
+	}
+	h, _ := strconv.ParseUint(state["h"], 10, 64)
+	return h, nil
+}
+
+func buildMapPayloadFromRPC(ctx context.Context, rpc *ethRPC, dep detectedDeposit, blockHeight uint64) json.RawMessage {
+	blockData, err := rpc.call("eth_getBlockByNumber", fmt.Sprintf(`"0x%x", false`, blockHeight))
+	if err != nil {
+		slog.Error("fetch block for proof", "block", blockHeight, "err", err)
+		return nil
+	}
+
+	var block struct {
+		Transactions []string `json:"transactions"`
+	}
+	if err := json.Unmarshal(blockData, &block); err != nil {
+		slog.Error("parse block for proof", "block", blockHeight, "err", err)
+		return nil
+	}
+
+	allReceipts := make([]receiptForProof, len(block.Transactions))
+	for i, hash := range block.Transactions {
+		rData, err := rpc.getReceipt(hash)
+		if err != nil {
+			slog.Error("fetch receipt for proof", "block", blockHeight, "tx", i, "err", err)
+			return nil
+		}
+		if err := json.Unmarshal(rData, &allReceipts[i]); err != nil {
+			slog.Error("parse receipt for proof", "block", blockHeight, "tx", i, "err", err)
+			return nil
+		}
+	}
+
+	encodedReceipts := make([][]byte, len(allReceipts))
+	for i := range allReceipts {
+		encodedReceipts[i] = encodeReceiptRLP(&allReceipts[i])
+	}
+
+	keys := make([][]byte, len(encodedReceipts))
+	for i := range keys {
+		keys[i] = rlpEncodeUint64(uint64(i))
+	}
+
+	_, proofNodes, targetRLP := buildMPTProof(keys, encodedReceipts, dep.TxIndex)
+	if proofNodes == nil {
+		slog.Error("proof construction failed", "block", blockHeight, "txIndex", dep.TxIndex, "receiptCount", len(encodedReceipts))
+		return nil
+	}
+
+	return buildMapPayload(dep, targetRLP, proofNodes)
+}
+
+func hexToUint64(s string) uint64 {
+	s = strings.TrimPrefix(s, "0x")
+	var v uint64
+	for _, c := range s {
+		v <<= 4
+		switch {
+		case c >= '0' && c <= '9':
+			v |= uint64(c - '0')
+		case c >= 'a' && c <= 'f':
+			v |= uint64(c - 'a' + 10)
+		case c >= 'A' && c <= 'F':
+			v |= uint64(c - 'A' + 10)
+		}
+	}
+	return v
+}
+
+func hexToBytes(s string) []byte {
+	s = strings.TrimPrefix(s, "0x")
+	b, _ := hex.DecodeString(s)
+	return b
+}
+
+func concatBytes(slices ...[]byte) []byte {
+	var total int
+	for _, s := range slices {
+		total += len(s)
+	}
+	out := make([]byte, 0, total)
+	for _, s := range slices {
+		out = append(out, s...)
+	}
+	return out
+}

--- a/cmd/evm-mapping-bot/main.go
+++ b/cmd/evm-mapping-bot/main.go
@@ -1448,8 +1448,8 @@ func RunLoop(ctx context.Context, cfg EVMBotConfig, ethKey *ecdsa.PrivateKey, di
 		cfg:    cfg,
 	}
 
-	// TSS key ID follows the UTXO bot's pattern: "{contractId}-main"
-	tssKeyID := cfg.ContractID + "-main"
+	// EVM contract creates key with ID "primary" (BTC contract uses "main")
+	tssKeyID := cfg.ContractID + "-primary"
 
 	slog.Info("loaded checkpoint", "lastBlock", cp.LastScannedBlock, "pendingTxs", len(cp.SentWithdrawals))
 
@@ -1704,7 +1704,36 @@ func handleWithdrawals(
 		}
 		txHash, err = rpc.broadcastTx(signedTxHex)
 		if err != nil {
-			slog.Error("broadcast failed with both v values", "err", err)
+			slog.Warn("broadcast failed with both v values, checking if already mined", "err", err)
+			for _, tryV := range []byte{0, 1} {
+				candidate, aErr := attachSignatureToTx(ps.UnsignedTxHex, tryV, r, s)
+				if aErr != nil {
+					continue
+				}
+				candidateBytes, _ := hex.DecodeString(candidate)
+				candidateHash := fmt.Sprintf("0x%x", keccak256(candidateBytes))
+				receiptData, rErr := rpc.getReceipt(candidateHash)
+				if rErr != nil || receiptData == nil {
+					continue
+				}
+				var receipt struct {
+					Status string `json:"status"`
+				}
+				if json.Unmarshal(receiptData, &receipt) != nil || receipt.Status == "" {
+					continue
+				}
+				slog.Info("withdrawal TX already mined on chain, recovering",
+					"txHash", candidateHash, "status", receipt.Status, "nonce", confirmedNonce)
+				cp.mu.Lock()
+				cp.SentWithdrawals[nonceKey] = SentTx{
+					SignedTxHex: candidate,
+					TxHash:     candidateHash,
+					Nonce:      confirmedNonce,
+					SentAt:     time.Now().Unix(),
+				}
+				cp.mu.Unlock()
+				return
+			}
 			return
 		}
 	}
@@ -1866,32 +1895,26 @@ func buildMapPayloadFromRPC(ctx context.Context, rpc *ethRPC, dep detectedDeposi
 		return nil
 	}
 
-	allReceipts := make([]receiptForProof, len(block.Transactions))
+	rawTxs := make([][]byte, len(block.Transactions))
 	for i, hash := range block.Transactions {
-		rData, err := rpc.getReceipt(hash)
+		rData, err := rpc.call("eth_getRawTransactionByHash", fmt.Sprintf(`"%s"`, hash))
 		if err != nil {
-			slog.Error("fetch receipt for proof", "block", blockHeight, "tx", i, "err", err)
+			slog.Error("fetch raw tx for proof", "block", blockHeight, "tx", i, "err", err)
 			return nil
 		}
-		if err := json.Unmarshal(rData, &allReceipts[i]); err != nil {
-			slog.Error("parse receipt for proof", "block", blockHeight, "tx", i, "err", err)
-			return nil
-		}
+		var rawHex string
+		json.Unmarshal(rData, &rawHex)
+		rawTxs[i] = hexToBytes(rawHex)
 	}
 
-	encodedReceipts := make([][]byte, len(allReceipts))
-	for i := range allReceipts {
-		encodedReceipts[i] = encodeReceiptRLP(&allReceipts[i])
-	}
-
-	keys := make([][]byte, len(encodedReceipts))
+	keys := make([][]byte, len(rawTxs))
 	for i := range keys {
 		keys[i] = rlpEncodeUint64(uint64(i))
 	}
 
-	_, proofNodes, targetRLP := buildMPTProof(keys, encodedReceipts, dep.TxIndex)
+	_, proofNodes, targetRLP := buildMPTProof(keys, rawTxs, dep.TxIndex)
 	if proofNodes == nil {
-		slog.Error("proof construction failed", "block", blockHeight, "txIndex", dep.TxIndex, "receiptCount", len(encodedReceipts))
+		slog.Error("proof construction failed", "block", blockHeight, "txIndex", dep.TxIndex, "txCount", len(rawTxs))
 		return nil
 	}
 

--- a/cmd/evm-mapping-bot/main.go
+++ b/cmd/evm-mapping-bot/main.go
@@ -242,7 +242,7 @@ func (e *ethRPC) call(method string, params string) (json.RawMessage, error) {
 	raw, _ := io.ReadAll(resp.Body)
 
 	var result struct {
-		Result json.RawMessage        `json:"result"`
+		Result json.RawMessage           `json:"result"`
 		Error  *struct{ Message string } `json:"error"`
 	}
 	if err := json.Unmarshal(raw, &result); err != nil {
@@ -672,7 +672,7 @@ const TransferEventSig = "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a
 type detectedDeposit struct {
 	BlockHeight  uint64
 	TxIndex      int
-	LogIndex     int    // -1 for native ETH
+	LogIndex     int // -1 for native ETH
 	TxHash       string
 	DepositType  string // "eth" or "erc20"
 	TokenAddress string
@@ -739,10 +739,30 @@ func scanBlock(rpc *ethRPC, height uint64, vaultAddr string, tokens map[string]s
 		json.Unmarshal(logsData, &logs)
 
 		for _, log := range logs {
+			// W4-A CRIT #14 + F2 hardening: the contract reader expects the
+			// PER-RECEIPT log position (0..N-1 within the receipt's own logs
+			// list), but eth_getLogs returns the BLOCK-LEVEL logIndex.
+			// Resolve the per-receipt position by finding the SPECIFIC log
+			// in the receipt that matches this block-level index. A tx
+			// emitting two Transfer(token -> vault) logs previously had
+			// both deposits collide on observed-index 0; matching by the
+			// block-level index gives each deposit a distinct per-receipt
+			// position.
+			if log.LogIndex == "" {
+				slog.Warn("eth_getLogs returned a log with no logIndex (non-standard RPC); skipping deposit",
+					"tx", log.TransactionHash, "token", tokenAddr)
+				continue
+			}
+			perReceiptIdx, lookupErr := lookupPerReceiptLogIndex(rpc, log.TransactionHash, tokenAddr, vaultPadded, hexToUint64(log.LogIndex))
+			if lookupErr != nil {
+				slog.Warn("CRIT #14: per-receipt logIndex lookup failed; skipping deposit",
+					"tx", log.TransactionHash, "token", tokenAddr, "err", lookupErr)
+				continue
+			}
 			result.Deposits = append(result.Deposits, detectedDeposit{
 				BlockHeight:  height,
 				TxIndex:      int(hexToUint64(log.TransactionIndex)),
-				LogIndex:     int(hexToUint64(log.LogIndex)),
+				LogIndex:     perReceiptIdx,
 				TxHash:       log.TransactionHash,
 				DepositType:  "erc20",
 				TokenAddress: tokenAddr,
@@ -751,6 +771,54 @@ func scanBlock(rpc *ethRPC, height uint64, vaultAddr string, tokens map[string]s
 	}
 
 	return result, nil
+}
+
+// lookupPerReceiptLogIndex resolves the per-receipt logIndex (0..N-1 within
+// the receipt's own Logs list) for a specific log identified by its block-
+// level logIndex. eth_getLogs returns block-level indices; the contract
+// reader expects per-receipt. Without this resolver a multi-Transfer-log
+// tx would map every deposit to per-receipt position 0 (W4-A CRIT #14), or
+// to the first matching position if a naive scan is used (F2-bot variant
+// of the same bug).
+func lookupPerReceiptLogIndex(rpc *ethRPC, txHash, tokenAddr, vaultPaddedTopic string, blockLogIndex uint64) (int, error) {
+	receiptData, err := rpc.getReceipt(txHash)
+	if err != nil {
+		return -1, fmt.Errorf("getReceipt %s: %w", txHash, err)
+	}
+	var receipt struct {
+		Logs []struct {
+			Address  string   `json:"address"`
+			Topics   []string `json:"topics"`
+			LogIndex string   `json:"logIndex"` // block-level index
+		} `json:"logs"`
+	}
+	if err := json.Unmarshal(receiptData, &receipt); err != nil {
+		return -1, fmt.Errorf("decode receipt %s: %w", txHash, err)
+	}
+	wantedAddr := strings.ToLower(strings.TrimPrefix(tokenAddr, "0x"))
+	wantedTopic := strings.ToLower(vaultPaddedTopic)
+	// F2: resolve the per-receipt array position of the SPECIFIC block-level
+	// log (matched by its block-level logIndex), NOT the first matching log.
+	for i, log := range receipt.Logs {
+		// F2 hardening: a non-standard RPC omitting logIndex would make
+		// hexToUint64("")==0 silently match only block index 0 — surface a
+		// distinct, retryable error instead of mis-resolving the position.
+		if log.LogIndex == "" {
+			return -1, fmt.Errorf("receipt %s log lacks logIndex (non-standard RPC); cannot resolve per-receipt index", txHash)
+		}
+		if hexToUint64(log.LogIndex) != blockLogIndex {
+			continue
+		}
+		// Sanity-check the resolved log really is the expected Transfer(token -> vault).
+		if strings.ToLower(strings.TrimPrefix(log.Address, "0x")) != wantedAddr ||
+			len(log.Topics) < 3 ||
+			strings.ToLower(strings.TrimPrefix(log.Topics[0], "0x")) != TransferEventSig ||
+			strings.ToLower(log.Topics[2]) != wantedTopic {
+			return -1, fmt.Errorf("log at block-level index %d in receipt %s is not the expected Transfer(token=%s -> vault)", blockLogIndex, txHash, tokenAddr)
+		}
+		return i, nil
+	}
+	return -1, fmt.Errorf("log with block-level index %d not found in receipt %s for token %s", blockLogIndex, txHash, tokenAddr)
 }
 
 // buildMapPayload constructs the JSON for a "map" contract call.
@@ -1727,9 +1795,9 @@ func handleWithdrawals(
 				cp.mu.Lock()
 				cp.SentWithdrawals[nonceKey] = SentTx{
 					SignedTxHex: candidate,
-					TxHash:     candidateHash,
-					Nonce:      confirmedNonce,
-					SentAt:     time.Now().Unix(),
+					TxHash:      candidateHash,
+					Nonce:       confirmedNonce,
+					SentAt:      time.Now().Unix(),
 				}
 				cp.mu.Unlock()
 				return
@@ -1749,9 +1817,9 @@ func handleWithdrawals(
 	cp.mu.Lock()
 	cp.SentWithdrawals[nonceKey] = SentTx{
 		SignedTxHex: signedTxHex,
-		TxHash:     txHash,
-		Nonce:      confirmedNonce,
-		SentAt:     time.Now().Unix(),
+		TxHash:      txHash,
+		Nonce:       confirmedNonce,
+		SentAt:      time.Now().Unix(),
 	}
 	cp.mu.Unlock()
 }

--- a/cmd/evm-mapping-bot/security_pass1_test.go
+++ b/cmd/evm-mapping-bot/security_pass1_test.go
@@ -1,0 +1,1161 @@
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"math"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Ledger constants replicated here because the ledger-system package can't compile
+// in this environment (WasmEdge dependency from other test files in the package).
+const ledgerETH_REGEX = "^0x[a-fA-F0-9]{40}$"
+const ledgerHIVE_REGEX = `^[a-z][0-9a-z\-]*[0-9a-z](\.[a-z][0-9a-z\-]*[0-9a-z])*$`
+
+// ===========================================================================
+// Attack 1 — PendingSpend parsing
+// ===========================================================================
+
+func TestSecurityAttack1_ParsePendingSpend_MissingFields(t *testing.T) {
+	// Fewer than 6 pipes — must return nil, not panic
+	inputs := []string{
+		"a|b|c|d|e",    // 5 fields
+		"a|b|c|d",      // 4 fields
+		"a|b|c",        // 3 fields
+		"a|b",          // 2 fields
+		"a",            // 1 field
+	}
+	for _, input := range inputs {
+		ps := parsePendingSpend(0, input)
+		if ps != nil {
+			t.Errorf("FINDING: parsePendingSpend(%q) returned non-nil with %d fields", input, len(strings.Split(input, "|")))
+		}
+	}
+}
+
+func TestSecurityAttack1_ParsePendingSpend_ExtraFields(t *testing.T) {
+	// More than 7 fields — should not panic, should parse the first 7
+	input := "from|to|eth|1000|aabbcc|12345|tokenAddr|extraField|moreExtra"
+	ps := parsePendingSpend(42, input)
+	if ps == nil {
+		t.Fatal("parsePendingSpend with extra fields returned nil")
+	}
+	if ps.TokenAddress != "tokenAddr" {
+		t.Errorf("expected tokenAddr=%q, got %q", "tokenAddr", ps.TokenAddress)
+	}
+	// Extra fields should be ignored — no crash
+	t.Log("CLEAN: Extra fields are silently ignored")
+}
+
+func TestSecurityAttack1_ParsePendingSpend_EmptyString(t *testing.T) {
+	ps := parsePendingSpend(0, "")
+	if ps != nil {
+		t.Error("FINDING: parsePendingSpend(\"\") should return nil")
+	} else {
+		t.Log("CLEAN: empty string returns nil")
+	}
+}
+
+func TestSecurityAttack1_ParsePendingSpend_EmptyFieldValues(t *testing.T) {
+	// All empty fields between pipes — 6 pipes = 7 fields, all empty
+	input := "||||||"
+	ps := parsePendingSpend(0, input)
+	if ps != nil {
+		t.Fatal("parsePendingSpend with empty fields should return nil (zero amount rejected)")
+	}
+	t.Log("CLEAN (FIXED): empty field values correctly rejected — zero amount returns nil")
+}
+
+func TestSecurityAttack1_ParsePendingSpend_AmountOverflow(t *testing.T) {
+	// Amount field is parsed as int64. Try a number way beyond int64 range.
+	input := "from|to|eth|99999999999999999999999999|aabbcc|12345"
+	ps := parsePendingSpend(0, input)
+	if ps == nil {
+		t.Fatal("parsePendingSpend returned nil")
+	}
+	// strconv.ParseInt with overflow returns max int64 and an error, but error is ignored
+	// Actually, strconv.ParseInt returns 0 on range error with the error set
+	// Let's check what the actual value is
+	if ps.Amount == 0 {
+		t.Log("FINDING (MEDIUM): Amount overflow '99999999999999999999999999' silently parsed as 0. "+
+			"Error from strconv.ParseInt is discarded. A withdrawal with amount=0 could be created.")
+	} else if ps.Amount == math.MaxInt64 {
+		t.Log("INFO: Amount overflow parsed as MaxInt64")
+	} else {
+		t.Errorf("Unexpected amount value: %d", ps.Amount)
+	}
+}
+
+func TestSecurityAttack1_ParsePendingSpend_InvalidToAddress(t *testing.T) {
+	// Invalid "to" address — no validation in parsePendingSpend
+	input := "from|NOTANADDRESS!!!|eth|1000|aabbcc|12345"
+	ps := parsePendingSpend(0, input)
+	if ps == nil {
+		t.Fatal("parsePendingSpend returned nil")
+	}
+	if ps.To != "NOTANADDRESS!!!" {
+		t.Errorf("expected To=%q, got %q", "NOTANADDRESS!!!", ps.To)
+	}
+	// FINDING: No address validation at parse time
+	t.Log("FINDING (INFO): parsePendingSpend performs no validation on To address. "+
+		"Invalid addresses pass through to downstream code.")
+}
+
+func TestSecurityAttack1_ParsePendingSpend_NegativeAmount(t *testing.T) {
+	input := "from|to|eth|-500|aabbcc|12345"
+	ps := parsePendingSpend(0, input)
+	if ps != nil {
+		t.Fatal("parsePendingSpend should reject negative amounts")
+	}
+	t.Log("CLEAN (FIXED): negative amounts correctly rejected — returns nil")
+}
+
+// ===========================================================================
+// Attack 2 — DER to r,s conversion
+// ===========================================================================
+
+func TestSecurityAttack2_ParseDER_TruncatedDER(t *testing.T) {
+	// 30 bytes of plausible but truncated DER
+	truncated := make([]byte, 30)
+	truncated[0] = 0x30 // SEQUENCE
+	truncated[1] = 28   // length
+	truncated[2] = 0x02 // INTEGER tag for r
+	truncated[3] = 20   // r length = 20 bytes
+	// Only 26 bytes remain after position 4, but rLen says 20. We need 20 bytes for r,
+	// then we need at least 2 more for s tag and length.
+	// After r (pos 4..23), pos=24. Need der[24]==0x02 and length.
+	// But sLen will point beyond buffer.
+
+	// Fill with valid data up to r
+	for i := 4; i < 24; i++ {
+		truncated[i] = byte(i)
+	}
+	truncated[24] = 0x02 // INTEGER tag for s
+	truncated[25] = 10   // sLen=10, but only 4 bytes remain (26..29)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("FINDING (HIGH): parseDERSignature panicked on truncated DER: %v", r)
+		}
+	}()
+
+	_, _, err := parseDERSignature(truncated)
+	if err != nil {
+		t.Logf("CLEAN: truncated DER returned error: %v", err)
+	} else {
+		// If it didn't error, check if the s value is corrupted
+		t.Log("FINDING (HIGH): parseDERSignature did not error on truncated DER — " +
+			"s bytes may extend beyond the input buffer")
+	}
+}
+
+func TestSecurityAttack2_ParseDER_WrongLengthPrefix(t *testing.T) {
+	// DER with sequence length that doesn't match actual content
+	der := []byte{
+		0x30, 0xFF, // SEQUENCE with length 255 (way too long)
+		0x02, 0x01, 0x01, // r = 1
+		0x02, 0x01, 0x01, // s = 1
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("FINDING (HIGH): parseDERSignature panicked on wrong length prefix: %v", r)
+		}
+	}()
+
+	r, s, err := parseDERSignature(der)
+	if err != nil {
+		t.Logf("Error on wrong length: %v", err)
+	} else {
+		t.Logf("FINDING (MEDIUM): parseDERSignature ignores sequence length field. "+
+			"Parsed r=%x, s=%x despite length=255 in header", r, s)
+	}
+}
+
+func TestSecurityAttack2_ParseDER_EmptyByteSlice(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("FINDING (HIGH): parseDERSignature panicked on empty slice: %v", r)
+		}
+	}()
+
+	_, _, err := parseDERSignature([]byte{})
+	if err == nil {
+		t.Error("FINDING: parseDERSignature should error on empty slice")
+	} else {
+		t.Logf("CLEAN: empty slice returns error: %v", err)
+	}
+}
+
+func TestSecurityAttack2_ParseDER_NilByteSlice(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("FINDING (HIGH): parseDERSignature panicked on nil slice: %v", r)
+		}
+	}()
+
+	_, _, err := parseDERSignature(nil)
+	if err == nil {
+		t.Error("FINDING: parseDERSignature should error on nil slice")
+	} else {
+		t.Logf("CLEAN: nil slice returns error: %v", err)
+	}
+}
+
+func TestSecurityAttack2_ParseDER_ValidWith33ByteR(t *testing.T) {
+	// Valid DER with 33-byte r value (leading zero for sign bit preservation)
+	// DER: 30 <len> 02 21 00<32 bytes r> 02 20 <32 bytes s>
+	r32 := make([]byte, 32)
+	for i := range r32 {
+		r32[i] = 0xAA
+	}
+	s32 := make([]byte, 32)
+	for i := range s32 {
+		s32[i] = 0xBB
+	}
+
+	// r with leading zero (33 bytes): 00 || r32
+	rDER := append([]byte{0x00}, r32...)
+
+	der := []byte{0x30, byte(2 + 33 + 2 + 32)} // SEQUENCE
+	der = append(der, 0x02, byte(len(rDER)))     // INTEGER r
+	der = append(der, rDER...)
+	der = append(der, 0x02, byte(len(s32)))      // INTEGER s
+	der = append(der, s32...)
+
+	rParsed, sParsed, err := parseDERSignature(der)
+	if err != nil {
+		t.Fatalf("parseDERSignature failed on valid 33-byte r: %v", err)
+	}
+
+	if len(rParsed) != 32 {
+		t.Errorf("FINDING: expected r to be 32 bytes after padding, got %d", len(rParsed))
+	}
+	if len(sParsed) != 32 {
+		t.Errorf("FINDING: expected s to be 32 bytes after padding, got %d", len(sParsed))
+	}
+
+	// Verify the leading zero was stripped
+	if rParsed[0] == 0x00 {
+		t.Error("FINDING: leading zero was NOT stripped from r")
+	} else {
+		t.Log("CLEAN: 33-byte r with leading zero correctly handled")
+	}
+}
+
+func TestSecurityAttack2_ParseDER_OutOfBoundsSlice(t *testing.T) {
+	// rLen claims 100 bytes but DER is only 10 bytes total
+	der := []byte{
+		0x30, 0x08,  // SEQUENCE
+		0x02, 0x64,  // INTEGER, rLen=100 (0x64)
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, // only 6 bytes of data
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("FINDING (CRITICAL): parseDERSignature panicked with out-of-bounds rLen: %v. "+
+				"An attacker controlling the TSS signature output could crash the bot.", r)
+		}
+	}()
+
+	_, _, err := parseDERSignature(der)
+	if err != nil {
+		t.Logf("Error (expected): %v", err)
+	} else {
+		t.Log("FINDING: parseDERSignature did not return error despite rLen > available data")
+	}
+}
+
+// ===========================================================================
+// Attack 3 — v recovery / attachSignatureToTx
+// ===========================================================================
+
+func TestSecurityAttack3_AttachSig_ValidEIP1559(t *testing.T) {
+	// Build a minimal valid EIP-1559 unsigned tx:
+	// Type prefix 0x02 + RLP list with 9 fields:
+	// [chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList]
+	// Use small single-byte values for simplicity.
+	// RLP: each field is 0x80 (empty bytes) except accessList which is 0xc0 (empty list)
+	// 9 fields: 0x80 * 8 + 0xc0 = 9 bytes content
+	// List header: 0xc0 + 9 = 0xc9
+
+	content := []byte{0x01, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0xc0}
+	rlpList := append([]byte{0xc0 + byte(len(content))}, content...)
+	unsignedTxHex := "02" + hex.EncodeToString(rlpList)
+
+	r := make([]byte, 32)
+	s := make([]byte, 32)
+	r[31] = 1
+	s[31] = 1
+
+	defer func() {
+		if rec := recover(); rec != nil {
+			t.Errorf("FINDING (HIGH): attachSignatureToTx panicked on valid EIP-1559 tx: %v", rec)
+		}
+	}()
+
+	result, err := attachSignatureToTx(unsignedTxHex, 0, r, s)
+	if err != nil {
+		t.Fatalf("attachSignatureToTx failed on valid EIP-1559: %v", err)
+	}
+
+	// Verify the result starts with "02" (type prefix preserved)
+	if !strings.HasPrefix(result, "02") {
+		t.Errorf("FINDING: signed tx does not start with 02 prefix: %s", result[:10])
+	}
+	t.Logf("CLEAN: valid EIP-1559 tx signed successfully, result=%s...", result[:20])
+}
+
+func TestSecurityAttack3_AttachSig_EmptyRLPList(t *testing.T) {
+	// Edge case: 0x02 + empty RLP list (0xc0) — no fields at all
+	unsignedTxHex := "02c0"
+
+	r := make([]byte, 32)
+	s := make([]byte, 32)
+	r[31] = 1
+	s[31] = 1
+
+	defer func() {
+		if rec := recover(); rec != nil {
+			t.Errorf("FINDING (MEDIUM): attachSignatureToTx panics on empty RLP list: %v. "+
+				"A malicious contract could provide an empty unsigned tx to crash the bot.", rec)
+		}
+	}()
+
+	result, err := attachSignatureToTx(unsignedTxHex, 0, r, s)
+	if err != nil {
+		t.Logf("CLEAN: empty RLP list returns error: %v", err)
+	} else {
+		t.Logf("Result from empty RLP list: %s", result)
+	}
+}
+
+func TestSecurityAttack3_AttachSig_EmptyUnsignedTxHex(t *testing.T) {
+	r := make([]byte, 32)
+	s := make([]byte, 32)
+
+	defer func() {
+		if rec := recover(); rec != nil {
+			t.Errorf("FINDING (HIGH): attachSignatureToTx panics on empty tx hex: %v. "+
+				"The code at line 853 does `unsignedBytes[0]` without length check after "+
+				"`hex.DecodeString(\"\")` returns empty slice. "+
+				"A PendingSpend with empty UnsignedTxHex (from corrupted contract state) "+
+				"would crash the bot.", rec)
+		}
+	}()
+
+	_, err := attachSignatureToTx("", 0, r, s)
+	if err == nil {
+		t.Error("FINDING: attachSignatureToTx should error on empty tx hex")
+	} else {
+		t.Logf("CLEAN: empty tx hex returns error: %v", err)
+	}
+}
+
+func TestSecurityAttack3_AttachSig_NonEIP1559(t *testing.T) {
+	// Type prefix 0x01 (EIP-2930, not EIP-1559)
+	unsignedTxHex := "01c0"
+
+	r := make([]byte, 32)
+	s := make([]byte, 32)
+
+	_, err := attachSignatureToTx(unsignedTxHex, 0, r, s)
+	if err == nil {
+		t.Error("FINDING: attachSignatureToTx should reject non-EIP-1559 tx types")
+	} else {
+		if strings.Contains(err.Error(), "not an EIP-1559") {
+			t.Logf("CLEAN: non-EIP-1559 tx correctly rejected: %v", err)
+		} else {
+			t.Logf("Rejected with different error: %v", err)
+		}
+	}
+}
+
+func TestSecurityAttack3_AttachSig_TruncatedRLP(t *testing.T) {
+	// 0x02 prefix then truncated RLP: 0xf8 says "long list, 1 byte length follows"
+	// but no length byte present
+	unsignedTxHex := "02f8"
+
+	r := make([]byte, 32)
+	s := make([]byte, 32)
+
+	defer func() {
+		if rec := recover(); rec != nil {
+			t.Errorf("FINDING (HIGH): attachSignatureToTx panicked on truncated RLP: %v", rec)
+		}
+	}()
+
+	_, err := attachSignatureToTx(unsignedTxHex, 0, r, s)
+	if err != nil {
+		t.Logf("CLEAN: truncated RLP returns error: %v", err)
+	} else {
+		t.Log("FINDING: truncated RLP did not return error")
+	}
+}
+
+func TestSecurityAttack3_AttachSig_SingleByte(t *testing.T) {
+	// Only the type prefix, no RLP payload
+	unsignedTxHex := "02"
+
+	r := make([]byte, 32)
+	s := make([]byte, 32)
+
+	defer func() {
+		if rec := recover(); rec != nil {
+			t.Errorf("FINDING (HIGH): attachSignatureToTx panicked on single-byte input: %v", rec)
+		}
+	}()
+
+	_, err := attachSignatureToTx(unsignedTxHex, 0, r, s)
+	if err != nil {
+		t.Logf("Error on single byte: %v", err)
+	} else {
+		t.Log("FINDING: single-byte tx hex did not return error")
+	}
+}
+
+// ===========================================================================
+// Attack 4 — State key defaults
+// ===========================================================================
+
+func TestSecurityAttack4_HexToUint64_EmptyString(t *testing.T) {
+	result := hexToUint64("")
+	if result != 0 {
+		t.Errorf("FINDING: hexToUint64(\"\") returned %d, expected 0", result)
+	} else {
+		t.Log("CLEAN: hexToUint64(\"\") returns 0")
+	}
+}
+
+func TestSecurityAttack4_ParsePendingSpend_MaxUint64Nonce(t *testing.T) {
+	input := "from|to|eth|1000|aabbcc|18446744073709551615" // MaxUint64
+	ps := parsePendingSpend(math.MaxUint64, input)
+	if ps == nil {
+		t.Fatal("parsePendingSpend returned nil")
+	}
+	if ps.Nonce != math.MaxUint64 {
+		t.Errorf("expected nonce=MaxUint64, got %d", ps.Nonce)
+	}
+	if ps.BlockHeight != math.MaxUint64 {
+		t.Errorf("expected BlockHeight=MaxUint64, got %d", ps.BlockHeight)
+	}
+	t.Logf("CLEAN: MaxUint64 nonce handled without overflow, nonce=%d, blockHeight=%d",
+		ps.Nonce, ps.BlockHeight)
+}
+
+func TestSecurityAttack4_HexToUint64_Various(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected uint64
+	}{
+		{"0x0", 0},
+		{"0x1", 1},
+		{"0xff", 255},
+		{"0x", 0},                        // prefix only
+		{"0xffffffffffffffff", math.MaxUint64}, // max
+		{"0xZZZ", 0},                     // invalid hex chars — will they be silently treated as 0?
+		{"garbage", 0},
+	}
+
+	for _, tc := range tests {
+		result := hexToUint64(tc.input)
+		if tc.input == "0xZZZ" || tc.input == "garbage" {
+			// Invalid characters: the function silently ignores them (switch default does nothing)
+			t.Logf("FINDING (LOW): hexToUint64(%q) = %d — invalid hex chars silently ignored, no error returned",
+				tc.input, result)
+		} else if result != tc.expected {
+			t.Errorf("hexToUint64(%q) = %d, expected %d", tc.input, result, tc.expected)
+		}
+	}
+}
+
+func TestSecurityAttack4_HexToUint64_Overflow(t *testing.T) {
+	// Input that would overflow uint64 — just keeps shifting
+	input := "0xffffffffffffffffff" // 9 bytes = 72 bits, overflows uint64
+	result := hexToUint64(input)
+	// The function just shifts and ORs without checking for overflow
+	t.Logf("FINDING (LOW): hexToUint64(%q) = %d — silently overflows uint64 without error", input, result)
+}
+
+// ===========================================================================
+// Attack 7 — ETH deposit detection (scanBlock)
+// ===========================================================================
+
+func TestSecurityAttack7_ScanBlock_ContractCreationTx(t *testing.T) {
+	// Contract creation: To is "" (empty) or null in JSON
+	// The bot does strings.ToLower(tx.To) — this should not panic on empty To
+	blockJSON := `{
+		"transactions": [
+			{
+				"hash": "0xabc",
+				"from": "0x1111111111111111111111111111111111111111",
+				"to": "",
+				"value": "0x100"
+			},
+			{
+				"hash": "0xdef",
+				"from": "0x2222222222222222222222222222222222222222",
+				"to": null,
+				"value": "0x100"
+			}
+		]
+	}`
+
+	// Simulate what scanBlock does internally
+	var block struct {
+		Transactions []struct {
+			Hash  string `json:"hash"`
+			From  string `json:"from"`
+			To    string `json:"to"`
+			Value string `json:"value"`
+		} `json:"transactions"`
+	}
+
+	if err := json.Unmarshal([]byte(blockJSON), &block); err != nil {
+		t.Fatalf("JSON parse failed: %v", err)
+	}
+
+	vaultAddr := "0x3333333333333333333333333333333333333333"
+	vaultLower := strings.ToLower(vaultAddr)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("FINDING (HIGH): Contract creation tx (To=\"\" or null) causes panic: %v", r)
+		}
+	}()
+
+	for i, tx := range block.Transactions {
+		toLower := strings.ToLower(tx.To)
+		isDeposit := toLower == vaultLower && hexToUint64(tx.Value) > 0
+		if isDeposit {
+			t.Errorf("FINDING: contract creation tx %d falsely detected as deposit", i)
+		}
+	}
+	t.Log("CLEAN: Contract creation txs (To=\"\"/null) do not match vault address and do not panic")
+}
+
+func TestSecurityAttack7_ScanBlock_CaseSensitivity(t *testing.T) {
+	// Vault address comparison should be case-insensitive
+	vaultAddr := "0xAbCdEf1234567890AbCdEf1234567890AbCdEf12"
+	vaultLower := strings.ToLower(vaultAddr)
+
+	// Test various casings
+	txToAddresses := []string{
+		"0xabcdef1234567890abcdef1234567890abcdef12",
+		"0xABCDEF1234567890ABCDEF1234567890ABCDEF12",
+		"0xAbCdEf1234567890AbCdEf1234567890AbCdEf12",
+	}
+
+	for _, addr := range txToAddresses {
+		toLower := strings.ToLower(addr)
+		if toLower != vaultLower {
+			t.Errorf("FINDING: Case sensitivity bug — %q != %q after ToLower", toLower, vaultLower)
+		}
+	}
+	t.Log("CLEAN: Vault address comparison is case-insensitive via strings.ToLower")
+}
+
+func TestSecurityAttack7_ScanBlock_ZeroValueETH(t *testing.T) {
+	// Zero-value ETH transfer to vault — should NOT be detected as deposit
+	// The code checks: hexToUint64(tx.Value) > 0
+
+	tests := []struct {
+		value    string
+		isDeposit bool
+		desc     string
+	}{
+		{"0x0", false, "zero value"},
+		{"0x00", false, "zero with padding"},
+		{"0x", false, "empty hex"},
+		{"0x1", true, "1 wei"},
+	}
+
+	vaultAddr := "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	vaultLower := strings.ToLower(vaultAddr)
+
+	for _, tc := range tests {
+		toLower := strings.ToLower(vaultAddr)
+		isDeposit := toLower == vaultLower && hexToUint64(tc.value) > 0
+		if isDeposit != tc.isDeposit {
+			t.Errorf("FINDING: %s (%s) detected as deposit=%v, expected %v",
+				tc.desc, tc.value, isDeposit, tc.isDeposit)
+		}
+	}
+	t.Log("CLEAN: Zero-value ETH transfers are correctly filtered out")
+}
+
+// ===========================================================================
+// Attack 8 — ERC-20 detection: topic padding format
+// ===========================================================================
+
+func TestSecurityAttack8_ERC20_TopicPaddingFormat(t *testing.T) {
+	// The bot constructs: "0x000000000000000000000000" + trimmedVaultAddr
+	// This should produce a valid 32-byte hex value (0x + 64 hex chars)
+
+	vaultAddr := "0xabcdef1234567890abcdef1234567890abcdef12"
+	vaultLower := strings.ToLower(vaultAddr)
+	vaultPadded := "0x000000000000000000000000" + strings.TrimPrefix(vaultLower, "0x")
+
+	// Verify the padded address is 66 chars (0x + 64 hex)
+	if len(vaultPadded) != 66 {
+		t.Errorf("FINDING (HIGH): Padded vault address is %d chars, expected 66. Value: %s",
+			len(vaultPadded), vaultPadded)
+	}
+
+	// Verify it's valid hex
+	_, err := hex.DecodeString(strings.TrimPrefix(vaultPadded, "0x"))
+	if err != nil {
+		t.Errorf("FINDING: Padded vault address is not valid hex: %v", err)
+	}
+
+	// Verify the padding is correct (12 zero bytes = 24 hex chars)
+	padding := vaultPadded[2:26] // after "0x", first 24 chars
+	for _, c := range padding {
+		if c != '0' {
+			t.Errorf("FINDING: Padding contains non-zero char: %c", c)
+		}
+	}
+
+	// Verify the address portion is preserved
+	addrPortion := vaultPadded[26:]
+	expectedAddr := strings.TrimPrefix(vaultLower, "0x")
+	if addrPortion != expectedAddr {
+		t.Errorf("FINDING: Address portion mismatch. Got %q, expected %q",
+			addrPortion, expectedAddr)
+	}
+
+	t.Logf("CLEAN: Topic padding format is correct: %s", vaultPadded)
+}
+
+func TestSecurityAttack8_ERC20_TopicPaddingWithoutPrefix(t *testing.T) {
+	// Edge case: vault address without 0x prefix
+	vaultAddr := "abcdef1234567890abcdef1234567890abcdef12"
+	vaultLower := strings.ToLower(vaultAddr)
+	vaultPadded := "0x000000000000000000000000" + strings.TrimPrefix(vaultLower, "0x")
+
+	// Without 0x prefix, TrimPrefix is a no-op, so address stays full 40 chars
+	if len(vaultPadded) != 66 {
+		t.Errorf("FINDING: Padded vault without 0x prefix is %d chars, expected 66. Value: %s",
+			len(vaultPadded), vaultPadded)
+	} else {
+		t.Log("CLEAN: Vault address without 0x prefix still produces correct padding")
+	}
+}
+
+// ===========================================================================
+// Attack 11 — Arithmetic sweep
+// ===========================================================================
+
+func TestSecurityAttack11_PendingVsConfirmedNonce_Underflow(t *testing.T) {
+	// In handleWithdrawals: pendingNonce <= confirmedNonce → return
+	// But if both parse from empty string → both are 0 → pendingNonce(0) <= confirmedNonce(0) → returns early
+	// This is actually SAFE — it prevents processing when state is empty.
+
+	// The dangerous case: what if the contract state returns non-zero confirmedNonce
+	// but pendingNonce somehow gets corrupted to a smaller value?
+	// The code does: if pendingNonce <= confirmedNonce { return }
+	// This is a <= check, NOT <. So equal values also return early. SAFE.
+
+	confirmedNonce := uint64(5)
+	pendingNonce := uint64(3) // pendingNonce < confirmedNonce
+
+	if pendingNonce <= confirmedNonce {
+		t.Log("CLEAN: pendingNonce(3) <= confirmedNonce(5) → correctly returns early. No underflow.")
+	}
+
+	// But note: the original concern was about subtraction.
+	// grep for "pendingNonce - confirmedNonce" — it doesn't exist in the code.
+	// The code only does comparison: pendingNonce <= confirmedNonce
+	t.Log("CLEAN: No subtraction of pendingNonce - confirmedNonce in the code. Only comparison.")
+}
+
+func TestSecurityAttack11_HexToUint64_NoOverflowProtection(t *testing.T) {
+	// hexToUint64 has no overflow protection — it silently wraps on large inputs
+	// This could affect block height comparisons
+	input := "0x1" + strings.Repeat("0", 20) // way beyond uint64
+
+	result := hexToUint64(input)
+	t.Logf("FINDING (LOW): hexToUint64(%q) = %d — overflows silently, no error. "+
+		"Could corrupt block height comparisons if RPC returns malformed data.", input, result)
+}
+
+func TestSecurityAttack11_ParseInt64_AmountOverflow(t *testing.T) {
+	// PendingSpend.Amount is int64, parsed with strconv.ParseInt
+	// On overflow, ParseInt returns err (which is ignored) and 0
+	overflow := "9999999999999999999999"
+	input := "from|to|eth|" + overflow + "|aabbcc|12345"
+	ps := parsePendingSpend(0, input)
+	if ps == nil {
+		t.Fatal("returned nil")
+	}
+	if ps.Amount == 0 {
+		t.Logf("FINDING (MEDIUM): Amount overflow (%s) silently produces Amount=0. "+
+			"A withdrawal with amount=0 would be created and broadcast. "+
+			"The error from strconv.ParseInt is discarded (line 788: ps.Amount, _ = strconv.ParseInt(...))",
+			overflow)
+	}
+}
+
+func TestSecurityAttack11_BlockHeight_ParseUint64_Overflow(t *testing.T) {
+	// PendingSpend.BlockHeight is uint64, parsed with strconv.ParseUint
+	overflow := "99999999999999999999999"
+	input := "from|to|eth|1000|aabbcc|" + overflow
+	ps := parsePendingSpend(0, input)
+	if ps == nil {
+		t.Fatal("returned nil")
+	}
+	if ps.BlockHeight == 0 {
+		t.Logf("FINDING (LOW): BlockHeight overflow (%s) silently produces BlockHeight=0. "+
+			"Error from strconv.ParseUint is discarded (line 790).", overflow)
+	}
+}
+
+// ===========================================================================
+// Attack 12 — Error handling sweep
+// ===========================================================================
+
+func TestSecurityAttack12_JsonUnmarshal_WrongTypes(t *testing.T) {
+	// What happens when JSON response has wrong types?
+	// The code does json.Unmarshal without checking errors in several places.
+
+	// Test: block number is not a string but a number
+	blockJSON := `{"number": 12345}`
+	var block struct {
+		Number string `json:"number"`
+	}
+	err := json.Unmarshal([]byte(blockJSON), &block)
+	if err != nil {
+		t.Logf("JSON type mismatch error: %v", err)
+	} else {
+		t.Logf("FINDING (MEDIUM): JSON number 12345 silently unmarshals to string %q. "+
+			"If RPC returns number instead of hex string, hexToUint64 will parse it differently. "+
+			"Block.Number=%q", block.Number, block.Number)
+	}
+
+	// Test: what happens when transaction receipt status is a number
+	receiptJSON := `{"status": 1, "blockNumber": "0x100", "transactionIndex": "0x0"}`
+	var receipt struct {
+		Status           string `json:"status"`
+		BlockNumber      string `json:"blockNumber"`
+		TransactionIndex string `json:"transactionIndex"`
+	}
+	err = json.Unmarshal([]byte(receiptJSON), &receipt)
+	if err != nil {
+		t.Logf("FINDING (MEDIUM): Receipt status as integer causes unmarshal error: %v. "+
+			"The bot ignores this error in multiple places, leading to zero-value fields.", err)
+	} else {
+		t.Logf("Receipt status parsed as: %q", receipt.Status)
+	}
+}
+
+func TestSecurityAttack12_CheckpointJsonUnmarshal(t *testing.T) {
+	// loadCheckpoint does json.Unmarshal without checking the error
+	// What happens with corrupted JSON?
+	corrupted := `{"last_scanned_block": "not_a_number", "sent_withdrawals": null}`
+
+	cp := &Checkpoint{SentWithdrawals: make(map[string]SentTx)}
+	err := json.Unmarshal([]byte(corrupted), cp)
+	if err != nil {
+		t.Logf("FINDING (MEDIUM): Corrupted checkpoint JSON produces error: %v. "+
+			"But loadCheckpoint at line 188 ignores this error: `json.Unmarshal(data, cp)`. "+
+			"Partially parsed state could leave LastScannedBlock at 0, "+
+			"causing the bot to rescan from block 1.", err)
+	} else {
+		t.Logf("LastScannedBlock after corrupted JSON: %d", cp.LastScannedBlock)
+	}
+
+	// Test with valid JSON but missing SentWithdrawals
+	valid := `{"last_scanned_block": 100}`
+	cp2 := &Checkpoint{SentWithdrawals: make(map[string]SentTx)}
+	json.Unmarshal([]byte(valid), cp2)
+	if cp2.SentWithdrawals == nil {
+		t.Log("FINDING: SentWithdrawals becomes nil after unmarshal of JSON without that field")
+	} else {
+		t.Log("CLEAN: SentWithdrawals preserved as empty map")
+	}
+}
+
+func TestSecurityAttack12_HexToBytes_InvalidHex(t *testing.T) {
+	// hexToBytes ignores hex.DecodeString error
+	result := hexToBytes("0xZZZZZZ")
+	if len(result) == 0 {
+		t.Log("FINDING (LOW): hexToBytes(\"0xZZZZZZ\") returns empty slice silently. " +
+			"Error from hex.DecodeString is discarded. Could produce empty receipt RLP data.")
+	} else {
+		t.Logf("hexToBytes result: %x", result)
+	}
+}
+
+// ===========================================================================
+// Attack 13 — Zero/default value bypass
+// ===========================================================================
+
+func TestSecurityAttack13_ZeroVaultAddress(t *testing.T) {
+	// What happens when vault address is the zero address?
+	vaultAddr := "0x0000000000000000000000000000000000000000"
+	vaultLower := strings.ToLower(vaultAddr)
+
+	// A contract creation tx has To="" which is different from zero address
+	// But what about a tx explicitly sending to zero address?
+	txTo := "0x0000000000000000000000000000000000000000"
+	txValue := "0x100"
+
+	isDeposit := strings.ToLower(txTo) == vaultLower && hexToUint64(txValue) > 0
+	if isDeposit {
+		t.Log("FINDING (HIGH): Zero vault address matches txs sent to zero address (burn address). " +
+			"This would falsely detect ETH burns as deposits. " +
+			"In production, the config validation at line 116-119 checks for empty vault, " +
+			"but NOT for zero address specifically.")
+	}
+
+	// Check the topic padding for ERC-20 with zero vault
+	vaultPadded := "0x000000000000000000000000" + strings.TrimPrefix(vaultLower, "0x")
+	expectedAllZeros := "0x" + strings.Repeat("0", 64)
+	if vaultPadded == expectedAllZeros {
+		t.Log("FINDING (HIGH): Zero vault address produces all-zero topic filter. " +
+			"This would match ALL ERC-20 Transfer events to the zero address (burns). " +
+			"Every token burn would be treated as a deposit.")
+	}
+}
+
+func TestSecurityAttack13_ZeroChainID(t *testing.T) {
+	// Chain ID 0 in EIP-1559 tx — the bot doesn't set chain ID, it comes from the contract.
+	// If the contract provides chainId=0 in the unsigned tx, the tx would be valid for
+	// any chain (pre-EIP-155 behavior). But EIP-1559 requires chainId.
+	// This is really a contract-side issue, but test that the bot doesn't add protection.
+
+	// The bot doesn't validate or set chain ID anywhere — it trusts the unsigned tx from contract.
+	t.Log("INFO: The bot does not validate chainId in unsigned transactions. " +
+		"It trusts the contract's unsigned tx hex. A malicious or buggy contract could " +
+		"produce a tx with chainId=0.")
+}
+
+func TestSecurityAttack13_EmptyContractID(t *testing.T) {
+	// While parseConfig checks for empty ContractID, what if the state returns empty?
+	// fetchContractLastHeight parses state["h"] which could be ""
+	// strconv.ParseUint("", 10, 64) returns 0 and error, error is ignored
+
+	h := ""
+	height, _ := parseUint64FromString(h)
+	if height != 0 {
+		t.Errorf("expected 0 for empty height string, got %d", height)
+	}
+	t.Log("INFO: Empty contract height state returns 0 — bot would start scanning from block 1")
+}
+
+// helper to match what fetchContractLastHeight does
+func parseUint64FromString(s string) (uint64, error) {
+	return 0, nil // strconv.ParseUint behavior — returns 0 on empty string
+}
+
+// ===========================================================================
+// Attack 2 BONUS — DER signature with sLen pointing beyond buffer
+// ===========================================================================
+
+func TestSecurityAttack2_ParseDER_SLenBeyondBuffer(t *testing.T) {
+	// Construct DER where sLen points beyond available data
+	// This is the most likely exploitable crash vector
+	der := []byte{
+		0x30, 0x08,        // SEQUENCE, total content length 8
+		0x02, 0x01, 0x01,  // INTEGER r=1 (1 byte)
+		0x02, 0x20,        // INTEGER sLen=32, but only 1 byte remains
+		0xFF,
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("FINDING (CRITICAL): parseDERSignature panics when sLen (32) > remaining bytes (1). "+
+				"Panic: %v. An attacker who controls TSS signature output can crash the bot process. "+
+				"The vulnerable code at line 819: `s = der[pos : pos+sLen]` performs no bounds check.", r)
+		}
+	}()
+
+	_, _, err := parseDERSignature(der)
+	if err != nil {
+		t.Logf("Error (safe): %v", err)
+	}
+}
+
+// ===========================================================================
+// Attack 11 BONUS — fetchContractLastHeight with empty/zero state
+// ===========================================================================
+
+func TestSecurityAttack11_ScanUpToCalc(t *testing.T) {
+	// In runOnce: scanUpTo = min(finalized, contractHeight)
+	// If contractHeight is 0 (from empty state), scanUpTo = 0
+	// Then the loop: for h := cp.LastScannedBlock + 1; h <= scanUpTo
+	// If LastScannedBlock is 0 and scanUpTo is 0: for h := 1; h <= 0 → no iterations
+	// SAFE — but if LastScannedBlock > 0, it means no blocks are scanned at all.
+
+	finalized := uint64(1000)
+	contractHeight := uint64(0) // from empty/failed state
+
+	scanUpTo := finalized
+	if contractHeight < scanUpTo {
+		scanUpTo = contractHeight
+	}
+
+	if scanUpTo == 0 {
+		t.Log("INFO: contractHeight=0 causes scanUpTo=0, no blocks scanned. " +
+			"This is safe (no processing) but could stall the bot indefinitely " +
+			"if contract state query consistently fails.")
+	}
+}
+
+// ===========================================================================
+// Attack 3 BONUS — computeSighash with invalid hex
+// ===========================================================================
+
+func TestSecurityAttack3_ComputeSighash_InvalidHex(t *testing.T) {
+	_, err := computeSighash("ZZZZ")
+	if err != nil {
+		t.Logf("CLEAN: computeSighash with invalid hex returns error: %v", err)
+	} else {
+		t.Log("FINDING: computeSighash should error on invalid hex")
+	}
+}
+
+func TestSecurityAttack3_ComputeSighash_Empty(t *testing.T) {
+	result, err := computeSighash("")
+	if err != nil {
+		t.Logf("Error on empty: %v", err)
+	} else {
+		// keccak256 of empty bytes — valid but meaningless
+		t.Logf("INFO: computeSighash(\"\") = %q — keccak256 of empty bytes", result)
+	}
+}
+
+// ===========================================================================
+// Attack 13 BONUS — padLeft edge cases
+// ===========================================================================
+
+func TestSecurityAttack13_PadLeft_LargerThanSize(t *testing.T) {
+	// If r value is > 32 bytes after stripping leading zeros,
+	// padLeft truncates from the LEFT (takes rightmost 32 bytes)
+	bigR := make([]byte, 40)
+	for i := range bigR {
+		bigR[i] = byte(i + 1) // 01 02 03 ... 28
+	}
+
+	padded := padLeft(bigR, 32)
+	if len(padded) != 32 {
+		t.Errorf("expected 32 bytes, got %d", len(padded))
+	}
+	// Should take the LAST 32 bytes: bytes 9..40
+	if padded[0] != 9 {
+		t.Errorf("FINDING: padLeft truncation takes wrong portion. First byte=%d, expected 9", padded[0])
+	} else {
+		t.Log("CLEAN: padLeft correctly takes last 32 bytes when input > 32")
+	}
+}
+
+// ===========================================================================
+// Attack 12 BONUS — Checkpoint save error handling
+// ===========================================================================
+
+func TestSecurityAttack12_CheckpointSave_ErrorIgnored(t *testing.T) {
+	// Checkpoint.save() ignores errors from json.MarshalIndent and os.WriteFile
+	// (lines 198-199). If the disk is full or path is invalid, the bot
+	// continues without persisting state.
+
+	// We can't easily test disk-full, but we can verify the code structure
+	// by documenting the finding.
+	t.Log("FINDING (MEDIUM): Checkpoint.save() at lines 196-200 ignores ALL errors: " +
+		"`data, _ := json.MarshalIndent(cp, \"\", \"  \")` and " +
+		"`os.WriteFile(path, data, 0644)`. " +
+		"If checkpoint file can't be written (disk full, permissions, path traversal), " +
+		"the bot will rescan all blocks from 0 on restart, potentially resubmitting " +
+		"deposit proofs (idempotent) and losing withdrawal tracking (not idempotent — " +
+		"could lead to duplicate broadcasts of withdrawal transactions).")
+}
+
+// ===========================================================================
+// Attack 1 BONUS — parsePendingSpend with pipe in field values
+// ===========================================================================
+
+func TestSecurityAttack1_ParsePendingSpend_PipeInFieldValue(t *testing.T) {
+	// If any field value contains a pipe character, parsing breaks
+	// E.g., a memo or address with | in it
+	input := "from|to|eth|with|pipe|1000|aabbcc|12345"
+	ps := parsePendingSpend(0, input)
+	if ps == nil {
+		t.Log("parsePendingSpend returned nil — treated as having too many fields")
+		return
+	}
+	// Fields would be: from, to, eth, with, pipe, 1000, aabbcc, 12345
+	// Amount would be "with" → ParseInt error → 0
+	// UnsignedTxHex would be "pipe"
+	// BlockHeight would be "1000"
+	if ps.Amount == 0 {
+		t.Logf("FINDING (INFO): Pipe characters in field values corrupt parsing. "+
+			"Amount=%d (should not be 0), UnsignedTxHex=%q (corrupted)",
+			ps.Amount, ps.UnsignedTxHex)
+	}
+}
+
+// ===========================================================================
+// Attack 10 — Ledger Withdraw validation
+// Tests run here because modules/ledger-system/ can't compile test binary
+// (WasmEdge header missing). We test the validation logic directly.
+// ===========================================================================
+
+func TestSecurityAttack10_AssetValidation_UppercaseETH(t *testing.T) {
+	// The Withdraw function checks: slices.Contains([]string{"hive", "hbd", "eth", "usdc"}, withdraw.Asset)
+	// "ETH" (uppercase) should NOT match
+	allowedAssets := []string{"hive", "hbd", "eth", "usdc"}
+	asset := "ETH"
+	found := false
+	for _, a := range allowedAssets {
+		if a == asset {
+			found = true
+			break
+		}
+	}
+	if found {
+		t.Error("FINDING (MEDIUM): Uppercase 'ETH' matches the allowed asset list.")
+	} else {
+		t.Log("CLEAN: Uppercase 'ETH' is correctly rejected by asset validation (case-sensitive check)")
+	}
+}
+
+func TestSecurityAttack10_EthRegexRejectsInvalidHex(t *testing.T) {
+	// ETH_REGEX = "^0x[a-fA-F0-9]{40}$"
+	tests := []struct {
+		addr     string
+		expected bool
+		desc     string
+	}{
+		{"0x1234567890abcdef1234567890abcdef12345678", true, "valid ETH address"},
+		{"0xINVALIDHEXNOTREALADDRESS1234567890aabb", false, "invalid hex chars"},
+		{"", false, "empty string"},
+		{"0x", false, "just prefix"},
+		{"0x1234", false, "too short"},
+		{"0x1234567890abcdef1234567890abcdef12345678ff", false, "too long"},
+		{"1234567890abcdef1234567890abcdef12345678", false, "missing 0x prefix"},
+		{"0x1234567890ABCDEF1234567890ABCDEF12345678", true, "uppercase hex"},
+	}
+
+	for _, tc := range tests {
+		matched, _ := regexp.MatchString(ledgerETH_REGEX, tc.addr)
+		if matched != tc.expected {
+			t.Errorf("FINDING: ETH_REGEX match for %q (%s): got %v, expected %v",
+				tc.addr, tc.desc, matched, tc.expected)
+		}
+	}
+	t.Log("CLEAN: ETH_REGEX correctly validates/rejects all edge cases")
+}
+
+func TestSecurityAttack10_WithdrawEthEmptyAddress(t *testing.T) {
+	// to="eth:" — the code does strings.Split(withdraw.To, ":")[1] to get the address
+	// For "eth:", Split returns ["eth", ""], so ethAddr = ""
+	// Then ETH_REGEX is applied to "" — should NOT match
+	to := "eth:"
+	ethAddr := strings.Split(to, ":")[1]
+	matchedEth, _ := regexp.MatchString(ledgerETH_REGEX, ethAddr)
+	if matchedEth {
+		t.Error("FINDING (HIGH): 'eth:' with empty address matches ETH_REGEX")
+	} else {
+		t.Logf("CLEAN: 'eth:' with empty address correctly rejected by ETH_REGEX. ethAddr=%q", ethAddr)
+	}
+}
+
+func TestSecurityAttack10_WithdrawDIDEmptyAddress(t *testing.T) {
+	// to="did:pkh:eip155:1:" — TrimPrefix gives ""
+	to := "did:pkh:eip155:1:"
+	ethAddr := strings.TrimPrefix(to, "did:pkh:eip155:1:")
+	matchedEth, _ := regexp.MatchString(ledgerETH_REGEX, ethAddr)
+	if matchedEth {
+		t.Error("FINDING (HIGH): 'did:pkh:eip155:1:' with empty address matches ETH_REGEX")
+	} else {
+		t.Logf("CLEAN: 'did:pkh:eip155:1:' with empty address correctly rejected. ethAddr=%q", ethAddr)
+	}
+}
+
+func TestSecurityAttack10_WithdrawHiveEthRouting(t *testing.T) {
+	// to="hive:eth" — must route to Hive validation, not ETH
+	// The Withdraw code checks prefixes in order:
+	//   1. matchedHive (bare Hive name, no prefix)
+	//   2. "hive:" prefix
+	//   3. "eth:" prefix
+	//   4. "did:pkh:eip155:1:" prefix
+	// "hive:eth" starts with "hive:" so enters branch 2 correctly.
+	to := "hive:eth"
+	if strings.HasPrefix(to, "hive:") {
+		splitHive := strings.Split(to, ":")[1]
+		matchedHive, _ := regexp.MatchString(ledgerHIVE_REGEX, splitHive)
+		if matchedHive && len(splitHive) >= 3 && len(splitHive) < 17 {
+			t.Logf("CLEAN: 'hive:eth' correctly routes to Hive validation. "+
+				"'eth' is a valid Hive username (matches HIVE_REGEX, length=%d)", len(splitHive))
+		} else {
+			t.Logf("INFO: 'hive:eth' routed to Hive but rejected. matched=%v, len=%d",
+				matchedHive, len(splitHive))
+		}
+	} else if strings.HasPrefix(to, "eth:") {
+		t.Error("FINDING (HIGH): 'hive:eth' incorrectly routed to ETH validation instead of Hive")
+	}
+}
+
+func TestSecurityAttack10_HiveRegexEdgeCases(t *testing.T) {
+	// HIVE_REGEX = ^[a-z][0-9a-z\-]*[0-9a-z](\.[a-z][0-9a-z\-]*[0-9a-z])*$
+	tests := []struct {
+		name     string
+		expected bool
+		desc     string
+	}{
+		{"ab", true, "minimum 2-char Hive name"},
+		{"a", false, "single char"},
+		{"alice", true, "normal Hive name"},
+		{"Alice", false, "uppercase"},
+		{"a-b", true, "hyphen in middle"},
+		{"-ab", false, "starts with hyphen"},
+		{"ab-", false, "ends with hyphen"},
+		{"ab.cd", true, "multi-part name"},
+		{"", false, "empty"},
+	}
+
+	for _, tc := range tests {
+		matched, _ := regexp.MatchString(ledgerHIVE_REGEX, tc.name)
+		if matched != tc.expected {
+			t.Errorf("FINDING: HIVE_REGEX %q (%s): got %v, expected %v",
+				tc.name, tc.desc, matched, tc.expected)
+		}
+	}
+	t.Log("CLEAN: HIVE_REGEX validation covers edge cases correctly")
+}
+
+func TestSecurityAttack10_TransferableAssetTypes(t *testing.T) {
+	// transferableAssetTypes = []string{"hive", "hbd", "hbd_savings"}
+	// These are the ONLY assets that can be transferred via ExecuteTransfer.
+	// "eth" and "usdc" are NOT transferable — they can only be withdrawn.
+	transferable := []string{"hive", "hbd", "hbd_savings"}
+	notTransferable := []string{"eth", "usdc", "ETH", "USDC", "hive_consensus", ""}
+	for _, asset := range notTransferable {
+		found := false
+		for _, a := range transferable {
+			if a == asset {
+				found = true
+				break
+			}
+		}
+		if found {
+			t.Errorf("FINDING: Asset %q should NOT be in transferableAssetTypes", asset)
+		}
+	}
+	t.Log("CLEAN: 'eth', 'usdc', uppercase variants are not in transferableAssetTypes")
+}
+
+func TestSecurityAttack10_WithdrawColonInjection(t *testing.T) {
+	// "eth:0x1234...1234:malicious" — Split(":") gives ["eth", "0x1234...1234", "malicious"]
+	// Code uses Split(":")[1] which only takes the address part. Extra is silently dropped.
+	to := "eth:0x1234567890abcdef1234567890abcdef12345678:malicious"
+	if strings.HasPrefix(to, "eth:") {
+		ethAddr := strings.Split(to, ":")[1]
+		matchedEth, _ := regexp.MatchString(ledgerETH_REGEX, ethAddr)
+		if matchedEth {
+			t.Logf("FINDING (LOW): 'eth:address:extra' — ':malicious' suffix silently dropped. "+
+				"ethAddr=%q. Not exploitable (regex validates), but extra data silently ignored.", ethAddr)
+		}
+	}
+}


### PR DESCRIPTION
Brings `cmd/evm-mapping-bot/` onto current `develop` plus the per-receipt `logIndex` fix the contract reader requires.

### Commits on top of `develop@1ddfc681`

| | |
|---|---|
| `642371d2` | Evm mapping bot (cherry-pick from `feature/evm-mapping-bot`) |
| `488cd080` | EVM mapping bot testnet fixes (same source) |
| `ee606170` | W4-A CRIT #C14 — per-receipt logIndex resolver (+ F2 hardening) |

### Why the CRIT #C14 patch

`eth_getLogs` returns BLOCK-level `logIndex`; the deposit-proof contract reader expects PER-RECEIPT index (0..N-1 within the tx's own logs list). The bare bot writes block-level → wrong by accident when a tx has one matching log, broken when a tx emits two `Transfer(token → vault)` logs (both deposits collide on `IsObserved`, second is permanently uncreditable).

Adds `lookupPerReceiptLogIndex(...)` to fetch the receipt, match the SPECIFIC log by its block-level index, and return its per-receipt array position. Reuses upstream's existing `rpc.getReceipt`/`TransferEventSig`/`hexToUint64` — no new helpers. F2 hardening: rejects non-standard RPCs that omit `logIndex` (would otherwise silently match block index 0).

### Scope / coupling

- 2 files touched, +77/-9 over the upstream bot.
- `go build ./cmd/evm-mapping-bot/` clean; `gofmt` clean.
- No changes outside `cmd/evm-mapping-bot/`.
- Companion contract-side fix (CRIT #C14 monitor side) lives in  `vsc-eco/account-mapping` — must ship together.