### PR TITLE
fix(testnet): re-pin Version0_2_0Height above chain head to end the epoch-662 election stall

### DIFF
--- a/modules/common/system-config/system-config.go
+++ b/modules/common/system-config/system-config.go
@@ -282,7 +282,17 @@ func TestnetConfig() SystemConfig {
 			// v0.2.0 release activation gate. Testnet has persistent history, so
 			// PIN a future testnet height (above chain head) before rollout — not 1.
 			// 0 = inert until then.
-			Version0_2_0Height: 323_250,
+			//
+			// FIX(election-stall 2026-06-11): the prior 323_250 was BELOW the testnet
+			// head (~3.84M), so the H-6 gateway-PoP gate (+ contract-update timelock)
+			// went active the instant nodes ran the binary — against witness records
+			// the upgrade never backfilled with gateway_key_pop → the epoch-662
+			// election formed with member_count=0 and the chain stopped rotating
+			// committees. Re-pinned ~8h above the head (3_842_080 @ 2026-06-11) so every
+			// witness re-announces (its record gains gateway_key_pop) before the gate
+			// activates. protocol_version was already stored by the old indexer, so the
+			// 0.2.0 floor at ConsensusVersionFloorEpoch=662 already passes.
+			Version0_2_0Height: 3_852_000,
 			// Bond inclusion window (CP-2): 7,200 blocks (~6h) for faster testnet
 			// iteration. Activation 0 = inert until pinned.
 			BondInclusionWindowBlocks:     7_200,


### PR DESCRIPTION
Testnet config had Version0_2_0Height=323_250, far below the current testnet head (~3.84M). Version0_2_0Active(height) is therefore true the instant a node runs the binary, so the v0.2.0 H-6 gateway-key-PoP gate (WitnessKeyStrictActive) and the contract-update timelock activate retroactively with no runway.

The witness DB is built incrementally and is NOT reindexed on a binary upgrade, so the records the next election reads were written before gateway_key_pop storage existed (added in 09a22e0d) and carry an empty gateway_key_pop. With the gate live, the epoch-662 election (anchor 3827600) excludes all 6 witnesses
("gateway pop: missing proof-of-possession") and forms with member_count=0 ->
elections halt (the chain still produces on the epoch-661 committee but can no longer rotate the committee).

Re-pin to 3_852_000 (~8h above head 3_842_080 @ 2026-06-11): with the gate dormant, epoch 662 forms; on restart every witness re-announces and its record gains gateway_key_pop; by the new height the gate reads ready records and passes. protocol_version was already stored by the old indexer, so the 0.2.0 floor at ConsensusVersionFloorEpoch=662 already passes and the election forms as 0.2.0.

Deploy to all 6 testnet witnesses together (the committee is computed deterministically; a partial rollout would diverge).