### PR TITLE
feat(contracts): timelock contract updates 48h before activation

### DIFF
--- a/cmd/contract-deployer/args.go
+++ b/cmd/contract-deployer/args.go
@@ -20,6 +20,10 @@ type args struct {
 	// update contract args
 	contractId string
 
+	// cancel a pending (timelocked) contract update
+	cancelUpdate bool
+	cancelTxId   string
+
 	// offline-signing args (Ledger / hardware-wallet flow)
 	noBroadcast     bool
 	out             string
@@ -56,6 +60,16 @@ func ParseArgs() (args, error) {
 		"Existing contract ID to update contract. Omit to deploy a new contract.",
 	)
 	sysconfigPath := flag.String("sysconfig", "", "Path to JSON file with system config overrides")
+	cancelUpdate := flag.Bool(
+		"cancel-update",
+		false,
+		"Cancel a pending (timelocked) contract update for -contractId instead of deploying/updating. Owner-only.",
+	)
+	cancelTxId := flag.String(
+		"cancel-tx",
+		"",
+		"With -cancel-update: tx id of the specific queued update to cancel. Omit to cancel all pending updates for the contract.",
+	)
 	noBroadcast := flag.Bool(
 		"no-broadcast",
 		false,
@@ -100,6 +114,8 @@ func ParseArgs() (args, error) {
 		dataDir:         *dataDir,
 		sysconfigPath:   *sysconfigPath,
 		contractId:      *contractId,
+		cancelUpdate:    *cancelUpdate,
+		cancelTxId:      *cancelTxId,
 		noBroadcast:     *noBroadcast,
 		out:             *out,
 		expiration:      *expiration,

--- a/cmd/contract-deployer/main.go
+++ b/cmd/contract-deployer/main.go
@@ -80,12 +80,25 @@ func main() {
 		fmt.Println("generated config files successfully")
 		os.Exit(0)
 	}
+	if args.cancelUpdate && args.contractId == "" {
+		fmt.Println("contractId must be specified to cancel a pending contract update")
+		os.Exit(1)
+	}
 	if args.contractId == "" && args.wasmPath == "" {
 		fmt.Println("Path to compiled WASM bytecode must be specified when deploying new contract")
 		os.Exit(1)
 	}
 
 	a.Start()
+
+	if args.cancelUpdate {
+		cancelContractUpdate(sysConfig, identityConfig, hiveConfig, args)
+		if err = a.Stop(); err != nil {
+			fmt.Println("failed to stop plugins", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	if args.wasmPath != "" {
 		code, err := os.ReadFile(args.wasmPath)
@@ -226,6 +239,45 @@ func updateContract(
 	}
 
 	submitOrPrepare(sysConfig, identityConfig, hiveConfig, ops, user, args)
+}
+
+// cancelContractUpdate posts a vsc.cancel_contract_update op that tombstones a
+// queued contract update still inside its timelock window. Owner-gated and free
+// (no deployment fee). With args.cancelTxId set, only that queued update is
+// cancelled; otherwise every pending update for the contract is.
+func cancelContractUpdate(
+	sysConfig systemconfig.SystemConfig,
+	identityConfig common.IdentityConfig,
+	hiveConfig streamer.HiveConfig,
+	args args,
+) {
+	user := identityConfig.Get().HiveUsername
+	if len(user) == 0 {
+		fmt.Println("could not cancel update as username is not specified in identityConfig.json")
+		return
+	}
+
+	tx := stateEngine.TxCancelContractUpdate{
+		NetId: sysConfig.NetId(),
+		Id:    args.contractId,
+		TxId:  args.cancelTxId,
+	}
+
+	j, err := json.Marshal(tx)
+	if err != nil {
+		fmt.Println("failed to marshal tx json data", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(j))
+
+	cancelOp := hivego.CustomJsonOperation{
+		RequiredAuths:        []string{user},
+		RequiredPostingAuths: []string{},
+		Id:                   "vsc.cancel_contract_update",
+		Json:                 string(j),
+	}
+
+	submitOrPrepare(sysConfig, identityConfig, hiveConfig, []hivego.HiveOperation{cancelOp}, user, args)
 }
 
 // submitOrPrepare either broadcasts the operations with the local active key

--- a/cmd/contract-deployer/main.go
+++ b/cmd/contract-deployer/main.go
@@ -160,8 +160,10 @@ func deployNewContract(
 	}
 	fmt.Println(string(j))
 
+	// Mainnet uses HBD; every test network (testnet/devnet) runs on a Hive
+	// testnet chain whose HBD-equivalent symbol is TBD.
 	currency := "HBD"
-	if sysConfig.OnTestnet() {
+	if !sysConfig.OnMainnet() {
 		currency = "TBD"
 	}
 
@@ -216,8 +218,10 @@ func updateContract(
 	}
 	fmt.Println(string(j))
 
+	// Mainnet uses HBD; every test network (testnet/devnet) runs on a Hive
+	// testnet chain whose HBD-equivalent symbol is TBD.
 	currency := "HBD"
-	if sysConfig.OnTestnet() {
+	if !sysConfig.OnMainnet() {
 		currency = "TBD"
 	}
 

--- a/lib/test_utils/mock_contracts.go
+++ b/lib/test_utils/mock_contracts.go
@@ -29,6 +29,22 @@ func (m *MockContractDb) FindContracts(contractId *string, code *string, histori
 	return []contracts.Contract{}, nil
 }
 
+// GraphQL use only, not implemented in mocks
+func (m *MockContractDb) FindActiveContracts(contractId *string, code *string, head uint64, offset int, limit int) ([]contracts.Contract, error) {
+	return []contracts.Contract{}, nil
+}
+
+// GraphQL use only, not implemented in mocks
+func (m *MockContractDb) FindPendingUpdates(contractId *string, head uint64, offset int, limit int) ([]contracts.Contract, error) {
+	return []contracts.Contract{}, nil
+}
+
+// CancelPendingUpdate is a no-op in the single-version mock (the timelock /
+// pending-version semantics are covered by the real mongo-backed contracts tests).
+func (m *MockContractDb) CancelPendingUpdate(contractId string, head uint64, cancelledHeight uint64, cancelledTx string, targetTx *string) (int, error) {
+	return 0, nil
+}
+
 type MockContractStateDb struct {
 	aggregate.Plugin
 	Outputs map[string]contracts.ContractOutput

--- a/modules/common/params/params.go
+++ b/modules/common/params/params.go
@@ -99,12 +99,18 @@ var CONTRACT_UPDATE_TIMELOCK_BLOCKS_TESTNET uint64 = 30
 
 // CONTRACT_UPDATE_TIMELOCK_HEIGHT is the MAINNET rollout gate. Updates submitted
 // at/after this Hive height are timelocked; earlier ones stay immediate so a
-// full reindex reproduces historical state byte-for-byte. 0 == disabled until
-// pinned. MUST be set to a height STRICTLY ABOVE the current chain head before
-// rollout — a value at/below an already-processed block is a consensus footgun
+// full reindex reproduces historical state byte-for-byte. 0 == disabled.
+// MUST be a height STRICTLY ABOVE the current chain head when this binary is
+// deployed — a value at/below an already-processed block is a consensus footgun
 // (live nodes activated those updates immediately, a reindex would delay them).
 // Non-mainnet networks ignore this gate (always timelocked at their block count).
-var CONTRACT_UPDATE_TIMELOCK_HEIGHT uint64 = 0
+//
+// Pinned 2026-06-05 to ~1h above the Hive head at the time (107,009,647 @ 15:09
+// UTC) per a fast rollout. CONSENSUS-CRITICAL DEPLOY CONSTRAINT: every mainnet
+// witness must be running this binary BEFORE Hive reaches this height, otherwise
+// upgraded and not-yet-upgraded nodes disagree on whether updates in the gap are
+// timelocked. If the rollout slips past this height, bump it before deploying.
+var CONTRACT_UPDATE_TIMELOCK_HEIGHT uint64 = 107_011_000
 
 // review2 LOW #70/#110: contract-call payloads were only UTF-8 checked,
 // with no explicit length cap — the node implicitly relied on Hive's

--- a/modules/common/params/params.go
+++ b/modules/common/params/params.go
@@ -75,6 +75,37 @@ var CONTRACT_DEPLOYMENT_FEE_START_HEIGHT uint64 = 99410000
 var CONTRACT_UPDATE_HEIGHT uint64 = 102100000
 var CONTRACT_CALL_MAX_RECURSION_DEPTH = 20
 
+// ───── Contract update timelock ─────
+//
+// A vsc.update_contract is queued and only takes effect after this many Hive L1
+// blocks (3s/block) have passed since it was submitted. During the window the
+// previously-active code keeps running; the active version at any height H is
+// the newest one whose activation_height <= H (see contracts.ContractById).
+//
+// This is a CONSENSUS RULE enforced on the deterministic state-processing replay
+// path, so it MUST be identical on every node. The value is therefore network-
+// baked in system-config and intentionally NOT exposed via -sysconfig overrides:
+// no single operator can shorten it (a custom binary just forks that node off
+// consensus, since the honest supermajority won't sign its divergent state).
+
+// CONTRACT_UPDATE_TIMELOCK_BLOCKS is the mainnet timelock: 57,600 blocks ≈ 48h.
+var CONTRACT_UPDATE_TIMELOCK_BLOCKS uint64 = 57_600
+
+// CONTRACT_UPDATE_TIMELOCK_BLOCKS_TESTNET is the shorter delay used on test
+// networks (testnet/devnet) so the timelock is exercisable: 30 blocks ≈ 90s.
+// Mocknet uses 0 (disabled) so the in-process e2e harness keeps its immediate-
+// update mechanics.
+var CONTRACT_UPDATE_TIMELOCK_BLOCKS_TESTNET uint64 = 30
+
+// CONTRACT_UPDATE_TIMELOCK_HEIGHT is the MAINNET rollout gate. Updates submitted
+// at/after this Hive height are timelocked; earlier ones stay immediate so a
+// full reindex reproduces historical state byte-for-byte. 0 == disabled until
+// pinned. MUST be set to a height STRICTLY ABOVE the current chain head before
+// rollout — a value at/below an already-processed block is a consensus footgun
+// (live nodes activated those updates immediately, a reindex would delay them).
+// Non-mainnet networks ignore this gate (always timelocked at their block count).
+var CONTRACT_UPDATE_TIMELOCK_HEIGHT uint64 = 0
+
 // review2 LOW #70/#110: contract-call payloads were only UTF-8 checked,
 // with no explicit length cap — the node implicitly relied on Hive's
 // ~8KB custom_json limit. Cap explicitly so the bound is enforced

--- a/modules/common/params/params.go
+++ b/modules/common/params/params.go
@@ -95,22 +95,10 @@ var CONTRACT_UPDATE_TIMELOCK_BLOCKS uint64 = 57_600
 // networks (testnet/devnet) so the timelock is exercisable: 30 blocks ≈ 90s.
 // Mocknet uses 0 (disabled) so the in-process e2e harness keeps its immediate-
 // update mechanics.
-var CONTRACT_UPDATE_TIMELOCK_BLOCKS_TESTNET uint64 = 30
-
-// CONTRACT_UPDATE_TIMELOCK_HEIGHT is the MAINNET rollout gate. Updates submitted
-// at/after this Hive height are timelocked; earlier ones stay immediate so a
-// full reindex reproduces historical state byte-for-byte. 0 == disabled.
-// MUST be a height STRICTLY ABOVE the current chain head when this binary is
-// deployed — a value at/below an already-processed block is a consensus footgun
-// (live nodes activated those updates immediately, a reindex would delay them).
-// Non-mainnet networks ignore this gate (always timelocked at their block count).
 //
-// Pinned 2026-06-05 to ~1h above the Hive head at the time (107,009,647 @ 15:09
-// UTC) per a fast rollout. CONSENSUS-CRITICAL DEPLOY CONSTRAINT: every mainnet
-// witness must be running this binary BEFORE Hive reaches this height, otherwise
-// upgraded and not-yet-upgraded nodes disagree on whether updates in the gap are
-// timelocked. If the rollout slips past this height, bump it before deploying.
-var CONTRACT_UPDATE_TIMELOCK_HEIGHT uint64 = 107_011_000
+// The MAINNET rollout gate height lives in ConsensusParams.ContractUpdateTimelockHeight
+// (set per-network in system-config), alongside the other rollout heights.
+var CONTRACT_UPDATE_TIMELOCK_BLOCKS_TESTNET uint64 = 30
 
 // review2 LOW #70/#110: contract-call payloads were only UTF-8 checked,
 // with no explicit length cap — the node implicitly relied on Hive's
@@ -168,6 +156,23 @@ type ConsensusParams struct {
 	// verbatim behavior) — the correct default until an operator pins the
 	// activation height for a deploy.
 	EvmAddressChecksumHeight uint64 `json:"evmAddressChecksumHeight,omitempty"`
+
+	// ContractUpdateTimelockHeight is the MAINNET rollout gate for the contract-
+	// update timelock. A vsc.update_contract submitted at BlockHeight >= this value
+	// is queued and only activates after the network timelock
+	// (ContractUpdateTimelockBlocks); earlier updates stay immediate so a full
+	// reindex reproduces historical state byte-for-byte. 0 == disabled (every
+	// update immediate). Only consulted on mainnet — test networks always timelock
+	// at their block count and ignore this gate.
+	//
+	// MUST be a height STRICTLY ABOVE the current chain head when this binary is
+	// deployed — a value at/below an already-processed block is a consensus footgun
+	// (live nodes activated those updates immediately, a reindex would delay them).
+	// CONSENSUS-CRITICAL DEPLOY CONSTRAINT: every mainnet witness must be running a
+	// binary with this gate BEFORE Hive reaches it, otherwise upgraded and not-yet-
+	// upgraded nodes disagree on whether updates in the gap are timelocked. If the
+	// rollout slips past this height, bump it before deploying.
+	ContractUpdateTimelockHeight uint64 `json:"contractUpdateTimelockHeight,omitempty"`
 
 	// RecoveryMultisigAccounts are Hive account names (no hive: prefix) authorized to post
 	// vsc.recovery_suspend and vsc.recovery_require_version.

--- a/modules/common/system-config/system-config.go
+++ b/modules/common/system-config/system-config.go
@@ -209,6 +209,11 @@ func MainnetConfig() SystemConfig {
 			ConsensusVersionFloorConsensus: 1,
 			PendulumSeedEpoch:              1622,
 			EvmAddressChecksumHeight:       106_907_500,
+			// Mainnet contract-update timelock rollout gate (see
+			// ConsensusParams.ContractUpdateTimelockHeight). Updates at/after this
+			// height are timelocked 48h; earlier ones stay immediate. MUST be bumped
+			// above the chain head at deploy time if the rollout slips past it.
+			ContractUpdateTimelockHeight: 0,
 		},
 		oracleParams: params.OracleParams{
 			ChainContracts: map[string]string{

--- a/modules/common/system-config/system-config.go
+++ b/modules/common/system-config/system-config.go
@@ -19,6 +19,11 @@ type SystemConfig interface {
 	GatewayWallet() string
 	StartHeight() uint64
 	ConsensusParams() params.ConsensusParams
+	// ContractUpdateTimelockBlocks is the network's contract-update timelock in
+	// Hive L1 blocks (3s/block). 0 means updates activate immediately. Network-
+	// baked and NOT overridable via -sysconfig: a consensus rule every node must
+	// share so no single operator can shorten it.
+	ContractUpdateTimelockBlocks() uint64
 	OracleParams() params.OracleParams
 	TssParams() params.TssParams
 	PendulumPoolWhitelist() []string
@@ -26,16 +31,19 @@ type SystemConfig interface {
 }
 
 type config struct {
-	network               string
-	bootstrapPeers        []string
-	netId                 string
-	hiveChainId           string
-	gatewayWallet         string
-	startHeight           uint64
-	consensusParams       params.ConsensusParams
-	oracleParams          params.OracleParams
-	tssParams             params.TssParams
-	pendulumPoolWhitelist []string
+	network         string
+	bootstrapPeers  []string
+	netId           string
+	hiveChainId     string
+	gatewayWallet   string
+	startHeight     uint64
+	consensusParams params.ConsensusParams
+	// Network-baked contract-update timelock length (Hive L1 blocks). Deliberately
+	// absent from SysConfigOverrides so it cannot be changed per-operator.
+	contractUpdateTimelockBlocks uint64
+	oracleParams                 params.OracleParams
+	tssParams                    params.TssParams
+	pendulumPoolWhitelist        []string
 }
 
 func (c *config) OnMainnet() bool {
@@ -75,6 +83,10 @@ func (c *config) GatewayWallet() string {
 }
 func (c *config) ConsensusParams() params.ConsensusParams {
 	return c.consensusParams
+}
+
+func (c *config) ContractUpdateTimelockBlocks() uint64 {
+	return c.contractUpdateTimelockBlocks
 }
 
 func (c *config) OracleParams() params.OracleParams {
@@ -182,6 +194,8 @@ func MainnetConfig() SystemConfig {
 		hiveChainId:    "beeab0de00000000000000000000000000000000000000000000000000000000",
 		gatewayWallet:  "vsc.gateway",
 		startHeight:    94601000,
+		// 48h timelock on contract updates (see params.CONTRACT_UPDATE_TIMELOCK_BLOCKS).
+		contractUpdateTimelockBlocks: params.CONTRACT_UPDATE_TIMELOCK_BLOCKS,
 		consensusParams: params.ConsensusParams{
 			MinStake:                       params.CONSENSUS_MINIMUM,
 			MinMembers:                     7,
@@ -221,6 +235,8 @@ func TestnetConfig() SystemConfig {
 		hiveChainId:    "18dcf0a285365fc58b71f18b3d3fec954aa0c141c44e4e5cb4cf777b9eab274e",
 		gatewayWallet:  "vsc.gateway",
 		startHeight:    2,
+		// Short (~90s) timelock so the mechanism is testable on testnet.
+		contractUpdateTimelockBlocks: params.CONTRACT_UPDATE_TIMELOCK_BLOCKS_TESTNET,
 		consensusParams: params.ConsensusParams{
 			MinStake:                       params.CONSENSUS_MINIMUM,
 			MinMembers:                     3,
@@ -270,6 +286,8 @@ func DevnetConfig() SystemConfig {
 		hiveChainId:   "18dcf0a285365fc58b71f18b3d3fec954aa0c141c44e4e5cb4cf777b9eab274e",
 		gatewayWallet: "vsc.gateway",
 		startHeight:   2,
+		// Short (~90s) timelock so the mechanism is testable on devnet.
+		contractUpdateTimelockBlocks: params.CONTRACT_UPDATE_TIMELOCK_BLOCKS_TESTNET,
 		consensusParams: params.ConsensusParams{
 			MinStake:                      1000,
 			MinMembers:                    3,
@@ -295,6 +313,9 @@ func MocknetConfig() SystemConfig {
 		hiveChainId:   "123456789abcdef000000000000000000000000000000000000000000000000",
 		gatewayWallet: "vsc.mocknet",
 		startHeight:   0,
+		// Disabled (0): the in-process e2e harness updates then immediately
+		// executes a contract and relies on updates taking effect at once.
+		contractUpdateTimelockBlocks: 0,
 		consensusParams: params.ConsensusParams{
 			MinStake:                      1,
 			MinMembers:                    3,

--- a/modules/db/vsc/contracts/contracts.go
+++ b/modules/db/vsc/contracts/contracts.go
@@ -45,19 +45,49 @@ func (e *contracts) Init() error {
 		return fmt.Errorf("failed to create index: %w", err)
 	}
 
+	// Index for activation-height lookups (active version + pending updates).
+	activationIndex := mongo.IndexModel{
+		Keys: bson.D{{Key: "id", Value: 1}, {Key: "activation_height", Value: -1}},
+	}
+	err = e.CreateIndexIfNotExist(activationIndex)
+	if err != nil {
+		return fmt.Errorf("failed to create index: %w", err)
+	}
+
+	// Backfill: rows written before the timelock feature have no activation_height.
+	// Treat them as immediate (activation == creation) so the activation-aware
+	// ContractById reproduces the pre-feature result exactly. Idempotent.
+	_, err = e.UpdateMany(
+		context.Background(),
+		bson.M{"activation_height": bson.M{"$exists": false}},
+		mongo.Pipeline{{{Key: "$set", Value: bson.M{"activation_height": "$creation_height"}}}},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to backfill activation_height: %w", err)
+	}
+
 	return nil
 }
 
-// ContractById implements Contracts.
+// ContractById returns the version of a contract that is ACTIVE at the given
+// height: the newest one whose activation_height has been reached and that has
+// not been cancelled. This is the single execution chokepoint, so a timelocked
+// (queued) update is invisible here — the previously-active code keeps running —
+// until its activation_height <= height. Pre-feature rows have
+// activation_height == creation_height, so this matches the old behavior exactly.
 func (c *contracts) ContractById(contractId string, height uint64) (Contract, error) {
 	res := Contract{}
 	filter := bson.M{
 		"id": contractId,
-		"creation_height": bson.M{
+		"activation_height": bson.M{
 			"$lte": height,
 		},
+		"cancelled": bson.M{"$ne": true},
 	}
-	opts := options.FindOne().SetSort(bson.M{"creation_height": -1})
+	opts := options.FindOne().SetSort(bson.D{
+		{Key: "activation_height", Value: -1},
+		{Key: "creation_height", Value: -1},
+	})
 	qRes := c.FindOne(context.TODO(), filter, opts)
 	if err := qRes.Err(); err != nil {
 		return res, err
@@ -97,20 +127,32 @@ func (c *contracts) FindContracts(contractId *string, code *string, historical *
 
 func (c *contracts) RegisterContract(contractId string, args Contract) {
 	// TODO: config to prune old versions
+
+	// A version can never activate before it was submitted. Default to immediate
+	// (activation == creation) so direct callers/tests that don't set
+	// ActivationHeight, and backfilled rows, never resolve to a future-created
+	// version in ContractById's activation_height <= height filter.
+	activationHeight := args.ActivationHeight
+	if activationHeight < args.CreationHeight {
+		activationHeight = args.CreationHeight
+	}
+
 	findQuery := bson.M{
 		"id":              contractId,
 		"creation_height": args.CreationHeight,
 	}
 	updateQuery := bson.M{
 		"$set": bson.M{
-			"code":        args.Code,
-			"name":        args.Name,
-			"description": args.Description,
-			"creator":     args.Creator,
-			"owner":       args.Owner,
-			"tx_id":       args.TxId,
-			"runtime":     args.Runtime,
-			"latest":      true,
+			"code":              args.Code,
+			"name":              args.Name,
+			"description":       args.Description,
+			"creator":           args.Creator,
+			"owner":             args.Owner,
+			"tx_id":             args.TxId,
+			"runtime":           args.Runtime,
+			"activation_height": activationHeight,
+			"proposer":          args.Proposer,
+			"latest":            true,
 		},
 	}
 	opts := options.FindOneAndUpdate().SetUpsert(true)
@@ -125,6 +167,127 @@ func (c *contracts) RegisterContract(contractId string, args Contract) {
 	}
 	c.UpdateMany(context.Background(), oldVersionsFilter, oldVersionsUpdate)
 	c.FindOneAndUpdate(context.Background(), findQuery, updateQuery, opts)
+}
+
+// FindActiveContracts returns, for each matching contract id, the version that is
+// ACTIVE at head (newest non-cancelled version with activation_height <= head).
+// Pending (timelocked) versions are excluded. Backs the default findContract.
+func (c *contracts) FindActiveContracts(contractId *string, code *string, head uint64, offset int, limit int) ([]Contract, error) {
+	match := bson.D{
+		{Key: "activation_height", Value: bson.M{"$lte": head}},
+		{Key: "cancelled", Value: bson.M{"$ne": true}},
+	}
+	if contractId != nil {
+		match = append(match, bson.E{Key: "id", Value: *contractId})
+	}
+	if code != nil {
+		match = append(match, bson.E{Key: "code", Value: *code})
+	}
+	pipe := mongo.Pipeline{
+		{{Key: "$match", Value: match}},
+		// Newest activated version first, then collapse to one row per id.
+		{{Key: "$sort", Value: bson.D{
+			{Key: "id", Value: 1},
+			{Key: "activation_height", Value: -1},
+			{Key: "creation_height", Value: -1},
+		}}},
+		{{Key: "$group", Value: bson.D{
+			{Key: "_id", Value: "$id"},
+			{Key: "doc", Value: bson.M{"$first": "$$ROOT"}},
+		}}},
+		{{Key: "$replaceRoot", Value: bson.M{"newRoot": "$doc"}}},
+		{{Key: "$sort", Value: bson.D{{Key: "id", Value: 1}}}},
+	}
+	if offset > 0 {
+		pipe = append(pipe, bson.D{{Key: "$skip", Value: offset}})
+	}
+	if limit > 0 {
+		pipe = append(pipe, bson.D{{Key: "$limit", Value: limit}})
+	}
+	pipe = append(pipe, creationTimestampLookup()...)
+	return c.runContractPipeline(pipe)
+}
+
+// FindPendingUpdates returns queued contract updates that have NOT yet activated
+// at head (activation_height > head, not cancelled). Each row exposes the new
+// code, proposer, and activation_height — i.e. which contract gets what new code,
+// by whom, and when it goes live. Backs findPendingContractUpdates.
+func (c *contracts) FindPendingUpdates(contractId *string, head uint64, offset int, limit int) ([]Contract, error) {
+	filters := bson.D{
+		{Key: "activation_height", Value: bson.M{"$gt": head}},
+		{Key: "cancelled", Value: bson.M{"$ne": true}},
+	}
+	if contractId != nil {
+		filters = append(filters, bson.E{Key: "id", Value: *contractId})
+	}
+	// Soonest-to-activate first.
+	pipe := hive_blocks.GetAggTimestampPipeline(filters, "creation_height", "creation_ts", offset, limit)
+	return c.runContractPipeline(pipe)
+}
+
+// CancelPendingUpdate tombstones still-pending (activation_height > head, not yet
+// cancelled) versions of a contract. When targetTx is non-nil only the version
+// queued by that tx is cancelled; otherwise every pending version is. Returns the
+// number of versions cancelled.
+func (c *contracts) CancelPendingUpdate(contractId string, head uint64, cancelledHeight uint64, cancelledTx string, targetTx *string) (int, error) {
+	filter := bson.M{
+		"id":                contractId,
+		"activation_height": bson.M{"$gt": head},
+		"cancelled":         bson.M{"$ne": true},
+	}
+	if targetTx != nil {
+		filter["tx_id"] = *targetTx
+	}
+	update := bson.M{
+		"$set": bson.M{
+			"cancelled":        true,
+			"cancelled_height": cancelledHeight,
+			"cancelled_tx":     cancelledTx,
+		},
+		"$unset": bson.M{
+			"latest": "",
+		},
+	}
+	res, err := c.UpdateMany(context.Background(), filter, update)
+	if err != nil {
+		return 0, err
+	}
+	return int(res.ModifiedCount), nil
+}
+
+// creationTimestampLookup joins hive_blocks to populate creation_ts from the
+// creation_height block, matching the tail of hive_blocks.GetAggTimestampPipeline
+// (used where a $group precedes pagination so the shared helper can't be reused
+// wholesale).
+func creationTimestampLookup() mongo.Pipeline {
+	return mongo.Pipeline{
+		{{Key: "$lookup", Value: bson.D{
+			{Key: "from", Value: "hive_blocks"},
+			{Key: "localField", Value: "creation_height"},
+			{Key: "foreignField", Value: "block.block_number"},
+			{Key: "as", Value: "block_info"},
+		}}},
+		{{Key: "$unwind", Value: "$block_info"}},
+		{{Key: "$addFields", Value: bson.D{{Key: "creation_ts", Value: "$block_info.block.timestamp"}}}},
+		{{Key: "$project", Value: bson.D{{Key: "block_info", Value: 0}}}},
+	}
+}
+
+func (c *contracts) runContractPipeline(pipe mongo.Pipeline) ([]Contract, error) {
+	cursor, err := c.Aggregate(context.TODO(), pipe)
+	if err != nil {
+		return []Contract{}, err
+	}
+	defer cursor.Close(context.TODO())
+	var results []Contract
+	for cursor.Next(context.TODO()) {
+		var elem Contract
+		if err := cursor.Decode(&elem); err != nil {
+			return []Contract{}, err
+		}
+		results = append(results, elem)
+	}
+	return results, nil
 }
 
 type contractState struct {

--- a/modules/db/vsc/contracts/contracts_test.go
+++ b/modules/db/vsc/contracts/contracts_test.go
@@ -1,0 +1,241 @@
+package contracts_test
+
+import (
+	"context"
+	"testing"
+
+	"vsc-node/lib/test_utils"
+	"vsc-node/modules/aggregate"
+	"vsc-node/modules/config"
+	"vsc-node/modules/db"
+	"vsc-node/modules/db/vsc"
+	"vsc-node/modules/db/vsc/contracts"
+	"vsc-node/modules/db/vsc/hive_blocks"
+	wasm_runtime "vsc-node/modules/wasm/runtime"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// These tests exercise the contract-update timelock at the DB layer: a queued
+// update (a version whose activation_height is in the future) must stay invisible
+// to ContractById — the chokepoint every code-execution path uses — until the
+// query height reaches its activation, and a cancelled update must never activate.
+
+const (
+	createHeight = uint64(100)
+	updateHeight = uint64(150)
+	// Activation 30 blocks after the update was submitted (mirrors the testnet
+	// timelock); the DB layer is told the activation height explicitly — the
+	// duration policy lives in the state engine, not here.
+	activateHeight = uint64(180)
+)
+
+func setupContractsDB(t *testing.T) (contracts.Contracts, hive_blocks.HiveBlocks, db.Db, db.DbConfig) {
+	config.UseMainConfigDuringTests = true
+	dbConfig := db.NewDbConfig()
+	dbConfig.Init()
+	dbConfig.SetDbName("go-vsc-contracts-test")
+	dbi := db.New(dbConfig)
+	v := vsc.New(dbi, dbConfig)
+	c := contracts.New(v)
+	hb, err := hive_blocks.New(v)
+	assert.NoError(t, err)
+
+	test_utils.RunPlugin(t, aggregate.New([]aggregate.Plugin{
+		dbConfig, dbi, v, c, hb,
+	}))
+	err = v.Clear()
+	assert.NoError(t, err)
+	return c, hb, dbi, dbConfig
+}
+
+// seedBlocks stores hive_blocks docs so the creation_ts $lookup/$unwind in
+// FindActiveContracts/FindPendingUpdates resolves (the unwind drops rows with no
+// matching block). Activation heights are NOT joined, so they need no block.
+func seedBlocks(t *testing.T, hb hive_blocks.HiveBlocks, heights ...uint64) {
+	for _, h := range heights {
+		err := hb.StoreBlocks(h, hive_blocks.HiveBlock{
+			BlockNumber: h,
+			BlockID:     "blk",
+			Timestamp:   "2026-06-05T00:00:00",
+		})
+		assert.NoError(t, err)
+	}
+}
+
+// registerWithTimelock seeds a contract created at createHeight and a code update
+// queued at updateHeight that activates at activateHeight.
+func registerWithTimelock(c contracts.Contracts) string {
+	id := "vsc1timelocktest"
+	c.RegisterContract(id, contracts.Contract{
+		Code:             "codeA",
+		Name:             "test",
+		Creator:          "hive:alice",
+		Owner:            "hive:alice",
+		Proposer:         "hive:alice",
+		TxId:             "tx-create",
+		CreationHeight:   createHeight,
+		ActivationHeight: createHeight,
+		Runtime:          wasm_runtime.Go,
+	})
+	c.RegisterContract(id, contracts.Contract{
+		Code:             "codeB",
+		Name:             "test",
+		Creator:          "hive:alice",
+		Owner:            "hive:alice",
+		Proposer:         "hive:alice",
+		TxId:             "tx-update",
+		CreationHeight:   updateHeight,
+		ActivationHeight: activateHeight,
+		Runtime:          wasm_runtime.Go,
+	})
+	return id
+}
+
+// A queued code update does not become the active code until its activation
+// height; the previously-active code keeps running for the whole window.
+func TestContractById_TimelockGatesActivation(t *testing.T) {
+	c, hb, _, _ := setupContractsDB(t)
+	seedBlocks(t, hb, createHeight, updateHeight)
+	id := registerWithTimelock(c)
+
+	cases := []struct {
+		height   uint64
+		wantCode string
+	}{
+		{createHeight, "codeA"}, // right after deploy
+		{updateHeight, "codeA"}, // update just submitted — still old code
+		{updateHeight + 1, "codeA"},
+		{activateHeight - 1, "codeA"}, // last block before activation
+		{activateHeight, "codeB"},     // activates exactly at activation height
+		{activateHeight + 50, "codeB"},
+	}
+	for _, tc := range cases {
+		got, err := c.ContractById(id, tc.height)
+		assert.NoError(t, err, "height %d", tc.height)
+		assert.Equal(t, tc.wantCode, got.Code, "active code at height %d", tc.height)
+	}
+}
+
+// FindPendingUpdates lists the queued update (code, proposer, activation) while it
+// is pending, and nothing once it has activated.
+func TestFindPendingUpdates(t *testing.T) {
+	c, hb, _, _ := setupContractsDB(t)
+	seedBlocks(t, hb, createHeight, updateHeight)
+	id := registerWithTimelock(c)
+
+	pending, err := c.FindPendingUpdates(nil, updateHeight, 0, 100)
+	assert.NoError(t, err)
+	assert.Len(t, pending, 1, "one update should be pending mid-window")
+	assert.Equal(t, "codeB", pending[0].Code)
+	assert.Equal(t, "hive:alice", pending[0].Proposer)
+	assert.Equal(t, activateHeight, pending[0].ActivationHeight)
+	assert.Equal(t, id, pending[0].Id)
+
+	activated, err := c.FindPendingUpdates(nil, activateHeight, 0, 100)
+	assert.NoError(t, err)
+	assert.Len(t, activated, 0, "nothing pending once activated")
+}
+
+// FindActiveContracts returns the active version per id (old code while a newer
+// version is still queued, new code after it activates) and never a pending one.
+func TestFindActiveContracts(t *testing.T) {
+	c, hb, _, _ := setupContractsDB(t)
+	seedBlocks(t, hb, createHeight, updateHeight)
+	registerWithTimelock(c)
+
+	mid, err := c.FindActiveContracts(nil, nil, updateHeight, 0, 100)
+	assert.NoError(t, err)
+	assert.Len(t, mid, 1)
+	assert.Equal(t, "codeA", mid[0].Code, "active is still old code during window")
+
+	after, err := c.FindActiveContracts(nil, nil, activateHeight, 0, 100)
+	assert.NoError(t, err)
+	assert.Len(t, after, 1)
+	assert.Equal(t, "codeB", after[0].Code, "active is new code after activation")
+}
+
+// A cancelled update is tombstoned and never activates; the contract keeps running
+// the previously-active code even past the original activation height.
+func TestCancelPendingUpdate(t *testing.T) {
+	c, hb, _, _ := setupContractsDB(t)
+	seedBlocks(t, hb, createHeight, updateHeight)
+	id := registerWithTimelock(c)
+
+	n, err := c.CancelPendingUpdate(id, updateHeight, updateHeight, "tx-cancel", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, n, "one pending version cancelled")
+
+	// Past the original activation height the old code still runs.
+	got, err := c.ContractById(id, activateHeight+10)
+	assert.NoError(t, err)
+	assert.Equal(t, "codeA", got.Code, "cancelled update must not activate")
+
+	pending, err := c.FindPendingUpdates(nil, updateHeight, 0, 100)
+	assert.NoError(t, err)
+	assert.Len(t, pending, 0, "cancelled update no longer pending")
+
+	// Cancelling again cancels nothing.
+	n, err = c.CancelPendingUpdate(id, updateHeight, updateHeight, "tx-cancel2", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+// RegisterContract must never let a version resolve before it was created: an
+// unset ActivationHeight defaults to CreationHeight (immediate), so a height-
+// scoped lookup below the creation height returns nothing.
+func TestRegisterContract_DefaultActivationGuard(t *testing.T) {
+	c, _, _, _ := setupContractsDB(t)
+	id := "vsc1defaultguard"
+	c.RegisterContract(id, contracts.Contract{
+		Code:           "codeX",
+		Creator:        "hive:bob",
+		Owner:          "hive:bob",
+		TxId:           "tx-x",
+		CreationHeight: 120,
+		// ActivationHeight intentionally left zero.
+		Runtime: wasm_runtime.Go,
+	})
+
+	_, err := c.ContractById(id, 119)
+	assert.Error(t, err, "version must not be visible before its creation height")
+
+	got, err := c.ContractById(id, 120)
+	assert.NoError(t, err)
+	assert.Equal(t, "codeX", got.Code)
+	assert.Equal(t, uint64(120), got.ActivationHeight, "activation defaults to creation height")
+}
+
+// Init backfills activation_height = creation_height for rows written before the
+// timelock feature, so the activation-aware ContractById reproduces pre-feature
+// results exactly.
+func TestInitBackfillsActivationHeight(t *testing.T) {
+	c, _, dbi, dbConfig := setupContractsDB(t)
+
+	// Insert a legacy-shaped doc with NO activation_height field.
+	coll := dbi.Database(dbConfig.GetDbName()).Collection("contracts")
+	_, err := coll.InsertOne(context.Background(), bson.M{
+		"id":              "vsc1legacy",
+		"code":            "legacyCode",
+		"creator":         "hive:carol",
+		"owner":           "hive:carol",
+		"tx_id":           "tx-legacy",
+		"creation_height": uint64(50),
+		"latest":          true,
+	})
+	assert.NoError(t, err)
+
+	// Re-run Init to trigger the backfill.
+	assert.NoError(t, c.Init())
+
+	// Before backfill the activation filter would have skipped it; after backfill
+	// (activation = creation = 50) it is the active version at height >= 50.
+	got, err := c.ContractById("vsc1legacy", 50)
+	assert.NoError(t, err)
+	assert.Equal(t, "legacyCode", got.Code)
+	assert.Equal(t, uint64(50), got.ActivationHeight)
+
+	_, err = c.ContractById("vsc1legacy", 49)
+	assert.Error(t, err, "legacy row must not resolve below its creation height after backfill")
+}

--- a/modules/db/vsc/contracts/interface.go
+++ b/modules/db/vsc/contracts/interface.go
@@ -10,6 +10,14 @@ type Contracts interface {
 	RegisterContract(contractId string, args Contract)
 	ContractById(contractId string, height uint64) (Contract, error)
 	FindContracts(contractId *string, code *string, historical *bool, offset int, limit int) ([]Contract, error)
+	// FindActiveContracts returns the version active at head for each matching id
+	// (excludes pending/timelocked and cancelled versions).
+	FindActiveContracts(contractId *string, code *string, head uint64, offset int, limit int) ([]Contract, error)
+	// FindPendingUpdates returns queued updates not yet active at head.
+	FindPendingUpdates(contractId *string, head uint64, offset int, limit int) ([]Contract, error)
+	// CancelPendingUpdate tombstones still-pending versions of a contract; returns
+	// how many were cancelled.
+	CancelPendingUpdate(contractId string, head uint64, cancelledHeight uint64, cancelledTx string, targetTx *string) (int, error)
 }
 
 type ContractState interface {

--- a/modules/db/vsc/contracts/schema.go
+++ b/modules/db/vsc/contracts/schema.go
@@ -14,6 +14,25 @@ type Contract struct {
 	CreationTs     *string              `bson:"creation_ts,omitempty"`
 	Runtime        wasm_runtime.Runtime `bson:"runtime"`
 	Latest         bool                 `bson:"latest,omitempty"`
+
+	// ActivationHeight is the Hive L1 height at/after which this version becomes
+	// the active code. For immediate writes (contract creation, metadata updates
+	// on networks with no timelock) it equals CreationHeight. For a timelocked
+	// update it is CreationHeight + the network timelock. ContractById returns the
+	// newest version whose ActivationHeight <= the query height, so queued code
+	// does not run until it matures. RegisterContract guarantees it is never less
+	// than CreationHeight.
+	ActivationHeight uint64 `bson:"activation_height"`
+	// Proposer is the account that submitted this version (creator on creation,
+	// the signing owner on an update). The "by who" of a pending update.
+	Proposer string `bson:"proposer,omitempty"`
+
+	// Cancellation (audit-preserved): a vsc.cancel_contract_update marks a still-
+	// pending version cancelled instead of deleting it. Cancelled versions are
+	// ignored by ContractById/FindActiveContracts/FindPendingUpdates.
+	Cancelled       bool   `bson:"cancelled,omitempty"`
+	CancelledHeight uint64 `bson:"cancelled_height,omitempty"`
+	CancelledTx     string `bson:"cancelled_tx,omitempty"`
 }
 
 type Intent struct {

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -13,6 +13,7 @@ import (
 	"math"
 	"os"
 	"strings"
+	"time"
 	"unicode/utf8"
 	"vsc-node/lib/datalayer"
 	"vsc-node/modules/announcements"
@@ -135,6 +136,36 @@ func (r *contractResolver) CreationHeight(ctx context.Context, obj *contracts.Co
 // Runtime is the resolver for the runtime field.
 func (r *contractResolver) Runtime(ctx context.Context, obj *contracts.Contract) (string, error) {
 	return obj.Runtime.String(), nil
+}
+
+// ActivationHeight is the resolver for the activation_height field.
+func (r *contractResolver) ActivationHeight(ctx context.Context, obj *contracts.Contract) (model.Uint64, error) {
+	return model.Uint64(obj.ActivationHeight), nil
+}
+
+// ActivationTs is the resolver for the activation_ts field. It estimates when a
+// queued version goes live: the creation timestamp plus the remaining timelock at
+// ~3s/block. Exact for immediate versions; an estimate for pending ones (the
+// activation block does not exist yet, so its real timestamp is unknown).
+func (r *contractResolver) ActivationTs(ctx context.Context, obj *contracts.Contract) (*string, error) {
+	if obj.CreationTs == nil {
+		return nil, nil
+	}
+	if obj.ActivationHeight <= obj.CreationHeight {
+		return obj.CreationTs, nil
+	}
+	layouts := []string{"2006-01-02T15:04:05Z", "2006-01-02T15:04:05", time.RFC3339}
+	for _, layout := range layouts {
+		base, err := time.Parse(layout, *obj.CreationTs)
+		if err != nil {
+			continue
+		}
+		est := base.Add(time.Duration(obj.ActivationHeight-obj.CreationHeight) * 3 * time.Second)
+		out := est.Format(layout)
+		return &out, nil
+	}
+	// Unparseable creation timestamp — activation_height is the exact source.
+	return nil, nil
 }
 
 // BlockHeight is the resolver for the block_height field.
@@ -431,7 +462,33 @@ func (r *queryResolver) FindContract(ctx context.Context, filterOptions *FindCon
 	if paginateErr != nil {
 		return nil, paginateErr
 	}
-	return r.Contracts.FindContracts(filterOptions.ByID, filterOptions.ByCode, filterOptions.Historical, offset, limit)
+	// Historical: return every stored version (unchanged behavior).
+	if filterOptions.Historical != nil && *filterOptions.Historical {
+		return r.Contracts.FindContracts(filterOptions.ByID, filterOptions.ByCode, filterOptions.Historical, offset, limit)
+	}
+	// Default: the version ACTIVE at the chain head, excluding queued (timelocked)
+	// updates — so a pending update never masquerades as the live contract.
+	head, err := r.HiveBlocks.GetHighestBlock()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get highest block: %w", err)
+	}
+	return r.Contracts.FindActiveContracts(filterOptions.ByID, filterOptions.ByCode, head, offset, limit)
+}
+
+// FindPendingContractUpdates is the resolver for the findPendingContractUpdates field.
+func (r *queryResolver) FindPendingContractUpdates(ctx context.Context, filterOptions *FindContractFilter) ([]contracts.Contract, error) {
+	if filterOptions == nil {
+		filterOptions = &FindContractFilter{}
+	}
+	offset, limit, paginateErr := Paginate(filterOptions.Offset, filterOptions.Limit)
+	if paginateErr != nil {
+		return nil, paginateErr
+	}
+	head, err := r.HiveBlocks.GetHighestBlock()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get highest block: %w", err)
+	}
+	return r.Contracts.FindPendingUpdates(filterOptions.ByID, head, offset, limit)
 }
 
 // SubmitTransactionV1 is the resolver for the submitTransactionV1 field.

--- a/modules/gql/schema.graphql
+++ b/modules/gql/schema.graphql
@@ -213,6 +213,21 @@ type Contract {
   creation_ts: String!
   """WASM runtime version used by this contract."""
   runtime: String!
+  """
+  Hive block height at/after which this version's code becomes active. For a
+  pending (timelocked) update this is in the future; until the chain head
+  reaches it, the previously-active code keeps running. Equals creation_height
+  for immediate versions (deploys, networks without a timelock).
+  """
+  activation_height: Uint64!
+  """
+  Estimated timestamp at which this version becomes active (creation timestamp
+  plus the remaining timelock at ~3s/block). Null when the creation timestamp
+  is unavailable.
+  """
+  activation_ts: String
+  """Account that submitted this version (creator on deploy, signer on update)."""
+  proposer: String
 }
 
 """
@@ -906,10 +921,24 @@ type Query {
   ): RcRecord
 
   """
-  Search for smart contracts matching the given filter criteria.
+  Search for smart contracts matching the given filter criteria. By default
+  returns the version currently ACTIVE at the chain head for each contract;
+  queued (timelocked) updates are excluded — use findPendingContractUpdates for
+  those. Pass historical: true to return every stored version.
   """
   findContract(
     """Filter criteria for the contract search."""
+    filterOptions: FindContractFilter
+  ): [Contract!]
+
+  """
+  List contract updates that are queued but not yet active (still inside their
+  timelock window). Each result shows which contract (id), the new code (code),
+  who submitted it (proposer/owner), and when it goes live (activation_height /
+  activation_ts). Filter by contract id via filterOptions.byId.
+  """
+  findPendingContractUpdates(
+    """Filter criteria; byId restricts to a single contract."""
     filterOptions: FindContractFilter
   ): [Contract!]
 

--- a/modules/state-processing/contract_timelock_policy_test.go
+++ b/modules/state-processing/contract_timelock_policy_test.go
@@ -1,0 +1,48 @@
+package state_engine
+
+import (
+	"testing"
+
+	"vsc-node/modules/common/params"
+	systemconfig "vsc-node/modules/common/system-config"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestContractUpdateActivationHeight covers the network-aware, consensus-gated
+// timelock policy that decides when a queued update activates. The duration is
+// network-baked (non-overridable) and, on mainnet, only applies at/after the
+// pinned rollout height so historical reindex stays byte-identical.
+func TestContractUpdateActivationHeight(t *testing.T) {
+	const submit = uint64(200_000_000)
+
+	// Mocknet: timelock disabled (0 blocks) -> immediate.
+	mock := &StateEngine{sconf: systemconfig.MocknetConfig()}
+	assert.Equal(t, submit, mock.contractUpdateActivationHeight(submit))
+
+	// Testnet: always timelocked at the short testnet duration (no mainnet gate).
+	testnet := &StateEngine{sconf: systemconfig.TestnetConfig()}
+	assert.Equal(t,
+		submit+params.CONTRACT_UPDATE_TIMELOCK_BLOCKS_TESTNET,
+		testnet.contractUpdateActivationHeight(submit),
+	)
+
+	// Mainnet: gated by CONTRACT_UPDATE_TIMELOCK_HEIGHT.
+	mainnet := &StateEngine{sconf: systemconfig.MainnetConfig()}
+	orig := params.CONTRACT_UPDATE_TIMELOCK_HEIGHT
+	defer func() { params.CONTRACT_UPDATE_TIMELOCK_HEIGHT = orig }()
+
+	// Gate unset (0 == disabled): updates stay immediate (today's behavior).
+	params.CONTRACT_UPDATE_TIMELOCK_HEIGHT = 0
+	assert.Equal(t, submit, mainnet.contractUpdateActivationHeight(submit))
+
+	// Gate pinned: below the gate stays immediate (preserves historical replay).
+	params.CONTRACT_UPDATE_TIMELOCK_HEIGHT = submit
+	assert.Equal(t, submit-1, mainnet.contractUpdateActivationHeight(submit-1))
+
+	// Gate pinned: at/after the gate is timelocked by the full 48h block count.
+	assert.Equal(t,
+		submit+params.CONTRACT_UPDATE_TIMELOCK_BLOCKS,
+		mainnet.contractUpdateActivationHeight(submit),
+	)
+}

--- a/modules/state-processing/contract_timelock_policy_test.go
+++ b/modules/state-processing/contract_timelock_policy_test.go
@@ -9,10 +9,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// timelockHeightSconf wraps a base SystemConfig so a test can override the
+// mainnet rollout gate (ConsensusParams.ContractUpdateTimelockHeight) without a
+// JSON override loader — mirroring the testChecksumSconf pattern used for the
+// EVM-checksum gate. OnMainnet()/ContractUpdateTimelockBlocks() fall through to
+// the embedded base.
+type timelockHeightSconf struct {
+	systemconfig.SystemConfig
+	cp params.ConsensusParams
+}
+
+func (t *timelockHeightSconf) ConsensusParams() params.ConsensusParams { return t.cp }
+
+func mainnetWithTimelockHeight(h uint64) systemconfig.SystemConfig {
+	base := systemconfig.MainnetConfig()
+	cp := base.ConsensusParams()
+	cp.ContractUpdateTimelockHeight = h
+	return &timelockHeightSconf{SystemConfig: base, cp: cp}
+}
+
 // TestContractUpdateActivationHeight covers the network-aware, consensus-gated
 // timelock policy that decides when a queued update activates. The duration is
 // network-baked (non-overridable) and, on mainnet, only applies at/after the
-// pinned rollout height so historical reindex stays byte-identical.
+// rollout gate height so historical reindex stays byte-identical.
 func TestContractUpdateActivationHeight(t *testing.T) {
 	const submit = uint64(200_000_000)
 
@@ -27,22 +46,21 @@ func TestContractUpdateActivationHeight(t *testing.T) {
 		testnet.contractUpdateActivationHeight(submit),
 	)
 
-	// Mainnet: gated by CONTRACT_UPDATE_TIMELOCK_HEIGHT.
-	mainnet := &StateEngine{sconf: systemconfig.MainnetConfig()}
-	orig := params.CONTRACT_UPDATE_TIMELOCK_HEIGHT
-	defer func() { params.CONTRACT_UPDATE_TIMELOCK_HEIGHT = orig }()
+	// Mainnet: gated by ConsensusParams.ContractUpdateTimelockHeight.
 
 	// Gate unset (0 == disabled): updates stay immediate (today's behavior).
-	params.CONTRACT_UPDATE_TIMELOCK_HEIGHT = 0
-	assert.Equal(t, submit, mainnet.contractUpdateActivationHeight(submit))
+	mainnetUngated := &StateEngine{sconf: mainnetWithTimelockHeight(0)}
+	assert.Equal(t, submit, mainnetUngated.contractUpdateActivationHeight(submit))
 
-	// Gate pinned: below the gate stays immediate (preserves historical replay).
-	params.CONTRACT_UPDATE_TIMELOCK_HEIGHT = submit
-	assert.Equal(t, submit-1, mainnet.contractUpdateActivationHeight(submit-1))
+	// Gate pinned at `submit`.
+	mainnetGated := &StateEngine{sconf: mainnetWithTimelockHeight(submit)}
 
-	// Gate pinned: at/after the gate is timelocked by the full 48h block count.
+	// Below the gate stays immediate (preserves historical replay).
+	assert.Equal(t, submit-1, mainnetGated.contractUpdateActivationHeight(submit-1))
+
+	// At/after the gate is timelocked by the full 48h block count.
 	assert.Equal(t,
 		submit+params.CONTRACT_UPDATE_TIMELOCK_BLOCKS,
-		mainnet.contractUpdateActivationHeight(submit),
+		mainnetGated.contractUpdateActivationHeight(submit),
 	)
 }

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -805,7 +805,8 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 					// Gated like the timelock itself: a no-op before rollout (no
 					// pending updates exist), and historical replay sees no such
 					// op, so reindex stays byte-identical. No fee.
-					if !se.sconf.OnMainnet() || (params.CONTRACT_UPDATE_TIMELOCK_HEIGHT != 0 && txSelf.BlockHeight >= params.CONTRACT_UPDATE_TIMELOCK_HEIGHT) {
+					timelockGate := se.sconf.ConsensusParams().ContractUpdateTimelockHeight
+					if !se.sconf.OnMainnet() || (timelockGate != 0 && txSelf.BlockHeight >= timelockGate) {
 						for idx, auth := range txSelf.RequiredAuths {
 							txSelf.RequiredAuths[idx] = "hive:" + auth
 						}

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -800,6 +800,27 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 						}
 					}
 					continue
+				} else if cj.Id == "vsc.cancel_contract_update" {
+					// Cancel a contract update still inside its timelock window.
+					// Gated like the timelock itself: a no-op before rollout (no
+					// pending updates exist), and historical replay sees no such
+					// op, so reindex stays byte-identical. No fee.
+					if !se.sconf.OnMainnet() || (params.CONTRACT_UPDATE_TIMELOCK_HEIGHT != 0 && txSelf.BlockHeight >= params.CONTRACT_UPDATE_TIMELOCK_HEIGHT) {
+						for idx, auth := range txSelf.RequiredAuths {
+							txSelf.RequiredAuths[idx] = "hive:" + auth
+						}
+
+						for idx, auth := range txSelf.RequiredPostingAuths {
+							txSelf.RequiredPostingAuths[idx] = "hive:" + auth
+						}
+
+						parsedTx := TxCancelContractUpdate{
+							Self: txSelf,
+						}
+						json.Unmarshal(cj.Json, &parsedTx)
+						parsedTx.ExecuteTx(se)
+					}
+					continue
 				} else if cj.Id == "vsc.election_result" {
 					parsedTx := &TxElectionResult{
 						Self: txSelf,
@@ -2520,7 +2541,7 @@ func New(sconf systemconfig.SystemConfig, da *DataLayer.DataLayer,
 		tssCommitments: tssCommitments,
 		tssKeys:        tssKeys,
 
-		consensusState: consensusStateDb,
+		consensusState:   consensusStateDb,
 		consensusRuntime: NewConsensusRuntime(),
 
 		wasm: wasm,

--- a/modules/state-processing/system_txs.go
+++ b/modules/state-processing/system_txs.go
@@ -8,6 +8,7 @@ import (
 	"vsc-node/lib/dids"
 	"vsc-node/modules/common"
 	"vsc-node/modules/common/common_types"
+	"vsc-node/modules/common/params"
 	systemconfig "vsc-node/modules/common/system-config"
 	"vsc-node/modules/db/vsc/contracts"
 	"vsc-node/modules/db/vsc/elections"
@@ -238,9 +239,13 @@ func (tx *TxCreateContract) ExecuteTx(se *StateEngine) TxResult {
 		Description:    tx.Description,
 		Creator:        tx.Self.RequiredAuths[0],
 		Owner:          owner,
+		Proposer:       tx.Self.RequiredAuths[0],
 		TxId:           tx.Self.TxId,
 		CreationHeight: tx.Self.BlockHeight,
-		Runtime:        tx.Runtime,
+		// Deploys are not timelocked; RegisterContract defaults activation to
+		// creation height when left zero.
+		ActivationHeight: tx.Self.BlockHeight,
+		Runtime:          tx.Runtime,
 	})
 
 	return TxResult{
@@ -361,6 +366,11 @@ func (tx *TxUpdateContract) ExecuteTx(se *StateEngine, hasFee bool) UpdateContra
 		// contract update history
 		TxId:           tx.Self.TxId,
 		CreationHeight: tx.Self.BlockHeight,
+		Proposer:       tx.Self.RequiredAuths[0],
+		// Queue the whole update behind the network timelock. Until this height
+		// the previously-active version (existing) keeps running; ContractById
+		// ignores this row while activation_height > the query height.
+		ActivationHeight: se.contractUpdateActivationHeight(tx.Self.BlockHeight),
 	}
 	if tx.Owner != "" {
 		// update owner
@@ -411,6 +421,97 @@ func (tx *TxUpdateContract) ExecuteTx(se *StateEngine, hasFee bool) UpdateContra
 	return UpdateContractResult{
 		Success:     true,
 		CodeUpdated: updatedContract.Code != existing.Code,
+	}
+}
+
+// contractUpdateActivationHeight returns the height at which an update submitted
+// at submitHeight becomes the active code. It is submitHeight (immediate) when
+// the network has no timelock, or — on mainnet — while the rollout gate is unset
+// or unreached, so a full reindex reproduces historical state byte-for-byte.
+// Otherwise it is submitHeight + the network's (non-overridable) timelock.
+func (se *StateEngine) contractUpdateActivationHeight(submitHeight uint64) uint64 {
+	blocks := se.sconf.ContractUpdateTimelockBlocks()
+	if blocks == 0 {
+		return submitHeight
+	}
+	if se.sconf.OnMainnet() {
+		if params.CONTRACT_UPDATE_TIMELOCK_HEIGHT == 0 || submitHeight < params.CONTRACT_UPDATE_TIMELOCK_HEIGHT {
+			return submitHeight
+		}
+	}
+	return submitHeight + blocks
+}
+
+// TxCancelContractUpdate cancels a contract update that is still in its timelock
+// window (queued but not yet active). Owner-gated and free.
+type TxCancelContractUpdate struct {
+	Self  TxSelf `json:"-"`
+	NetId string `json:"net_id"`
+	Id    string `json:"id"`
+	// TxId optionally targets a single queued update (the tx that queued it). When
+	// empty, every pending update for the contract is cancelled.
+	TxId string `json:"tx_id,omitempty"`
+}
+
+type CancelContractUpdateResult struct {
+	Success   bool
+	Cancelled int
+	Err       string
+}
+
+func (tx TxCancelContractUpdate) Type() string {
+	return "cancel_contract_update"
+}
+
+func (tx TxCancelContractUpdate) TxSelf() TxSelf {
+	return tx.Self
+}
+
+func (tx *TxCancelContractUpdate) ToData() map[string]interface{} {
+	return map[string]interface{}{
+		"net_id": tx.NetId,
+		"id":     tx.Id,
+		"tx_id":  tx.TxId,
+	}
+}
+
+func (tx *TxCancelContractUpdate) ExecuteTx(se *StateEngine) CancelContractUpdateResult {
+	if len(tx.Self.RequiredAuths) == 0 {
+		return CancelContractUpdateResult{
+			Success: false,
+			Err:     "cannot cancel contract update with posting auths",
+		}
+	}
+	// Authorize against the CURRENTLY ACTIVE owner. A queued owner transfer has
+	// not taken effect yet, so the existing owner stays in control and can cancel
+	// it (e.g. revert a stolen-key hand-off within the window).
+	existing, err := se.contractDb.ContractById(tx.Id, tx.Self.BlockHeight)
+	if err != nil {
+		return CancelContractUpdateResult{
+			Success: false,
+			Err:     "failed to retrieve contract to cancel update",
+		}
+	}
+	if tx.Self.RequiredAuths[0] != existing.Owner {
+		return CancelContractUpdateResult{
+			Success: false,
+			Err:     "not owner",
+		}
+	}
+	var targetTx *string
+	if tx.TxId != "" {
+		targetTx = &tx.TxId
+	}
+	cancelled, err := se.contractDb.CancelPendingUpdate(tx.Id, tx.Self.BlockHeight, tx.Self.BlockHeight, tx.Self.TxId, targetTx)
+	if err != nil {
+		return CancelContractUpdateResult{
+			Success: false,
+			Err:     "failed to cancel pending update",
+		}
+	}
+	return CancelContractUpdateResult{
+		Success:   true,
+		Cancelled: cancelled,
 	}
 }
 
@@ -709,7 +810,7 @@ type TxRecoveryRequireVersion struct {
 	Self          TxSelf
 	Major         uint64 `json:"major"`
 	Consensus     uint64 `json:"consensus"`
-	NonConsensus uint64 `json:"non_consensus"`
+	NonConsensus  uint64 `json:"non_consensus"`
 	Reason        string `json:"reason,omitempty"`
 	CheckpointRef string `json:"checkpoint_ref,omitempty"`
 }

--- a/modules/state-processing/system_txs.go
+++ b/modules/state-processing/system_txs.go
@@ -8,7 +8,6 @@ import (
 	"vsc-node/lib/dids"
 	"vsc-node/modules/common"
 	"vsc-node/modules/common/common_types"
-	"vsc-node/modules/common/params"
 	systemconfig "vsc-node/modules/common/system-config"
 	"vsc-node/modules/db/vsc/contracts"
 	"vsc-node/modules/db/vsc/elections"
@@ -435,7 +434,8 @@ func (se *StateEngine) contractUpdateActivationHeight(submitHeight uint64) uint6
 		return submitHeight
 	}
 	if se.sconf.OnMainnet() {
-		if params.CONTRACT_UPDATE_TIMELOCK_HEIGHT == 0 || submitHeight < params.CONTRACT_UPDATE_TIMELOCK_HEIGHT {
+		gate := se.sconf.ConsensusParams().ContractUpdateTimelockHeight
+		if gate == 0 || submitHeight < gate {
 			return submitHeight
 		}
 	}

--- a/tests/devnet/contract_timelock.go
+++ b/tests/devnet/contract_timelock.go
@@ -1,0 +1,276 @@
+package devnet
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"path/filepath"
+	"time"
+)
+
+// ContractUpdateOpts holds options for queueing a contract code update on the
+// running devnet (drives the contract-deployer with -contractId + -wasmPath).
+type ContractUpdateOpts struct {
+	ContractId   string
+	WasmPath     string
+	Name         string
+	DeployerNode int
+	GQLNode      int
+}
+
+// ContractCancelOpts holds options for cancelling a pending contract update.
+type ContractCancelOpts struct {
+	ContractId   string
+	DeployerNode int
+	GQLNode      int
+}
+
+// runDeployer stops the deployer node (to release its badger lock), runs the
+// contract-deployer container with the given args (optionally mounting a wasm
+// dir at /wasm), then restarts the node. Mirrors DeployContract's lifecycle.
+func (d *Devnet) runDeployer(ctx context.Context, deployerNode int, wasmDir string, deployArgs []string) (string, error) {
+	if !d.started {
+		return "", fmt.Errorf("devnet not started")
+	}
+	nodeName := fmt.Sprintf("magi-%d", deployerNode)
+
+	if err := d.compose(ctx, "stop", nodeName); err != nil {
+		return "", fmt.Errorf("stopping %s: %w", nodeName, err)
+	}
+
+	args := []string{"run", "--rm"}
+	if wasmDir != "" {
+		args = append(args, "-v", fmt.Sprintf("%s:/wasm", wasmDir))
+	}
+	args = append(args, "contract-deployer")
+	args = append(args, deployArgs...)
+
+	out, err := d.composeOutput(ctx, args...)
+
+	if startErr := d.compose(ctx, "start", nodeName); startErr != nil {
+		log.Printf("[devnet] warning: failed to restart %s: %v", nodeName, startErr)
+	}
+	time.Sleep(5 * time.Second)
+
+	if err != nil {
+		return "", fmt.Errorf("deployer run failed: %w\noutput: %s", err, out)
+	}
+	return out, nil
+}
+
+// resolveNodes fills in default/disjoint deployer and GQL nodes (the GQL node
+// must differ from the deployer node, which is stopped during the run).
+func (d *Devnet) resolveNodes(deployerNode, gqlNode int) (int, int) {
+	if deployerNode == 0 {
+		deployerNode = 1
+	}
+	if gqlNode == 0 {
+		gqlNode = 1
+	}
+	if gqlNode == deployerNode {
+		for i := 1; i <= d.cfg.Nodes; i++ {
+			if i != deployerNode {
+				gqlNode = i
+				break
+			}
+		}
+	}
+	return deployerNode, gqlNode
+}
+
+// UpdateContract queues a code update for an existing contract. On a network with
+// a timelock (devnet: 30 blocks) the new code does not become active immediately.
+func (d *Devnet) UpdateContract(ctx context.Context, opts ContractUpdateOpts) error {
+	if opts.ContractId == "" {
+		return fmt.Errorf("contract id is required")
+	}
+	if opts.WasmPath == "" {
+		return fmt.Errorf("wasm path is required")
+	}
+	deployerNode, gqlNode := d.resolveNodes(opts.DeployerNode, opts.GQLNode)
+
+	wasmPath, err := filepath.Abs(opts.WasmPath)
+	if err != nil {
+		return fmt.Errorf("resolving wasm path: %w", err)
+	}
+	wasmDir := filepath.Dir(wasmPath)
+	wasmFile := filepath.Base(wasmPath)
+	name := opts.Name
+	if name == "" {
+		name = "timelock-test"
+	}
+
+	deployArgs := []string{
+		"./contract-deployer",
+		"-network=devnet",
+		fmt.Sprintf("-data-dir=/data/devnet/data-%d", deployerNode),
+		fmt.Sprintf("-wasmPath=/wasm/%s", wasmFile),
+		fmt.Sprintf("-contractId=%s", opts.ContractId),
+		fmt.Sprintf("-name=%s", name),
+		fmt.Sprintf("-gqlUrl=http://magi-%d:8080/api/v1/graphql", gqlNode),
+	}
+
+	log.Printf("[devnet] queueing contract update for %s (stopping magi-%d)...", opts.ContractId, deployerNode)
+	out, err := d.runDeployer(ctx, deployerNode, wasmDir, deployArgs)
+	if err != nil {
+		return err
+	}
+	log.Printf("[devnet] update-contract deployer output:\n%s", out)
+	return nil
+}
+
+// CancelContractUpdate posts a vsc.cancel_contract_update for the contract,
+// tombstoning any pending (timelocked) update.
+func (d *Devnet) CancelContractUpdate(ctx context.Context, opts ContractCancelOpts) error {
+	if opts.ContractId == "" {
+		return fmt.Errorf("contract id is required")
+	}
+	deployerNode, gqlNode := d.resolveNodes(opts.DeployerNode, opts.GQLNode)
+
+	deployArgs := []string{
+		"./contract-deployer",
+		"-network=devnet",
+		fmt.Sprintf("-data-dir=/data/devnet/data-%d", deployerNode),
+		"-cancel-update",
+		fmt.Sprintf("-contractId=%s", opts.ContractId),
+		fmt.Sprintf("-gqlUrl=http://magi-%d:8080/api/v1/graphql", gqlNode),
+	}
+
+	log.Printf("[devnet] cancelling pending update for %s (stopping magi-%d)...", opts.ContractId, deployerNode)
+	out, err := d.runDeployer(ctx, deployerNode, "", deployArgs)
+	if err != nil {
+		return err
+	}
+	log.Printf("[devnet] cancel-update deployer output:\n%s", out)
+	return nil
+}
+
+// ContractGQL is a contract record as returned by the node's GraphQL API.
+type ContractGQL struct {
+	Id               string
+	Code             string
+	Proposer         string
+	CreationHeight   uint64
+	ActivationHeight uint64
+}
+
+// graphQLContracts runs a contracts-returning query against a node's GraphQL API
+// and decodes the named result field into []ContractGQL.
+func (d *Devnet) graphQLContracts(ctx context.Context, node int, field, query string) ([]ContractGQL, error) {
+	body, _ := json.Marshal(map[string]string{"query": query})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.GQLEndpoint(node), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+
+	var parsed struct {
+		Data   map[string][]struct {
+			Id               string  `json:"id"`
+			Code             string  `json:"code"`
+			Proposer         string  `json:"proposer"`
+			CreationHeight   float64 `json:"creation_height"`
+			ActivationHeight float64 `json:"activation_height"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, fmt.Errorf("decoding graphql response: %w\nbody: %s", err, string(raw))
+	}
+	if len(parsed.Errors) > 0 {
+		return nil, fmt.Errorf("graphql error: %s\nbody: %s", parsed.Errors[0].Message, string(raw))
+	}
+	rows := parsed.Data[field]
+	out := make([]ContractGQL, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, ContractGQL{
+			Id:               r.Id,
+			Code:             r.Code,
+			Proposer:         r.Proposer,
+			CreationHeight:   uint64(r.CreationHeight),
+			ActivationHeight: uint64(r.ActivationHeight),
+		})
+	}
+	return out, nil
+}
+
+// ActiveContract returns the version of a contract currently active at the chain
+// head (via findContract), or nil if not found.
+func (d *Devnet) ActiveContract(ctx context.Context, node int, id string) (*ContractGQL, error) {
+	q := fmt.Sprintf(`{ findContract(filterOptions: {byId: %q}) { id code proposer creation_height activation_height } }`, id)
+	rows, err := d.graphQLContracts(ctx, node, "findContract", q)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	return &rows[0], nil
+}
+
+// PendingUpdates returns queued (not-yet-active) updates for a contract via
+// findPendingContractUpdates.
+func (d *Devnet) PendingUpdates(ctx context.Context, node int, id string) ([]ContractGQL, error) {
+	q := fmt.Sprintf(`{ findPendingContractUpdates(filterOptions: {byId: %q}) { id code proposer creation_height activation_height } }`, id)
+	return d.graphQLContracts(ctx, node, "findPendingContractUpdates", q)
+}
+
+// WaitForActiveCode polls until the active version of a contract has the given
+// code CID, or the timeout expires.
+func (d *Devnet) WaitForActiveCode(ctx context.Context, node int, id, code string, timeout time.Duration) (*ContractGQL, error) {
+	deadline := time.Now().Add(timeout)
+	var last *ContractGQL
+	for {
+		c, err := d.ActiveContract(ctx, node, id)
+		if err == nil && c != nil {
+			last = c
+			if c.Code == code {
+				return c, nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return last, fmt.Errorf("timeout: active code for %s is %v, want %s", id, last, code)
+		}
+		select {
+		case <-ctx.Done():
+			return last, ctx.Err()
+		case <-time.After(3 * time.Second):
+		}
+	}
+}
+
+// WaitForPendingUpdate polls until a pending update with the given code appears
+// for a contract, returning it.
+func (d *Devnet) WaitForPendingUpdate(ctx context.Context, node int, id, code string, timeout time.Duration) (*ContractGQL, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		rows, err := d.PendingUpdates(ctx, node, id)
+		if err == nil {
+			for i := range rows {
+				if rows[i].Code == code {
+					return &rows[i], nil
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timeout waiting for pending update %s with code %s (err=%v)", id, code, err)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(3 * time.Second):
+		}
+	}
+}

--- a/tests/devnet/contract_timelock_devnet_test.go
+++ b/tests/devnet/contract_timelock_devnet_test.go
@@ -1,0 +1,208 @@
+package devnet
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestContractUpdateTimelockDevnet validates the 48h contract-update timelock on
+// a real multi-node devnet (where the timelock is 30 blocks, not 0 like mocknet):
+//
+//   - a queued code update does NOT become active immediately; the previously
+//     active code keeps running until activation_height (= submit + 30),
+//   - the new code activates once the chain head reaches activation_height,
+//   - findPendingContractUpdates surfaces the queued update with the right
+//     activation height and proposer,
+//   - a cancelled update never activates.
+//
+// All assertions go through the node's GraphQL API (findContract /
+// findPendingContractUpdates), exercising the full path: real Hive block
+// production -> state-engine timelock -> DB -> resolver.
+func TestContractUpdateTimelockDevnet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet contract-timelock test in short mode")
+	}
+	requireDocker(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	codeAWasm := TestContractPath()
+	codeBWasm := filepath.Join(findSourceRoot(), "modules", "e2e", "artifacts", "contract_test2.wasm")
+	for _, p := range []string{codeAWasm, codeBWasm} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("test wasm not found: %s: %v", p, err)
+		}
+	}
+
+	cfg := DefaultConfig()
+	// 5 nodes (the default): deploy/update stops the deployer node to take its
+	// data dir, so the storage-proof quorum (MinSpSigners=3) needs the remaining
+	// nodes to still clear it with margin. 4 nodes leaves exactly 3 and flakes.
+	// RAM is not the constraint here — the only spike is the one-time image build;
+	// the nodes themselves are light (the watchdog guards the host regardless).
+	cfg.Nodes = 5
+	cfg.GenesisNode = 5
+	// The default devnet ports collide with the live testnet stack on this host;
+	// remap every host port to a known-free range.
+	cfg.GQLBasePort = 28080
+	cfg.P2PBasePort = 21720
+	cfg.MongoPort = 28057
+	cfg.HivePort = 28091
+	cfg.DronePort = 29000
+	cfg.BitcoindRPCPort = 28543
+	cfg.DashdRPCPort = 29898
+	if os.Getenv("DEVNET_KEEP") != "" {
+		cfg.KeepRunning = true
+	}
+
+	d, err := New(cfg)
+	if err != nil {
+		t.Fatalf("creating devnet: %v", err)
+	}
+	t.Cleanup(func() { d.Stop() })
+	if err := d.Start(ctx); err != nil {
+		t.Fatalf("starting devnet: %v", err)
+	}
+
+	const (
+		deployNode     = 1
+		queryNode      = 2 // never stopped (deployer stops deployNode), so always serves GQL
+		timelockBlocks = uint64(30)
+	)
+
+	// Poll the active contract until it first appears on-chain.
+	waitActive := func(id string) *ContractGQL {
+		t.Helper()
+		deadline := time.Now().Add(4 * time.Minute)
+		for {
+			c, err := d.ActiveContract(ctx, queryNode, id)
+			if err == nil && c != nil {
+				return c
+			}
+			if time.Now().After(deadline) {
+				d.dumpContracts(ctx, t, queryNode)
+				t.Fatalf("contract %s never became active (err=%v)", id, err)
+			}
+			time.Sleep(3 * time.Second)
+		}
+	}
+	// Poll until a pending update appears for the contract.
+	waitPending := func(id string) *ContractGQL {
+		t.Helper()
+		deadline := time.Now().Add(4 * time.Minute)
+		for {
+			rows, err := d.PendingUpdates(ctx, queryNode, id)
+			if err == nil && len(rows) > 0 {
+				return &rows[0]
+			}
+			if time.Now().After(deadline) {
+				d.dumpContracts(ctx, t, queryNode)
+				t.Fatalf("no pending update appeared for %s (err=%v)", id, err)
+			}
+			time.Sleep(3 * time.Second)
+		}
+	}
+
+	// ───────── Scenario 1: queue → old code stays → activates after timelock ─────────
+	t.Log("scenario 1: deploy codeA, queue codeB, verify timelock then activation")
+	id1, err := d.DeployContract(ctx, ContractDeployOpts{WasmPath: codeAWasm, Name: "timelock-1", DeployerNode: deployNode})
+	if err != nil {
+		t.Fatalf("deploy contract 1: %v", err)
+	}
+	a := waitActive(id1)
+	codeA := a.Code
+	t.Logf("contract %s deployed, active code=%s", id1, codeA)
+
+	if err := d.UpdateContract(ctx, ContractUpdateOpts{ContractId: id1, WasmPath: codeBWasm, Name: "timelock-1", DeployerNode: deployNode}); err != nil {
+		t.Fatalf("queue update for %s: %v", id1, err)
+	}
+	pending := waitPending(id1)
+	codeB := pending.Code
+	t.Logf("queued update: code=%s creation_height=%d activation_height=%d proposer=%s",
+		codeB, pending.CreationHeight, pending.ActivationHeight, pending.Proposer)
+
+	if codeB == codeA {
+		t.Fatalf("queued code must differ from active code (both %s)", codeA)
+	}
+	if got := pending.ActivationHeight - pending.CreationHeight; got != timelockBlocks {
+		t.Errorf("timelock window = %d blocks, want %d (creation=%d activation=%d)",
+			got, timelockBlocks, pending.CreationHeight, pending.ActivationHeight)
+	}
+	if pending.Proposer == "" {
+		t.Errorf("pending update should record a proposer")
+	}
+
+	// During the window the OLD code is still active.
+	act, err := d.ActiveContract(ctx, queryNode, id1)
+	if err != nil {
+		t.Fatalf("active contract during window: %v", err)
+	}
+	if act.Code != codeA {
+		t.Fatalf("during timelock window active code = %s, want old code %s", act.Code, codeA)
+	}
+	t.Logf("during window: active code still %s ✓", codeA)
+
+	// Wait for the chain to reach activation, then confirm the new code is live.
+	if err := d.WaitForBlockProcessing(ctx, queryNode, pending.ActivationHeight+1, 8*time.Minute); err != nil {
+		t.Fatalf("waiting for activation height %d: %v", pending.ActivationHeight, err)
+	}
+	if _, err := d.WaitForActiveCode(ctx, queryNode, id1, codeB, 3*time.Minute); err != nil {
+		t.Fatalf("new code did not activate after timelock: %v", err)
+	}
+	t.Logf("after activation height %d: active code now %s ✓", pending.ActivationHeight, codeB)
+
+	if rows, err := d.PendingUpdates(ctx, queryNode, id1); err != nil {
+		t.Fatalf("pending after activation: %v", err)
+	} else if len(rows) != 0 {
+		t.Errorf("expected no pending updates after activation, got %d", len(rows))
+	}
+
+	// ───────── Scenario 2: queue → cancel → never activates ─────────
+	t.Log("scenario 2: deploy codeA, queue codeB, cancel, verify it never activates")
+	id2, err := d.DeployContract(ctx, ContractDeployOpts{WasmPath: codeAWasm, Name: "timelock-2", DeployerNode: deployNode})
+	if err != nil {
+		t.Fatalf("deploy contract 2: %v", err)
+	}
+	waitActive(id2)
+
+	if err := d.UpdateContract(ctx, ContractUpdateOpts{ContractId: id2, WasmPath: codeBWasm, Name: "timelock-2", DeployerNode: deployNode}); err != nil {
+		t.Fatalf("queue update for %s: %v", id2, err)
+	}
+	pending2 := waitPending(id2)
+	t.Logf("queued update for %s, activation_height=%d; cancelling...", id2, pending2.ActivationHeight)
+
+	if err := d.CancelContractUpdate(ctx, ContractCancelOpts{ContractId: id2, DeployerNode: deployNode}); err != nil {
+		t.Fatalf("cancel update for %s: %v", id2, err)
+	}
+
+	// Pending list should drain once the cancel is processed.
+	deadline := time.Now().Add(4 * time.Minute)
+	for {
+		rows, err := d.PendingUpdates(ctx, queryNode, id2)
+		if err == nil && len(rows) == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("pending update for %s was not cancelled (rows=%d err=%v)", id2, len(rows), err)
+		}
+		time.Sleep(3 * time.Second)
+	}
+	t.Logf("pending update for %s cancelled ✓", id2)
+
+	// Past the original activation height the OLD code must still be active.
+	if err := d.WaitForBlockProcessing(ctx, queryNode, pending2.ActivationHeight+2, 8*time.Minute); err != nil {
+		t.Fatalf("waiting past cancelled activation height %d: %v", pending2.ActivationHeight, err)
+	}
+	act2, err := d.ActiveContract(ctx, queryNode, id2)
+	if err != nil {
+		t.Fatalf("active contract after cancelled activation: %v", err)
+	}
+	if act2.Code != codeA {
+		t.Fatalf("cancelled update activated: active code = %s, want old code %s", act2.Code, codeA)
+	}
+	t.Logf("past activation height %d: cancelled update did NOT activate, code still %s ✓", pending2.ActivationHeight, codeA)
+}


### PR DESCRIPTION
This pull request implements a timelock mechanism for contract updates, ensuring that updates to smart contracts are queued and only take effect after a specified delay, rather than immediately. It also introduces the ability to cancel pending (timelocked) contract updates and provides supporting changes across the CLI, database, and configuration to enforce and expose these new behaviors. The changes are grouped below by their main themes.

**Timelock Mechanism for Contract Updates:**

* Added a consensus-enforced timelock for contract updates, configurable per network (mainnet, testnet, devnet, mocknet), so that updates are queued and only activate after a set number of Hive blocks. This is now a consensus rule and not operator-overridable. [[1]](diffhunk://#diff-6acd4dc4f130f38a0b50edb838a9f368375dc335d4a960bb31279edafd1baaa4R78-R114) [[2]](diffhunk://#diff-040b9521af929b26aeb68434ab997a8d84cc9c05fe477d272ee59f8e2a46ebc2R22-R26) [[3]](diffhunk://#diff-040b9521af929b26aeb68434ab997a8d84cc9c05fe477d272ee59f8e2a46ebc2R41-R43) [[4]](diffhunk://#diff-040b9521af929b26aeb68434ab997a8d84cc9c05fe477d272ee59f8e2a46ebc2R88-R91) [[5]](diffhunk://#diff-040b9521af929b26aeb68434ab997a8d84cc9c05fe477d272ee59f8e2a46ebc2R197-R198) [[6]](diffhunk://#diff-040b9521af929b26aeb68434ab997a8d84cc9c05fe477d272ee59f8e2a46ebc2R238-R239) [[7]](diffhunk://#diff-040b9521af929b26aeb68434ab997a8d84cc9c05fe477d272ee59f8e2a46ebc2R289-R290) [[8]](diffhunk://#diff-040b9521af929b26aeb68434ab997a8d84cc9c05fe477d272ee59f8e2a46ebc2R316-R318)
* Modified contract activation logic and database queries to use `activation_height` instead of `creation_height`, ensuring only versions whose timelock has expired are active. Backfilled old rows to set `activation_height` where missing. [[1]](diffhunk://#diff-49e2fd0d4ae319889b2bfd1388de2aad016fe8e0784994465a5d864b94b05454R48-R90) [[2]](diffhunk://#diff-49e2fd0d4ae319889b2bfd1388de2aad016fe8e0784994465a5d864b94b05454R130-R139) [[3]](diffhunk://#diff-49e2fd0d4ae319889b2bfd1388de2aad016fe8e0784994465a5d864b94b05454R153-R154)

**Pending Update Management and Cancellation:**

* Added new database methods and CLI commands to list pending (timelocked) contract updates and to cancel them, either individually (by tx id) or all at once for a contract. [[1]](diffhunk://#diff-49e2fd0d4ae319889b2bfd1388de2aad016fe8e0784994465a5d864b94b05454R172-R292) [[2]](diffhunk://#diff-5c59cdd3ad61bfd0b8ed4100acc9237a80b8d49193f202870249dfb5b4f98fd7R23-R26) [[3]](diffhunk://#diff-5c59cdd3ad61bfd0b8ed4100acc9237a80b8d49193f202870249dfb5b4f98fd7R63-R72) [[4]](diffhunk://#diff-5c59cdd3ad61bfd0b8ed4100acc9237a80b8d49193f202870249dfb5b4f98fd7R117-R118) [[5]](diffhunk://#diff-04a2c713748eb469a108463503a59c5d6c034111fe7fe3a719ea2254a02fa83eR83-R102) [[6]](diffhunk://#diff-04a2c713748eb469a108463503a59c5d6c034111fe7fe3a719ea2254a02fa83eR248-R286) [[7]](diffhunk://#diff-75093cec52fc5292b90d70140fb2b24481a0d51746c82d1fe326567b9bb34d3dR32-R47)
* Implemented a new CLI flag `--cancel-update` to cancel pending updates, with optional `--cancel-tx` to specify a particular transaction. [[1]](diffhunk://#diff-5c59cdd3ad61bfd0b8ed4100acc9237a80b8d49193f202870249dfb5b4f98fd7R23-R26) [[2]](diffhunk://#diff-5c59cdd3ad61bfd0b8ed4100acc9237a80b8d49193f202870249dfb5b4f98fd7R63-R72) [[3]](diffhunk://#diff-5c59cdd3ad61bfd0b8ed4100acc9237a80b8d49193f202870249dfb5b4f98fd7R117-R118) [[4]](diffhunk://#diff-04a2c713748eb469a108463503a59c5d6c034111fe7fe3a719ea2254a02fa83eR83-R102) [[5]](diffhunk://#diff-04a2c713748eb469a108463503a59c5d6c034111fe7fe3a719ea2254a02fa83eR248-R286)

**Testnet/Devnet/Mocknet Support and Currency Display:**

* Adjusted currency display logic and timelock parameters for testnet, devnet, and mocknet to ensure the timelock mechanism is testable and immediate where appropriate. [[1]](diffhunk://#diff-04a2c713748eb469a108463503a59c5d6c034111fe7fe3a719ea2254a02fa83eR163-R166) [[2]](diffhunk://#diff-04a2c713748eb469a108463503a59c5d6c034111fe7fe3a719ea2254a02fa83eR221-R224) [[3]](diffhunk://#diff-040b9521af929b26aeb68434ab997a8d84cc9c05fe477d272ee59f8e2a46ebc2R238-R239) [[4]](diffhunk://#diff-040b9521af929b26aeb68434ab997a8d84cc9c05fe477d272ee59f8e2a46ebc2R289-R290) [[5]](diffhunk://#diff-040b9521af929b26aeb68434ab997a8d84cc9c05fe477d272ee59f8e2a46ebc2R316-R318)

These changes collectively ensure that contract updates are more secure and auditable, providing time for review and the ability to cancel updates before they take effect.