### PR TITLE
Feat/pendulum lp minimum floor

### DIFF
--- a/cmd/contract-deployer/main.go
+++ b/cmd/contract-deployer/main.go
@@ -147,8 +147,12 @@ func deployNewContract(
 	}
 	fmt.Println(string(j))
 
+	// Mainnet uses HBD; every test network (testnet AND devnet) runs on a Hive
+	// testnet chain whose HBD-equivalent symbol is TBD. OnTestnet() alone misses
+	// devnet, leaving the fee asset as "HBD" which the devnet L1 rejects with
+	// "Cannot parse asset symbol".
 	currency := "HBD"
-	if sysConfig.OnTestnet() {
+	if !sysConfig.OnMainnet() {
 		currency = "TBD"
 	}
 
@@ -203,8 +207,12 @@ func updateContract(
 	}
 	fmt.Println(string(j))
 
+	// Mainnet uses HBD; every test network (testnet AND devnet) runs on a Hive
+	// testnet chain whose HBD-equivalent symbol is TBD. OnTestnet() alone misses
+	// devnet, leaving the fee asset as "HBD" which the devnet L1 rejects with
+	// "Cannot parse asset symbol".
 	currency := "HBD"
-	if sysConfig.OnTestnet() {
+	if !sysConfig.OnMainnet() {
 		currency = "TBD"
 	}
 

--- a/docs/pendulum/contract-api.md
+++ b/docs/pendulum/contract-api.md
@@ -165,5 +165,5 @@ The SDK itself is consensus-deterministic: it reads the snapshot at `block_heigh
 
 ## Open items the spec defers to the testnet plan
 
-- **LP minimum-floor cliff** (B12) — the SDK's `MinFractionBps` knob is currently 0; a future bump caps LP dilution at equilibrium. The contract surface is unchanged; only the SDK output `(new_X, new_Y)` shifts. No contract changes needed when the knob moves.
+- **LP minimum-floor** (B12) — IMPLEMENTED. The SDK caps the node fraction of every pendulum pot at `BpsScale − MinFractionBps`, including on the under-secured cliff, so liquidity providers always retain at least `MinFractionBps` of each pot. The knob defaults to `pendulum.DefaultLPFloorBps` (2500 bps = 25%, i.e. node share capped at 75%) and is gated on consensus `0.2.0` (`pendulum.LPFloorActivation`): below the activation line the floor is inert and splits are byte-identical to the pre-floor behavior. The contract surface is unchanged; only the SDK output `(new_X, new_Y)` shifts. Retune the floor by editing `DefaultLPFloorBps`; it ships inert until the chain activates `0.2.0`.
 - **Network-share asset of record** current design keeps the network cut native (output asset of each swap) and lets the claimer take a basket.

--- a/lib/test_utils/contract_test_utils.go
+++ b/lib/test_utils/contract_test_utils.go
@@ -343,6 +343,7 @@ func (ct *ContractTest) SetPendulumGeometry(out pendulumoracle.GeometryOutputs, 
 	ct.PendulumApplier = pendulumwasm.New(
 		stubGeometryReader{out: out},
 		func() []string { return whitelist },
+		nil, // no consensus-version reader → LP floor inert in contract tests
 		pendulumwasm.DefaultConfig(),
 	)
 }

--- a/modules/common/consensusversion/version.go
+++ b/modules/common/consensusversion/version.go
@@ -25,9 +25,15 @@ import (
 //   - 0.1.0 — pendulum settlement rollout. The Consensus 0→1 bump is what lets the floor
 //     rise to exclude pre-pendulum (0.0.0) nodes from the committee and TSS once a
 //     vsc.propose_consensus_version activates (see docs/consensus-upgrades.md).
+//   - 0.2.0 — pendulum LP minimum-floor (B12). The swap-fee split now caps the node
+//     fraction at BpsScale − MinFractionBps (including on the under-secured cliff), so
+//     liquidity providers always retain a minimum share of every pot. Gated on this line
+//     via pendulum.LPFloorActivation: while the chain-active version is still 0.1.0 the
+//     floor is inert and splits are byte-identical to 0.1.0, so the two interoperate until
+//     a vsc.propose_consensus_version activates 0.2.0.
 const (
 	currentMajor        uint64 = 0
-	currentConsensus    uint64 = 1
+	currentConsensus    uint64 = 2
 	currentNonConsensus uint64 = 0
 )
 

--- a/modules/common/consensusversion/version_test.go
+++ b/modules/common/consensusversion/version_test.go
@@ -44,7 +44,7 @@ func TestMaxComponentwise(t *testing.T) {
 // pinned current triple. Update this pin in the SAME commit that bumps the constants in
 // version.go.
 func TestRunningVersionIsSourcePinned(t *testing.T) {
-	want := Version{Major: 0, Consensus: 1, NonConsensus: 0}
+	want := Version{Major: 0, Consensus: 2, NonConsensus: 0}
 	if got := RunningVersion(); got != want {
 		t.Fatalf("running version = %+v, want %+v (source constants in version.go)", got, want)
 	}

--- a/modules/incentive-pendulum/floor.go
+++ b/modules/incentive-pendulum/floor.go
@@ -1,0 +1,50 @@
+package pendulum
+
+import "vsc-node/modules/common/consensusversion"
+
+// LP minimum-floor (B12). The PDF split routes an ever-larger share of every
+// pendulum pot to nodes as the collateralization ratio s = V/E rises, and the
+// full 100% once the under-secured cliff (V ≥ c·E) is crossed — exactly the
+// regime a network sits in when consensus stake does not cover pool liquidity.
+// The floor caps the node fraction so liquidity providers always retain at
+// least MinFractionBps of each pot, including on the cliff.
+//
+// This is consensus-critical: every node must apply the identical cap, so the
+// value is a compile-time constant (baked into the binary, see
+// wasm.DefaultConfig) and its activation is gated on a consensus version
+// (LPFloorActivation) rather than runtime/governance config.
+
+// DefaultLPFloorBps is the LP minimum-floor baked into wasm.DefaultConfig: the
+// minimum fraction (bps; BpsScale = 100%) of every pendulum pot that stays with
+// liquidity providers once the floor activates. 2500 bps = 25%, i.e. the node
+// share is capped at 75% (BpsScale − DefaultLPFloorBps) even on the under-
+// secured cliff.
+//
+// Economic policy parameter — retune by editing this single constant; it ships
+// inert until consensus LPFloorActivation activates, so changing it before
+// rollout is free.
+const DefaultLPFloorBps int64 = 2_500
+
+// LPFloorActivation is the consensus line (major.consensus) at/after which the
+// LP minimum-floor is enforced. Below it the floor is inert and splits are
+// byte-identical to the pre-floor 0.1.0 behavior, so pre-upgrade blocks replay
+// exactly and 0.1.0/0.2.0 nodes never fork on a swap. Bumped together with the
+// source consensus version (consensusversion currentConsensus) in the
+// activating commit.
+var LPFloorActivation = consensusversion.Version{Major: 0, Consensus: 2}
+
+// MaxNodeShareBps returns the ceiling on the node fraction (bps) implied by an
+// LP minimum-floor of minFractionBps: the largest node share that still leaves
+// LPs at least minFractionBps of the pot. A minFractionBps <= 0 disables the
+// floor (returns BpsScale = no ceiling), so a zero/unset knob is exactly the
+// historical PDF behavior; values above BpsScale are clamped to a 100% LP floor
+// (node ceiling 0) rather than wrapping.
+func MaxNodeShareBps(minFractionBps int64) int64 {
+	if minFractionBps <= 0 {
+		return BpsScale
+	}
+	if minFractionBps > BpsScale {
+		minFractionBps = BpsScale
+	}
+	return BpsScale - minFractionBps
+}

--- a/modules/incentive-pendulum/floor_test.go
+++ b/modules/incentive-pendulum/floor_test.go
@@ -1,0 +1,43 @@
+package pendulum
+
+import "testing"
+
+func TestMaxNodeShareBps(t *testing.T) {
+	cases := []struct {
+		name    string
+		minFrac int64
+		want    int64
+	}{
+		{"zero disables floor", 0, BpsScale},
+		{"negative disables floor", -100, BpsScale},
+		{"10% floor", 1_000, 9_000},
+		{"50% floor", 5_000, 5_000},
+		{"100% floor zeroes node ceiling", BpsScale, 0},
+		{"above 100% clamped, no wrap", BpsScale + 5_000, 0},
+	}
+	for _, c := range cases {
+		if got := MaxNodeShareBps(c.minFrac); got != c.want {
+			t.Fatalf("%s: MaxNodeShareBps(%d) = %d, want %d", c.name, c.minFrac, got, c.want)
+		}
+	}
+}
+
+// The floor activates at consensus 0.2.0 — the source line bumped in the
+// activating commit. Guards against the gate drifting away from the version.
+func TestLPFloorActivationLine(t *testing.T) {
+	if LPFloorActivation.Major != 0 || LPFloorActivation.Consensus != 2 {
+		t.Fatalf("LPFloorActivation = %s, want 0.2.x", LPFloorActivation.Format())
+	}
+}
+
+// The chosen default policy is a 75% node-share cap (25% LP floor). Pin it so a
+// stray edit to the constant trips a test rather than silently changing the
+// economic split.
+func TestDefaultLPFloorCapsNodeAt75(t *testing.T) {
+	if DefaultLPFloorBps != 2_500 {
+		t.Fatalf("DefaultLPFloorBps = %d, want 2500 (25%% LP floor)", DefaultLPFloorBps)
+	}
+	if got := MaxNodeShareBps(DefaultLPFloorBps); got != 7_500 {
+		t.Fatalf("default node-share cap = %d, want 7500 (75%%)", got)
+	}
+}

--- a/modules/incentive-pendulum/pendulum_int.go
+++ b/modules/incentive-pendulum/pendulum_int.go
@@ -38,6 +38,13 @@ type SplitOutputsInt struct {
 //
 // where c = CliffSBps/BpsScale is the cliff ratio (see params.go). This is the
 // generalized PDF closed form; c = 1 recovers the original V ≥ E cliff.
+//
+// This is the raw (un-floored) reference split; it is consumed only by the
+// settlement split preview (settlement.CalculateSplitPreviewFixed) and tests.
+// The live swap-fee path (wasm.splitFractionsBps) caps the node fraction with
+// the LP minimum-floor (B12, see floor.go / MaxNodeShareBps); SplitInt is left
+// un-floored on purpose because the floor is an application-layer policy gated
+// on a consensus version that this pure helper has no height to resolve.
 func SplitInt(in SplitInputsInt) (SplitOutputsInt, bool) {
 	out := SplitOutputsInt{}
 

--- a/modules/incentive-pendulum/wasm/applier.go
+++ b/modules/incentive-pendulum/wasm/applier.go
@@ -11,6 +11,7 @@ import (
 	"math/big"
 
 	"vsc-node/lib/intmath"
+	"vsc-node/modules/common/consensusversion"
 	"vsc-node/modules/db/vsc/contracts"
 	pendulum "vsc-node/modules/incentive-pendulum"
 	pendulumoracle "vsc-node/modules/incentive-pendulum/oracle"
@@ -34,24 +35,37 @@ type GeometryReader interface {
 // are picked up without re-construction).
 type WhitelistGetter func() []string
 
+// ConsensusVersionAt resolves the chain-active consensus version at a block
+// height — StateEngine.ActiveConsensusVersion in production, sourced purely
+// from the on-chain election so it is deterministic and replay-correct. When
+// nil the applier treats the chain as pre-activation, so the LP minimum-floor
+// stays inert (tests that don't exercise the floor pass nil).
+type ConsensusVersionAt func(blockHeight uint64) consensusversion.Version
+
 // Config is the per-network tuning the applier reads on every swap.
 type Config struct {
 	Stabilizer      pendulum.StabilizerParamsBps
 	NetworkShareNum int64 // 1 of 4 → 25% network share
 	NetworkShareDen int64
-	// MinFractionBps is the LP-side floor the plan parks behind a TODO. Zero
-	// means PDF behavior (no floor); leaving as a Config knob so we can dial
-	// it without code change once the team picks a value.
-	MinFractionBps int
+	// MinFractionBps is the LP minimum-floor (B12): the minimum fraction (bps;
+	// BpsScale = 100%) of every pendulum pot (CLP + protocol legs) that stays
+	// with liquidity providers. The node fraction is capped at
+	// BpsScale − MinFractionBps, including on the under-secured cliff. Enforced
+	// only from consensus pendulum.LPFloorActivation onward (see floor.go); 0
+	// disables it (historical PDF split).
+	MinFractionBps int64
 }
 
-// DefaultConfig returns the v1 testnet defaults: PDF stabilizer, 25% network
-// share, no LP floor. Override per-network via SystemConfig.
+// DefaultConfig returns the v1 defaults: PDF stabilizer, 25% network share, and
+// the pendulum.DefaultLPFloorBps LP minimum-floor (gated on consensus
+// pendulum.LPFloorActivation — inert until that line is chain-active). Override
+// per-network via SystemConfig.
 func DefaultConfig() Config {
 	return Config{
 		Stabilizer:      pendulum.DefaultStabilizerParamsBps(),
 		NetworkShareNum: 1,
 		NetworkShareDen: 4,
+		MinFractionBps:  pendulum.DefaultLPFloorBps,
 	}
 }
 
@@ -59,16 +73,18 @@ func DefaultConfig() Config {
 // It is stateless across calls — per-call ledger movement happens through the
 // AccrueNodeBucketFn the execution context supplies at call time.
 type Applier struct {
-	geometry  GeometryReader
-	whitelist WhitelistGetter
-	cfg       Config
+	geometry    GeometryReader
+	whitelist   WhitelistGetter
+	consensusAt ConsensusVersionAt
+	cfg         Config
 }
 
 // New constructs an Applier. Any nil dep produces an applier that always
 // returns ErrUnimplemented from ApplySwapFees, so the wasm runtime can call
-// without worrying about partial wiring.
-func New(geometry GeometryReader, whitelist WhitelistGetter, cfg Config) *Applier {
-	return &Applier{geometry: geometry, whitelist: whitelist, cfg: cfg}
+// without worrying about partial wiring. A nil consensusAt is permitted and
+// keeps the LP minimum-floor inert (pre-activation behavior).
+func New(geometry GeometryReader, whitelist WhitelistGetter, consensusAt ConsensusVersionAt, cfg Config) *Applier {
+	return &Applier{geometry: geometry, whitelist: whitelist, consensusAt: consensusAt, cfg: cfg}
 }
 
 // Sentinel errors. Wrapped with contracts.SDK_ERROR so the wasm runtime maps
@@ -239,7 +255,20 @@ func (a *Applier) ApplySwapFees(
 	pendulumProtocol := new(big.Int).Sub(totalProtocol, networkProtocol)
 
 	// 9. Split ratios from snapshot — closed form, integer math.
-	fNodeBps, fNodeProtocolBps := splitFractionsBps(T, V, E, P, sBps)
+	//
+	// LP minimum-floor (B12): cap the node fraction at BpsScale − MinFractionBps
+	// so LPs always retain at least MinFractionBps of every pot, including on the
+	// under-secured cliff. Gated on consensus pendulum.LPFloorActivation — below
+	// activation maxNodeBps stays BpsScale (no cap), so pre-upgrade blocks replay
+	// byte-identically and 0.1.0/0.2.0 nodes never fork on a swap. The
+	// active version is a pure function of the on-chain election at this height,
+	// so every node computes the identical gate.
+	maxNodeBps := int64(pendulum.BpsScale)
+	if a.cfg.MinFractionBps > 0 && a.consensusAt != nil &&
+		a.consensusAt(blockHeight).MeetsConsensusMin(pendulum.LPFloorActivation) {
+		maxNodeBps = pendulum.MaxNodeShareBps(a.cfg.MinFractionBps)
+	}
+	fNodeBps, fNodeProtocolBps := splitFractionsBps(T, V, E, P, sBps, maxNodeBps)
 
 	// 10. Per-pot splits (LP gets floor, node side gets residual for exact conservation).
 	scale := big.NewInt(pendulum.BpsScale)
@@ -388,13 +417,19 @@ func exacerbatesFromSnapshot(sBps int64, hbdIn bool) bool {
 // splitFractionsBps returns (f_node, f_node_protocol) as basis points. fNode
 // applies to the CLP pot; fNodeProtocol applies to the protocol+surplus pot
 // with §9 redirect cliffs at the safe-band edges (pendulum.RedirectLo/HiBps).
-func splitFractionsBps(T, V, E, P *big.Int, sBps int64) (int64, int64) {
+//
+// maxNodeBps is the LP minimum-floor ceiling on the node fraction (B12): every
+// node-share return — the computed fraction, the §9 redirect-to-nodes edge, and
+// the under-secured / degenerate cliffs — is capped at it. The caller passes
+// BpsScale when the floor is inactive, so all caps become no-ops and the result
+// is byte-identical to the pre-floor split.
+func splitFractionsBps(T, V, E, P *big.Int, sBps int64, maxNodeBps int64) (int64, int64) {
 	scale := big.NewInt(pendulum.BpsScale)
 
 	cE := pendulum.CliffTimesE(E)
 	if V.Cmp(cE) >= 0 {
-		// Under-secured cliff: all to nodes.
-		return pendulum.BpsScale, pendulum.BpsScale
+		// Under-secured cliff: route to nodes, but never past the LP floor.
+		return maxNodeBps, maxNodeBps
 	}
 
 	// denom = T·V² + P·E·(c·E − V)
@@ -405,17 +440,17 @@ func splitFractionsBps(T, V, E, P *big.Int, sBps int64) (int64, int64) {
 	peTerm.Mul(peTerm, cEMinusV)
 	denom := new(big.Int).Add(tvSquared, peTerm)
 	if denom.Sign() == 0 {
-		return pendulum.BpsScale, pendulum.BpsScale
+		return maxNodeBps, maxNodeBps
 	}
 
-	// f_node = T·V² / denom in bps.
+	// f_node = T·V² / denom in bps, capped at the LP-floor ceiling.
 	fNodeBig := intmath.MulDivFloor(tvSquared, scale, denom)
 	if !fNodeBig.IsInt64() {
-		return pendulum.BpsScale, pendulum.BpsScale
+		return maxNodeBps, maxNodeBps
 	}
 	fNode := fNodeBig.Int64()
-	if fNode > pendulum.BpsScale {
-		fNode = pendulum.BpsScale
+	if fNode > maxNodeBps {
+		fNode = maxNodeBps
 	}
 
 	// §9: protocol leg redirects to the rebalancing side past the safe band.
@@ -423,13 +458,13 @@ func splitFractionsBps(T, V, E, P *big.Int, sBps int64) (int64, int64) {
 	// s>high" (which compensated the starved side and so *dampened*
 	// restoration): below RedirectLo liquidity is starved → fund LPs
 	// (fNodeProtocol=0) to attract it; above RedirectHi liquidity is in excess
-	// → route to nodes (fNodeProtocol=BpsScale) to shed it. Edges are the
-	// safe-band edges (params.go).
+	// → route to nodes (fNodeProtocol=maxNodeBps, i.e. BpsScale absent the LP
+	// floor) to shed it. Edges are the safe-band edges (params.go).
 	fNodeProtocol := fNode
 	if sBps < pendulum.RedirectLoBps {
 		fNodeProtocol = 0
 	} else if sBps > pendulum.RedirectHiBps {
-		fNodeProtocol = pendulum.BpsScale
+		fNodeProtocol = maxNodeBps
 	}
 	return fNode, fNodeProtocol
 }

--- a/modules/incentive-pendulum/wasm/applier_test.go
+++ b/modules/incentive-pendulum/wasm/applier_test.go
@@ -56,6 +56,7 @@ func newApplier(t *testing.T, geo pendulumoracle.GeometryOutputs, whitelist []st
 	a := New(
 		&stubGeometry{out: geo},
 		func() []string { return whitelist },
+		nil, // LP floor inert unless a test wires a consensus-version reader
 		Config{
 			Stabilizer:      pendulum.DefaultStabilizerParamsBps(),
 			NetworkShareNum: 1,
@@ -435,14 +436,14 @@ func TestExacerbatesFromSnapshot(t *testing.T) {
 // wired state engine returns a clean error rather than panicking. Includes the
 // nil accrual callback case.
 func TestApplierConfiguredNilDeps(t *testing.T) {
-	a := New(nil, nil, DefaultConfig())
+	a := New(nil, nil, nil, DefaultConfig())
 	res := a.ApplySwapFees("contract:pool-1", "tx-1", 100, defaultArgs("hbd", "hive"), nil)
 	if !res.IsErr() {
 		t.Fatal("expected error from nil-dep applier")
 	}
 
 	// Configured applier but nil accrual callback also fails cleanly.
-	a2 := New(&stubGeometry{out: balancedGeometry()}, func() []string { return []string{"contract:pool-1"} }, DefaultConfig())
+	a2 := New(&stubGeometry{out: balancedGeometry()}, func() []string { return []string{"contract:pool-1"} }, nil, DefaultConfig())
 	res = a2.ApplySwapFees("contract:pool-1", "tx-1", 100, defaultArgs("hbd", "hive"), nil)
 	if !res.IsErr() {
 		t.Fatal("expected error when accrual callback is nil")

--- a/modules/incentive-pendulum/wasm/floor_applier_test.go
+++ b/modules/incentive-pendulum/wasm/floor_applier_test.go
@@ -1,0 +1,136 @@
+package pendulumwasm
+
+import (
+	"math/big"
+	"testing"
+
+	"vsc-node/modules/common/consensusversion"
+	pendulum "vsc-node/modules/incentive-pendulum"
+	pendulumoracle "vsc-node/modules/incentive-pendulum/oracle"
+	wasm_context "vsc-node/modules/wasm/context"
+)
+
+// fixedVersion is a ConsensusVersionAt returning the same triple at every
+// height, so floor tests can stand on either side of LPFloorActivation.
+func fixedVersion(major, consensus uint64) ConsensusVersionAt {
+	return func(uint64) consensusversion.Version {
+		return consensusversion.Version{Major: major, Consensus: consensus}
+	}
+}
+
+// On the under-secured cliff (V ≥ c·E) the raw split routes 100% to nodes; the
+// LP floor must cap that at the node ceiling instead.
+func TestSplitFractionsBpsFloorCapsCliff(t *testing.T) {
+	E := big.NewInt(1_000_000)
+	V := big.NewInt(4_000_000) // ≥ c·E = 3·1_000_000 → under-secured
+	P := big.NewInt(2_000_000)
+	T := big.NewInt(1_000_000)
+	sBps := int64(4 * pendulum.BpsScale)
+
+	if fN, fP := splitFractionsBps(T, V, E, P, sBps, pendulum.BpsScale); fN != pendulum.BpsScale || fP != pendulum.BpsScale {
+		t.Fatalf("floor off: got (%d,%d), want (10000,10000)", fN, fP)
+	}
+	maxNode := pendulum.MaxNodeShareBps(1_000) // 10% LP floor → node ceiling 9000
+	if fN, fP := splitFractionsBps(T, V, E, P, sBps, maxNode); fN != 9_000 || fP != 9_000 {
+		t.Fatalf("floor on: got (%d,%d), want (9000,9000)", fN, fP)
+	}
+}
+
+// Just below the cliff (s = 2.9) the raw node fraction already exceeds the
+// ceiling, and s > RedirectHi sends the protocol leg fully to nodes — both get
+// capped by the floor.
+func TestSplitFractionsBpsFloorCapsHighS(t *testing.T) {
+	E := big.NewInt(1_000_000)
+	V := big.NewInt(2_900_000)
+	P := big.NewInt(1_450_000)
+	T := big.NewInt(1_000_000)
+	sBps := int64(29_000)
+
+	fNodeOff, fProtoOff := splitFractionsBps(T, V, E, P, sBps, pendulum.BpsScale)
+	if fNodeOff <= 9_000 {
+		t.Fatalf("floor off: raw node fraction %d should exceed 9000 in this regime", fNodeOff)
+	}
+	if fProtoOff != pendulum.BpsScale {
+		t.Fatalf("floor off: protocol leg should redirect to nodes (%d), got %d", pendulum.BpsScale, fProtoOff)
+	}
+
+	maxNode := pendulum.MaxNodeShareBps(1_000)
+	if fNodeOn, fProtoOn := splitFractionsBps(T, V, E, P, sBps, maxNode); fNodeOn != maxNode || fProtoOn != maxNode {
+		t.Fatalf("floor on: got (%d,%d), want (%d,%d)", fNodeOn, fProtoOn, maxNode, maxNode)
+	}
+}
+
+// In the healthy band the node fraction is already under the ceiling, so the
+// floor is a strict no-op — the split is byte-identical with and without it.
+func TestSplitFractionsBpsFloorNoOpInHealthyBand(t *testing.T) {
+	E := big.NewInt(1_000_000)
+	V := big.NewInt(1_000_000) // s = 1.0 (equilibrium)
+	P := big.NewInt(500_000)
+	T := big.NewInt(1_000_000)
+	sBps := int64(pendulum.BpsScale)
+
+	offN, offP := splitFractionsBps(T, V, E, P, sBps, pendulum.BpsScale)
+	onN, onP := splitFractionsBps(T, V, E, P, sBps, pendulum.MaxNodeShareBps(1_000))
+	if onN != offN || onP != offP {
+		t.Fatalf("floor must be a no-op below the ceiling: off=(%d,%d) on=(%d,%d)", offN, offP, onN, onP)
+	}
+	if offN != 5_000 {
+		t.Fatalf("equilibrium node fraction = %d, want 5000", offN)
+	}
+}
+
+// End-to-end: the floor only takes effect once the chain-active consensus
+// version reaches LPFloorActivation (0.2.0). Below it — and with no version
+// reader at all — the split is the historical 100%-to-nodes cliff.
+func TestApplySwapFeesLPFloorGatedByConsensus(t *testing.T) {
+	wl := []string{"contract:pool-1"}
+	cfg := Config{
+		Stabilizer:      pendulum.DefaultStabilizerParamsBps(),
+		NetworkShareNum: 1,
+		NetworkShareDen: 4,
+		MinFractionBps:  1_000, // 10% LP floor
+	}
+	geo := pendulumoracle.GeometryOutputs{
+		OK: true, V: 4_000_000, P: 2_000_000, E: 1_000_000, T: 1_000_000,
+		SBps: 4 * pendulum.BpsScale, // under-secured cliff
+	}
+	args := wasm_context.PendulumSwapFeeArgs{
+		AssetIn: "hbd", AssetOut: "hive",
+		X: 10_000_000, XReserve: 1_000_000_000, YReserve: 1_000_000_000,
+	}
+
+	apply := func(cv ConsensusVersionAt) wasm_context.PendulumSwapFeeResult {
+		a := New(&stubGeometry{out: geo}, func() []string { return wl }, cv, cfg)
+		res := a.ApplySwapFees("contract:pool-1", "tx", 100, args, (&recordingAccrual{}).fn)
+		if res.IsErr() {
+			t.Fatalf("apply failed: %v", res)
+		}
+		return res.Unwrap()
+	}
+
+	active := apply(fixedVersion(0, 2)) // ≥ 0.2.0 → floor enforced
+	pre := apply(fixedVersion(0, 1))    // 0.1.0 (below activation) → floor inert
+	nilCV := apply(nil)                 // no reader → floor inert
+
+	if active.LpShareOutput <= 0 {
+		t.Fatalf("floor active: LPs must keep a positive share on the cliff, got %d", active.LpShareOutput)
+	}
+	if pre.LpShareOutput != 0 {
+		t.Fatalf("pre-activation: cliff routes 100%% to nodes, want LP share 0, got %d", pre.LpShareOutput)
+	}
+	if nilCV.LpShareOutput != 0 {
+		t.Fatalf("nil consensus reader: floor must stay inert, got LP share %d", nilCV.LpShareOutput)
+	}
+	if active.NodeShareOutput >= pre.NodeShareOutput {
+		t.Fatalf("floor active node share %d must be below pre-activation %d", active.NodeShareOutput, pre.NodeShareOutput)
+	}
+	// The floor only redistributes the pendulum pot between LP and node — it
+	// must not resize the pot or touch the network cut.
+	if active.LpShareOutput+active.NodeShareOutput != pre.LpShareOutput+pre.NodeShareOutput {
+		t.Fatalf("pot resized: active %d != pre %d",
+			active.LpShareOutput+active.NodeShareOutput, pre.LpShareOutput+pre.NodeShareOutput)
+	}
+	if active.NetworkCreditOutput != pre.NetworkCreditOutput {
+		t.Fatalf("network cut changed: active %d != pre %d", active.NetworkCreditOutput, pre.NetworkCreditOutput)
+	}
+}

--- a/modules/state-processing/pendulum_conservation_test.go
+++ b/modules/state-processing/pendulum_conservation_test.go
@@ -6,6 +6,7 @@ import (
 
 	"vsc-node/lib/intmath"
 	"vsc-node/lib/test_utils"
+	"vsc-node/modules/common/consensusversion"
 	ledgerDb "vsc-node/modules/db/vsc/ledger"
 	pendulum "vsc-node/modules/incentive-pendulum"
 	pendulumoracle "vsc-node/modules/incentive-pendulum/oracle"
@@ -99,6 +100,7 @@ func TestPendulumAccrualHBDConservation(t *testing.T) {
 	a := pendulumwasm.New(
 		&stubGeometryForConservation{out: balancedConservationGeometry()},
 		func() []string { return []string{contractID} },
+		nil, // LP floor inert in conservation tests
 		pendulumwasm.Config{
 			Stabilizer:      pendulum.DefaultStabilizerParamsBps(),
 			NetworkShareNum: 1,
@@ -177,6 +179,7 @@ func TestPendulumAccrualFailsWhenContractUnderfunded(t *testing.T) {
 	a := pendulumwasm.New(
 		&stubGeometryForConservation{out: balancedConservationGeometry()},
 		func() []string { return []string{contractID} },
+		nil, // LP floor inert in conservation tests
 		pendulumwasm.Config{
 			Stabilizer:      pendulum.DefaultStabilizerParamsBps(),
 			NetworkShareNum: 1,
@@ -195,4 +198,128 @@ func TestPendulumAccrualFailsWhenContractUnderfunded(t *testing.T) {
 	if !res.IsErr() {
 		t.Fatal("expected swap to fail when contract HBD is insufficient for the accrual")
 	}
+}
+
+// underSecuredConservationGeometry is the cliff regime the floor targets:
+// V = 4_000_000 >= c*E = 3*1_000_000, where the raw pendulum routes 100% to
+// nodes. (SBps = 4.0 in bps.)
+func underSecuredConservationGeometry() pendulumoracle.GeometryOutputs {
+	return pendulumoracle.GeometryOutputs{
+		OK: true, V: 4_000_000, P: 2_000_000, E: 1_000_000, T: 1_000_000,
+		SBps: 4 * intmath.BpsScale,
+	}
+}
+
+// TestPendulumLPFloorBindsUnderSecured drives a real swap through the
+// production LedgerSession on an UNDER-SECURED pool and proves the
+// consensus-0.2.0 LP minimum-floor binds end-to-end through the ledger, not
+// just in the pure-applier unit test:
+//
+//   - With the chain below 0.2.0 the under-secured cliff still routes 100% of
+//     the pot to nodes (LP share 0) — the historical behavior.
+//   - At 0.2.0 the node share is capped at 75% (DefaultLPFloorBps = 25% LP
+//     floor): LPs keep ~25% of the pot, the node bucket is credited only the
+//     capped amount, and HBD is conserved across the paired transfer.
+//
+// Running both sides with identical geometry/args isolates the difference to
+// the floor (consensus gate), not the swap math.
+func TestPendulumLPFloorBindsUnderSecured(t *testing.T) {
+	const seededY = int64(100_000_000)
+	args := wasm_context.PendulumSwapFeeArgs{
+		// HBD-out swap: the node share drains directly as HBD (no secondary
+		// hop), keeping the conservation assertion simple.
+		AssetIn:  "hive",
+		AssetOut: "hbd",
+		X:        100_000,
+		XReserve: 1_000_000,
+		YReserve: seededY,
+	}
+
+	// run executes one swap end-to-end through a real LedgerSession at the given
+	// chain-active consensus version, asserts HBD conservation, and returns the
+	// swap result.
+	run := func(t *testing.T, consensus uint64) wasm_context.PendulumSwapFeeResult {
+		t.Helper()
+		contractID := "pool-floor"
+		contractAcct := "contract:" + contractID
+		balDb := &test_utils.MockBalanceDb{
+			BalanceRecords: map[string][]ledgerDb.BalanceRecord{
+				contractAcct: {{Account: contractAcct, BlockHeight: 99, HBD: seededY}},
+			},
+		}
+		lDb := &test_utils.MockLedgerDb{LedgerRecords: make(map[string][]ledgerDb.LedgerRecord)}
+		aDb := &test_utils.MockActionsDb{Actions: make(map[string]ledgerDb.ActionRecord)}
+		ls := ledgerSystem.New(balDb, lDb, nil, aDb, nil)
+		state := ls.NewEmptyState()
+		session := ledgerSystem.NewSession(state)
+
+		a := pendulumwasm.New(
+			&stubGeometryForConservation{out: underSecuredConservationGeometry()},
+			func() []string { return []string{contractID} },
+			func(uint64) consensusversion.Version {
+				return consensusversion.Version{Major: 0, Consensus: consensus}
+			},
+			pendulumwasm.DefaultConfig(), // MinFractionBps = DefaultLPFloorBps (2500 = 25%)
+		)
+
+		const swapBh = uint64(100)
+		res := a.ApplySwapFees(contractID, "tx-floor", swapBh, args, realSessionAccrual(contractID, "tx-floor", swapBh, session))
+		if res.IsErr() {
+			t.Fatalf("ApplySwapFees (consensus 0.%d): %v", consensus, res.UnwrapErr())
+		}
+		out := res.Unwrap()
+		session.Done()
+
+		// HBD conservation across the paired transfer holds regardless of the floor.
+		contractBal := state.SnapshotForAccount(contractAcct, swapBh, "hbd")
+		bucketBal := state.SnapshotForAccount(ledgerSystem.PendulumNodesHBDBucket, swapBh, "hbd")
+		if bucketBal != out.NodeBucketCreditedHBD {
+			t.Fatalf("consensus 0.%d: bucket HBD %d != reported credit %d", consensus, bucketBal, out.NodeBucketCreditedHBD)
+		}
+		if contractBal+bucketBal != seededY {
+			t.Fatalf("consensus 0.%d: HBD conservation broken: contract=%d bucket=%d sum=%d (want %d)",
+				consensus, contractBal, bucketBal, contractBal+bucketBal, seededY)
+		}
+		return out
+	}
+
+	floorOn := run(t, 2)  // >= LPFloorActivation (0.2.0) → floor enforced
+	floorOff := run(t, 1) // 0.1.0, below activation → historical cliff
+
+	// Pre-activation: the under-secured cliff routes the entire pot to nodes.
+	if floorOff.LpShareOutput != 0 {
+		t.Fatalf("pre-0.2.0 under-secured swap must route 100%% to nodes, got LP share %d", floorOff.LpShareOutput)
+	}
+
+	// The floor only redistributes the pot between LP and node — pot size and
+	// the network cut are untouched.
+	pot := floorOff.LpShareOutput + floorOff.NodeShareOutput
+	if pot <= 0 {
+		t.Fatalf("degenerate test: empty pendulum pot")
+	}
+	if floorOn.LpShareOutput+floorOn.NodeShareOutput != pot {
+		t.Fatalf("floor resized the pot: on=%d off=%d", floorOn.LpShareOutput+floorOn.NodeShareOutput, pot)
+	}
+	if floorOn.NetworkCreditOutput != floorOff.NetworkCreditOutput {
+		t.Fatalf("floor changed the network cut: on=%d off=%d", floorOn.NetworkCreditOutput, floorOff.NetworkCreditOutput)
+	}
+
+	// At 0.2.0 LPs keep ~25% of the pot and nodes are capped at ~75% (the two
+	// pots floor-divide independently, so allow a couple base units of slack).
+	quarter := pot / 4
+	if floorOn.LpShareOutput < quarter-2 {
+		t.Fatalf("LP floor not enforced: LP share %d < ~25%% of pot %d", floorOn.LpShareOutput, pot)
+	}
+	if floorOn.NodeShareOutput > pot-quarter+2 {
+		t.Fatalf("node share %d exceeds ~75%% cap of pot %d", floorOn.NodeShareOutput, pot)
+	}
+	// The floor moved real money out of the node bucket and into LP reserves.
+	if floorOn.NodeBucketCreditedHBD >= floorOff.NodeBucketCreditedHBD {
+		t.Fatalf("floor should reduce node-bucket accrual: on=%d off=%d",
+			floorOn.NodeBucketCreditedHBD, floorOff.NodeBucketCreditedHBD)
+	}
+	t.Logf("under-secured pot=%d: floor-off node=%d/LP=%d → floor-on node=%d/LP=%d (bucket %d→%d)",
+		pot, floorOff.NodeShareOutput, floorOff.LpShareOutput,
+		floorOn.NodeShareOutput, floorOn.LpShareOutput,
+		floorOff.NodeBucketCreditedHBD, floorOn.NodeBucketCreditedHBD)
 }

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -2558,6 +2558,7 @@ func New(sconf systemconfig.SystemConfig, da *DataLayer.DataLayer,
 			effectiveStakeDen: 3,
 		},
 		func() []string { return sconf.PendulumPoolWhitelist() },
+		se.ActiveConsensusVersion, // gates the LP minimum-floor on consensus 0.2.0
 		pendulumwasm.DefaultConfig(),
 	)
 

--- a/tests/devnet/contract.go
+++ b/tests/devnet/contract.go
@@ -144,6 +144,30 @@ func BuildCallTssContract(ctx context.Context) (string, error) {
 	return wasmPath, nil
 }
 
+// BuildAmmPoolContract builds the amm-pool WASM contract used by the pendulum
+// LP-floor devnet test. The pool publishes pendulum geometry state keys, draws
+// HBD to back the node-share drain, and forwards swaps to
+// system.pendulum_apply_swap_fees.
+func BuildAmmPoolContract(ctx context.Context) (string, error) {
+	contractDir := filepath.Join(findSourceRoot(), "tests", "devnet", "contracts", "amm-pool")
+	wasmPath := filepath.Join(contractDir, "bin", "build.wasm")
+
+	log.Printf("[devnet] building amm-pool contract...")
+	cmd := exec.CommandContext(ctx, "make", "-C", contractDir, "build")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("building amm-pool contract: %w", err)
+	}
+
+	if _, err := os.Stat(wasmPath); err != nil {
+		return "", fmt.Errorf("built wasm not found at %s: %w", wasmPath, err)
+	}
+
+	log.Printf("[devnet] amm-pool contract built: %s", wasmPath)
+	return wasmPath, nil
+}
+
 // BuildBtcStubContract builds the btc-stub WASM contract used by oracle
 // chain-relay devnet tests. The stub mimics the BTC mapping contract's
 // `addBlocks` interface but skips all BTC validation, making it cheap to

--- a/tests/devnet/contracts/amm-pool/Makefile
+++ b/tests/devnet/contracts/amm-pool/Makefile
@@ -1,0 +1,36 @@
+ROOT_DIR 		:= $(abspath .)
+BIN_DIR			:= bin
+
+TARGET = contract/main.go
+BASEFLAGS = -gc=custom -scheduler=none -panic=trap -no-debug -target=wasm-unknown
+
+TINYJSON		:= tinyjson
+TINYJSON_FLAGS 	:= -snake_case -no_std_marshalers
+CONTRACTS_DIR	:= contract
+
+TINYGO_IMAGE := tinygo/tinygo:0.39.0
+WORKDIR      := /work
+
+TINYGO_CMD = docker run --rm \
+    -u $(shell id -u):$(shell id -g) \
+    $(GOWORK_EXTRA_MOUNTS) \
+    -v $(CURDIR):$(WORKDIR) \
+    -w $(WORKDIR) \
+    $(TINYGO_IMAGE) \
+    tinygo
+
+ifeq ($(USE_DOCKER),0)
+    TINYGO_CMD = tinygo
+endif
+
+all: build
+
+pull-tinygo:
+	docker pull $(TINYGO_IMAGE)
+
+build:
+	@echo "Building $@ ..."
+	$(TINYGO_CMD) build $(BASEFLAGS) -o $(BIN_DIR)/$@.wasm $(TARGET)
+
+clean:
+	rm -rf $(BIN_DIR)/*.wasm

--- a/tests/devnet/contracts/amm-pool/contract/main.go
+++ b/tests/devnet/contracts/amm-pool/contract/main.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+
+	"amm-pool/sdk"
+)
+
+// amm-pool is a minimal HBD-paired pool used by the pendulum LP-floor devnet
+// test. It does NOT implement a real CPMM; it only does the three things the
+// pendulum pipeline observes:
+//
+//   - setup() publishes the pool's geometry state keys (a0n/a1n/r0/r1) so the
+//     node's GeometryComputer reads this pool as HBD-paired with a chosen HBD
+//     reserve. A huge r0 forces V = 2*r0 >> c*E (the under-secured regime where
+//     the raw pendulum routes ~100% to nodes — exactly where the 0.2.0 LP floor
+//     must cap the node share at 75%).
+//   - fund() draws real HBD into the pool's balance so the applier's node-share
+//     drain (a paired transfer from contract:<id> to pendulum:nodes) succeeds.
+//   - swap() forwards swap inputs to system.pendulum_apply_swap_fees and stores
+//     the returned split JSON under the "result" state key for the test to read
+//     cross-node.
+
+// u64BE encodes n as minimal unsigned big-endian bytes — the form
+// pendulumPoolReserveReader decodes pool reserves from (big.Int.SetBytes).
+func u64BE(n uint64) string {
+	if n == 0 {
+		return string([]byte{0})
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte(n & 0xff)}, b...)
+		n >>= 8
+	}
+	return string(b)
+}
+
+func mustU64(s string) uint64 {
+	v, err := strconv.ParseUint(strings.TrimSpace(s), 10, 64)
+	if err != nil {
+		sdk.Abort("invalid uint: " + s)
+	}
+	return v
+}
+
+// jsonField extracts a string-valued field from a flat JSON object without a
+// full JSON parser (the pendulum result is flat with all-string values):
+// `"<key>":"<value>"`.
+func jsonField(js, key string) string {
+	marker := "\"" + key + "\":\""
+	i := strings.Index(js, marker)
+	if i < 0 {
+		return ""
+	}
+	i += len(marker)
+	j := strings.Index(js[i:], "\"")
+	if j < 0 {
+		return ""
+	}
+	return js[i : i+j]
+}
+
+// setup publishes pendulum geometry. Input CSV: "<r0_hbd>,<r1_hive>" (base units).
+//
+//go:wasmexport setup
+func setup(input *string) *string {
+	parts := strings.Split(*input, ",")
+	if len(parts) != 2 {
+		sdk.Abort("setup expects <r0_hbd>,<r1_hive>")
+	}
+	sdk.StateSetObject("a0n", "hbd")
+	sdk.StateSetObject("a1n", "hive")
+	sdk.StateSetObject("r0", u64BE(mustU64(parts[0])))
+	sdk.StateSetObject("r1", u64BE(mustU64(parts[1])))
+	out := "0"
+	return &out
+}
+
+// fund draws HBD from the caller's transfer.allow intent into the pool balance,
+// backing the node-share drain the pendulum applier performs on swap. Input:
+// HBD amount in base units (decimal string).
+//
+//go:wasmexport fund
+func fund(input *string) *string {
+	sdk.HiveDraw(strings.TrimSpace(*input), "hbd")
+	// Record the pool's own HBD balance after the draw so the test can confirm
+	// funding via a plain state key (contract-account balances aren't reliably
+	// exposed via the account-balance GQL).
+	if id := sdk.GetEnvKey("contract.id"); id != nil {
+		sdk.StateSetObject("funded_hbd", sdk.HiveGetBalance("contract:"+*id, "hbd"))
+	}
+	out := "0"
+	return &out
+}
+
+// swap forwards the pendulum swap inputs to system.pendulum_apply_swap_fees and
+// records the returned split. Input is the SDK input JSON:
+// {"asset_in":"hive","asset_out":"hbd","x":"..","x_reserve":"..","y_reserve":".."}.
+// Stores the full result JSON under "result"; aborts (tx fails) if the host
+// rejects the swap (not whitelisted / insufficient reserves / etc.).
+//
+//go:wasmexport swap
+func swap(input *string) *string {
+	res := sdk.PendulumApplySwapFees(*input)
+	sdk.StateSetObject("result", res)
+	// Surface the split fields as plain decimal-string state keys so the test
+	// can read them cross-node without JSON-in-state ambiguity.
+	sdk.StateSetObject("lp_share", jsonField(res, "lp_share_output"))
+	sdk.StateSetObject("node_share", jsonField(res, "node_share_output"))
+	sdk.StateSetObject("s_after", jsonField(res, "s_after_bps"))
+	sdk.StateSetObject("node_bucket", jsonField(res, "node_bucket_credited_hbd"))
+	return &res
+}

--- a/tests/devnet/contracts/amm-pool/go.mod
+++ b/tests/devnet/contracts/amm-pool/go.mod
@@ -1,0 +1,3 @@
+module amm-pool
+
+go 1.25.0

--- a/tests/devnet/contracts/amm-pool/runtime/gc_leaking_exported.go
+++ b/tests/devnet/contracts/amm-pool/runtime/gc_leaking_exported.go
@@ -1,0 +1,203 @@
+// https://github.com/tinygo-org/tinygo/blob/2a76ceb7dd5ea5a834ec470b724882564d9681b3/src/runtime/arch_tinygowasm.go#L42
+// https://github.com/tinygo-org/tinygo/blob/2a76ceb7dd5ea5a834ec470b724882564d9681b3/src/runtime/gc_leaking.go
+
+//go:build gc.custom
+
+package runtime
+
+// This GC implementation is the simplest useful memory allocator possible: it
+// only allocates memory and never frees it. For some constrained systems, it
+// may be the only memory allocator possible.
+
+import (
+	realRuntime "runtime"
+	"unsafe"
+)
+
+// https://github.com/tinygo-org/tinygo/blob/2a76ceb7dd5ea5a834ec470b724882564d9681b3/src/runtime/arch_tinygowasm.go#L19
+//
+//go:extern __heap_base
+var heapStartSymbol [0]byte
+
+var heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
+
+// https://github.com/tinygo-org/tinygo/blob/2a76ceb7dd5ea5a834ec470b724882564d9681b3/src/runtime/arch_tinygowasm.go#L34
+//
+//export llvm.wasm.memory.size.i32
+func wasm_memory_size(index int32) int32
+
+// https://github.com/tinygo-org/tinygo/blob/2a76ceb7dd5ea5a834ec470b724882564d9681b3/src/runtime/arch_tinygowasm.go#L34
+const wasmPageSize = 64 * 1024
+
+var heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
+
+// Ever-incrementing pointer: no memory is freed.
+var heapptr = heapStart
+
+// Total amount allocated for runtime.MemStats
+var gcTotalAlloc uint64
+
+// Total number of calls to alloc()
+var gcMallocs uint64
+
+// Total number of objected freed; for leaking collector this stays 0
+const gcFrees = 0
+
+// trap is a compiler hint that this function cannot be executed. It is
+// translated into either a trap instruction or a call to abort().
+//
+//export llvm.trap
+func trap()
+
+//go:wasmexport alloc
+func Alloc(size uintptr) unsafe.Pointer {
+	return alloc(size, unsafe.Pointer(nil))
+}
+
+// Inlining alloc() speeds things up slightly but bloats the executable by 50%,
+// see https://github.com/tinygo-org/tinygo/issues/2674.  So don't.
+//
+//go:noinline
+//go:linkname alloc runtime.alloc
+func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer {
+	// TODO: this can be optimized by not casting between pointers and ints so
+	// much. And by using platform-native data types (e.g. *uint8 for 8-bit
+	// systems).
+	size = align(size)
+	addr := heapptr
+	gcTotalAlloc += uint64(size)
+	gcMallocs++
+	heapptr += size
+	for heapptr >= heapEnd {
+		// Try to increase the heap and check again.
+		if growHeap() {
+			continue
+		}
+		// Failed to make the heap bigger, so we must really be out of memory.
+		trap() // NOTE: alterred from original impl since we just trap. `runtimePanic("out of memory")`
+		// see: https://github.com/tinygo-org/tinygo/blob/2a76ceb7dd5ea5a834ec470b724882564d9681b3/src/runtime/panic.go#L72
+	}
+	pointer := unsafe.Pointer(addr)
+	zero_new_alloc(pointer, size)
+	return pointer
+}
+
+//go:inline
+func zero_new_alloc(ptr unsafe.Pointer, size uintptr) {
+	memzero(ptr, size)
+}
+
+// Copy size bytes from src to dst. The memory areas must not overlap.
+// This function is implemented by the compiler as a call to a LLVM intrinsic
+// like llvm.memcpy.p0.p0.i32(dst, src, size, false).
+//
+//go:linkname memcpy runtime.memcpy
+func memcpy(dst, src unsafe.Pointer, size uintptr)
+
+// Copy size bytes from src to dst. The memory areas may overlap and will do the
+// correct thing.
+// This function is implemented by the compiler as a call to a LLVM intrinsic
+// like llvm.memmove.p0.p0.i32(dst, src, size, false).
+//
+//go:linkname memmove runtime.memmove
+func memmove(dst, src unsafe.Pointer, size uintptr)
+
+// Set the given number of bytes to zero.
+// This function is implemented by the compiler as a call to a LLVM intrinsic
+// like llvm.memset.p0.i32(ptr, 0, size, false).
+//
+//go:linkname memzero runtime.memzero
+func memzero(ptr unsafe.Pointer, size uintptr)
+
+// This can be exported to wasm if needed like this: //go:wasmexport realloc
+//
+//go:linkname realloc runtime.realloc
+func realloc(ptr unsafe.Pointer, size uintptr) unsafe.Pointer {
+	newAlloc := alloc(size, nil)
+	if ptr == nil {
+		return newAlloc
+	}
+	// according to POSIX everything beyond the previous pointer's
+	// size will have indeterminate values so we can just copy garbage
+	memcpy(newAlloc, ptr, size)
+
+	return newAlloc
+}
+
+//go:linkname free runtime.free
+func free(ptr unsafe.Pointer) {
+	// Memory is never freed.
+}
+
+// ReadMemStats populates m with memory statistics.
+//
+// The returned memory statistics are up to date as of the
+// call to ReadMemStats. This would not do GC implicitly for you.
+//
+//go:linkname ReadMemStats runtime.ReadMemStats
+func ReadMemStats(m *realRuntime.MemStats) {
+	m.HeapIdle = 0
+	m.HeapInuse = gcTotalAlloc
+	m.HeapReleased = 0 // always 0, we don't currently release memory back to the OS.
+
+	m.HeapSys = m.HeapInuse + m.HeapIdle
+	m.GCSys = 0
+	m.TotalAlloc = gcTotalAlloc
+	m.Mallocs = gcMallocs
+	m.Frees = gcFrees
+	m.Sys = uint64(heapEnd - heapStart)
+	// no free -- current in use heap is the total allocated
+	m.HeapAlloc = gcTotalAlloc
+	m.Alloc = m.HeapAlloc
+}
+
+//go:linkname GC runtime.GC
+func GC() {
+	// No-op.
+}
+
+func SetFinalizer(obj interface{}, finalizer interface{}) {
+	// No-op.
+}
+
+//go:linkname initHeap runtime.initHeap
+func initHeap() {
+	// preinit() may have moved heapStart; reset heapptr
+	heapptr = heapStart
+}
+
+// setHeapEnd sets a new (larger) heapEnd pointer.
+//
+//go:linkname setHeapEnd runtime.setHeapEnd
+// func setHeapEnd(newHeapEnd uintptr) {
+// 	// This "heap" is so simple that simply assigning a new value is good
+// 	// enough.
+// 	heapEnd = newHeapEnd
+// }
+
+const wasmMemoryIndex = 0
+
+//export llvm.wasm.memory.grow.i32
+func wasm_memory_grow(index int32, delta int32) int32
+
+func growHeap() bool {
+	// Grow memory by the available size, which means the heap size is doubled.
+	memorySize := wasm_memory_size(wasmMemoryIndex)
+	result := wasm_memory_grow(wasmMemoryIndex, memorySize)
+	if result == -1 {
+		// Grow failed.
+		return false
+	}
+
+	heapEnd = uintptr(wasm_memory_size(wasmMemoryIndex) * wasmPageSize)
+
+	// Heap has grown successfully.
+	return true
+}
+
+func align(ptr uintptr) uintptr {
+	// Align to 16, which is the alignment of max_align_t:
+	// https://godbolt.org/z/dYqTsWrGq
+	const heapAlign = 16
+	return (ptr + heapAlign - 1) &^ (heapAlign - 1)
+}

--- a/tests/devnet/contracts/amm-pool/sdk/runtime_imports.go
+++ b/tests/devnet/contracts/amm-pool/sdk/runtime_imports.go
@@ -1,0 +1,80 @@
+//go:build gc.custom
+
+package sdk
+
+import (
+	_ "amm-pool/runtime"
+)
+
+//go:wasmimport sdk console.log
+func log(s *string) *string
+
+//go:wasmimport sdk system.pendulum_apply_swap_fees
+func pendulumApplySwapFees(arg *string) *string
+
+func Log(s string) {
+	log(&s)
+}
+
+//go:wasmimport sdk db.set_object
+func stateSetObject(key *string, value *string) *string
+
+//go:wasmimport sdk db.get_object
+func stateGetObject(key *string) *string
+
+//go:wasmimport sdk db.rm_object
+func stateDeleteObject(key *string) *string
+
+//go:wasmimport sdk ephem_db.set_object
+func ephemStateSetObject(key *string, value *string) *string
+
+//go:wasmimport sdk ephem_db.get_object
+func ephemStateGetObject(contractId *string, key *string) *string
+
+//go:wasmimport sdk ephem_db.rm_object
+func ephemStateDeleteObject(key *string) *string
+
+//go:wasmimport sdk system.get_env
+func getEnv(arg *string) *string
+
+//go:wasmimport sdk system.get_env_key
+func getEnvKey(arg *string) *string
+
+//go:wasmimport sdk hive.get_balance
+func getBalance(arg1 *string, arg2 *string) *string
+
+//go:wasmimport sdk hive.draw
+func hiveDraw(arg1 *string, arg2 *string) *string
+
+//go:wasmimport sdk hive.draw_from
+func hiveDrawFrom(arg1 *string, arg2 *string, arg3 *string) *string
+
+//go:wasmimport sdk hive.transfer
+func hiveTransfer(arg1 *string, arg2 *string, arg3 *string) *string
+
+//go:wasmimport sdk hive.withdraw
+func hiveWithdraw(arg1 *string, arg2 *string, arg3 *string) *string
+
+//go:wasmimport sdk contracts.read
+func contractRead(contractId *string, key *string) *string
+
+//go:wasmimport sdk contracts.call
+func contractCall(contractId *string, method *string, payload *string, options *string) *string
+
+//go:wasmimport sdk tss_v2.create_key
+func tssCreateKey(keyId *string, algo *string, epochs *string) *string
+
+//go:wasmimport sdk tss_v2.renew_key
+func tssRenewKey(keyId *string, epochs *string) *string
+
+//go:wasmimport sdk tss.sign_key
+func tssSignKey(keyId *string, msgId *string) *string
+
+//go:wasmimport sdk tss.get_key
+func tssGetKey(keyId *string) *string
+
+//go:wasmimport env abort
+func abort(msg, file *string, line, column *int32)
+
+//go:wasmimport env revert
+func revert(msg, symbol *string)

--- a/tests/devnet/contracts/amm-pool/sdk/sdk.go
+++ b/tests/devnet/contracts/amm-pool/sdk/sdk.go
@@ -1,0 +1,120 @@
+package sdk
+
+import (
+	"encoding/hex"
+	"strconv"
+)
+
+// Aborts the contract execution
+func Abort(msg string) {
+	ln := int32(0)
+	abort(&msg, nil, &ln, &ln)
+	panic(msg)
+}
+
+// Reverts the transaction and abort execution in the same way as Abort().
+func Revert(msg string, symbol string) {
+	revert(&msg, &symbol)
+}
+
+// Set a value by key in the contract state
+func StateSetObject(key string, value string) {
+	stateSetObject(&key, &value)
+}
+
+// Get a value by key from the contract state
+func StateGetObject(key string) *string {
+	return stateGetObject(&key)
+}
+
+// Delete or unset a value by key in the contract state
+func StateDeleteObject(key string) {
+	stateDeleteObject(&key)
+}
+
+// Set a value by key in the ephemeral contract state
+func EphemStateSetObject(key string, value string) {
+	ephemStateSetObject(&key, &value)
+}
+
+// Get a value by key from the ephemeral contract state
+func EphemStateGetObject(contractId string, key string) *string {
+	return ephemStateGetObject(&contractId, &key)
+}
+
+// Delete or unset a value by key in the ephemeral contract state
+func EphemStateDeleteObject(key string) {
+	ephemStateDeleteObject(&key)
+}
+
+// Get current execution environment variables as json string
+func GetEnvStr() string {
+	return *getEnv(nil)
+}
+
+// Get current execution environment variable by a key
+func GetEnvKey(key string) *string {
+	return getEnvKey(&key)
+}
+
+// Get a value by key from the contract state of another contract
+func ContractStateGet(contractId string, key string) *string {
+	return contractRead(&contractId, &key)
+}
+
+// TryContractCall calls another contract in try/catch mode. If the callee
+// reverts, the caller is NOT trapped: the returned *string is a JSON outcome
+// {"ok":false,...} and the callee's state/ledger writes are rolled back. On
+// success it is {"ok":true,"result":<callee return>}. RC and gas are charged
+// either way.
+func TryContractCall(contractId string, method string, payload string) *string {
+	opts := `{"try":true}`
+	return contractCall(&contractId, &method, &payload, &opts)
+}
+
+func TssCreateKey(keyId string, algo string, epochs uint64) string {
+	if algo != "ecdsa" && algo != "eddsa" {
+		Abort("algo must be ecdsa or eddsa")
+	}
+	epochsStr := strconv.FormatUint(epochs, 10)
+	return *tssCreateKey(&keyId, &algo, &epochsStr)
+}
+
+// TssRenewKey extends the expiry of a key owned by this contract by additionalEpochs.
+// The key must be active or deprecated. Returns "renewed" on success.
+func TssRenewKey(keyId string, additionalEpochs uint64) string {
+	epochsStr := strconv.FormatUint(additionalEpochs, 10)
+	return *tssRenewKey(&keyId, &epochsStr)
+}
+
+func TssGetKey(keyId string) string {
+	return *tssGetKey(&keyId)
+}
+
+func TssSignKey(keyId string, bytes []byte) {
+	byteStr := hex.EncodeToString(bytes)
+
+	tssSignKey(&keyId, &byteStr)
+}
+
+// PendulumApplySwapFees invokes system.pendulum_apply_swap_fees with the
+// JSON input {asset_in,asset_out,x,x_reserve,y_reserve} and returns the
+// JSON output {user_output,...,lp_share_output,node_share_output,...}.
+// The host applies the whitelist check, the fee/stabilizer math, the
+// node-vs-LP split (with the LP minimum-floor when active), and the
+// node-bucket accrual; this is a thin marshalling wrapper.
+func PendulumApplySwapFees(inputJSON string) string {
+	return *pendulumApplySwapFees(&inputJSON)
+}
+
+// HiveDraw pulls `amount` (base units, decimal string) of `asset` from the
+// calling transaction's transfer.allow intents into this contract's balance.
+func HiveDraw(amount string, asset string) {
+	hiveDraw(&amount, &asset)
+}
+
+// HiveGetBalance returns this/any account's balance for an asset as a
+// decimal string of base units.
+func HiveGetBalance(account string, asset string) string {
+	return *getBalance(&account, &asset)
+}

--- a/tests/devnet/contracts/amm-pool/sdk/sdk_stub.go
+++ b/tests/devnet/contracts/amm-pool/sdk/sdk_stub.go
@@ -1,0 +1,89 @@
+//go:build !gc.custom
+
+package sdk
+
+//go:wasmimport sdk console.log
+func log(s *string) *string { return nil }
+
+func Log(s string) {
+	log(&s)
+}
+
+//go:wasmimport sdk system.pendulum_apply_swap_fees
+func pendulumApplySwapFees(arg *string) *string { return nil }
+
+//go:wasmimport sdk db.set_object
+func stateSetObject(key *string, value *string) *string { return nil }
+
+//go:wasmimport sdk db.get_object
+func stateGetObject(key *string) *string { return nil }
+
+//go:wasmimport sdk db.rm_object
+func stateDeleteObject(key *string) *string { return nil }
+
+//go:wasmimport sdk ephem_db.set_object
+func ephemStateSetObject(key *string, value *string) *string { return nil }
+
+//go:wasmimport sdk ephem_db.get_object
+func ephemStateGetObject(contractId *string, key *string) *string { return nil }
+
+//go:wasmimport sdk ephem_db.rm_object
+func ephemStateDeleteObject(key *string) *string { return nil }
+
+//go:wasmimport sdk system.get_env
+func getEnv(arg *string) *string { return nil }
+
+//go:wasmimport sdk system.get_env_key
+func getEnvKey(arg *string) *string { return nil }
+
+//go:wasmimport sdk hive.get_balance
+func getBalance(arg1 *string, arg2 *string) *string { return nil }
+
+//go:wasmimport sdk hive.draw
+func hiveDraw(arg1 *string, arg2 *string) *string { return nil }
+
+//go:wasmimport sdk hive.draw_from
+func hiveDrawFrom(arg1 *string, arg2 *string, arg3 *string) *string { return nil }
+
+//go:wasmimport sdk hive.transfer
+func hiveTransfer(arg1 *string, arg2 *string, arg3 *string) *string { return nil }
+
+//go:wasmimport sdk hive.withdraw
+func hiveWithdraw(arg1 *string, arg2 *string, arg3 *string) *string { return nil }
+
+//go:wasmimport sdk contracts.read
+func contractRead(contractId *string, key *string) *string { return nil }
+
+//go:wasmimport sdk contracts.call
+func contractCall(contractId *string, method *string, payload *string, options *string) *string {
+	return nil
+}
+
+//go:wasmimport sdk tss_v2.create_key
+func tssCreateKey(keyId *string, algo *string, epochs *string) *string { return nil }
+
+//go:wasmimport sdk tss_v2.renew_key
+func tssRenewKey(keyId *string, epochs *string) *string { return nil }
+
+//go:wasmimport sdk tss.sign_key
+func tssSignKey(keyId *string, msgId *string) *string { return nil }
+
+//go:wasmimport sdk tss.get_key
+func tssGetKey(keyId *string) *string { return nil }
+
+// var envMap = []string{
+// 	"contract.id",
+// 	"tx.origin",
+// 	"tx.id",
+// 	"tx.index",
+// 	"tx.op_index",
+// 	"block.id",
+// 	"block.height",
+// 	"block.timestamp",
+// }
+
+//go:wasmimport env abort
+func abort(msg, file *string, line, column *int32) { return }
+
+//go:wasmimport env revert
+func revert(msg, symbol *string) { return }

--- a/tests/devnet/hive_ops.go
+++ b/tests/devnet/hive_ops.go
@@ -14,15 +14,33 @@ import (
 // method. The caller is the witness at the given node index (1-indexed).
 // Retries up to 3 times on transient connection errors.
 func (d *Devnet) CallContract(ctx context.Context, node int, contractId, action, payload string) (string, error) {
+	return d.CallContractWithIntents(ctx, node, contractId, action, payload, nil, 500000)
+}
+
+// CallContractWithIntents is CallContract plus an `intents` array (e.g. a
+// transfer.allow intent that authorizes the contract to hive.draw a token from
+// the caller) and an explicit rc_limit. Each intent is
+// {"type": "...", "args": {"k":"v"}}.
+//
+// rc_limit matters for intent draws: PullBalance reserves
+// (rc_limit - free_rc) HBD of the caller's balance against RC, so a call that
+// draws HBD must use a LOW rc_limit (<= RC_HIVE_FREE_AMOUNT) or the caller's
+// balance is reserved out from under the draw (see [[vsc_rc_limit_hbd_exclusion]]).
+func (d *Devnet) CallContractWithIntents(ctx context.Context, node int, contractId, action, payload string, intents []map[string]interface{}, rcLimit int) (string, error) {
 	witnessName := fmt.Sprintf("%s%d", d.cfg.WitnessPrefix, node)
+
+	intentsField := make([]interface{}, 0, len(intents))
+	for _, it := range intents {
+		intentsField = append(intentsField, it)
+	}
 
 	callTx := map[string]interface{}{
 		"net_id":      "vsc-devnet",
 		"contract_id": contractId,
 		"action":      action,
 		"payload":     payload,
-		"rc_limit":    500000,
-		"intents":     []interface{}{},
+		"rc_limit":    rcLimit,
+		"intents":     intentsField,
 	}
 	txJSON, err := json.Marshal(callTx)
 	if err != nil {

--- a/tests/devnet/pendulum_lpfloor_devnet_test.go
+++ b/tests/devnet/pendulum_lpfloor_devnet_test.go
@@ -1,0 +1,352 @@
+package devnet
+
+// Multi-node devnet proof of the pendulum LP minimum-floor (consensus 0.2.0).
+//
+// The split that routes swap fees between node operators and liquidity
+// providers is consensus-critical: every validator must compute the IDENTICAL
+// floored split from the same geometry, or the chain forks. Unit + single-node
+// ledger tests prove the math and the gating; only a real multi-node devnet
+// proves all nodes agree on the floored split on-chain.
+//
+// Setup: an HBD-paired amm-pool publishes a huge HBD reserve (r0), which drives
+// the geometry into the under-secured regime (V = 2*r0 >> c*E) where the raw
+// pendulum routes ~100% of the pot to nodes. With the consensus floor pinned to
+// 0.2.0 the LP minimum-floor must instead cap the node share at 75% (LPs keep
+// >= 25%). The test fires a real swap through system.pendulum_apply_swap_fees
+// and asserts, on a DIFFERENT node than the caller and across ALL nodes, that
+// the split is ~75/25 and byte-identical everywhere.
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"vsc-node/modules/common/params"
+	systemconfig "vsc-node/modules/common/system-config"
+)
+
+func TestPendulumLPFloorDevnet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping pendulum LP-floor devnet test in short mode")
+	}
+	requireDocker(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Minute)
+	t.Cleanup(cancel)
+
+	wasm, err := BuildAmmPoolContract(ctx)
+	if err != nil {
+		t.Fatalf("building amm-pool contract: %v", err)
+	}
+
+	cfg := DefaultConfig()
+	// Pin the election floor to consensus 0.2.0 from epoch 1: every node runs
+	// the 0.2.0 binary, so none are excluded and ActiveConsensusVersion >= 0.2.0
+	// makes the LP minimum-floor active. Fast elections keep the run bounded.
+	cfg.LogLevel = "error,pendulum=trace,oracle=trace"
+	cfg.SysConfigOverrides = &systemconfig.SysConfigOverrides{
+		ConsensusParams: &params.ConsensusParams{
+			ConsensusVersionFloorEpoch:     1,
+			ConsensusVersionFloorConsensus: 2,
+			ElectionInterval:               20,
+		},
+	}
+
+	d, err := New(cfg)
+	if err != nil {
+		t.Fatalf("creating devnet: %v", err)
+	}
+	t.Cleanup(func() { d.Stop() })
+
+	t.Logf("starting %d-node devnet (~12 min)...", cfg.Nodes)
+	if err := d.Start(ctx); err != nil {
+		dumpLogs(t, d, ctx)
+		t.Fatalf("starting devnet: %v", err)
+	}
+	if err := d.WaitForBlockProcessing(ctx, 1, 30, 8*time.Minute); err != nil {
+		dumpDiagnostics(t, d, ctx)
+		t.Fatalf("network never reached block 30: %v", err)
+	}
+	for n := 1; n <= cfg.Nodes; n++ {
+		nctx, c := context.WithTimeout(ctx, 10*time.Minute)
+		if err := d.waitForElectionEpoch(nctx, n, 1, 10*time.Minute); err != nil {
+			c()
+			dumpDiagnostics(t, d, ctx)
+			t.Fatalf("magi-%d never ingested epoch >= 1: %v", n, err)
+		}
+		c()
+	}
+
+	// Deploy the pool, then whitelist it (its id isn't known until now) by
+	// rewriting sysconfig and restarting all nodes.
+	poolID, err := d.DeployContract(ctx, ContractDeployOpts{
+		WasmPath: wasm, Name: "amm-pool", DeployerNode: 1, GQLNode: 2,
+	})
+	if err != nil {
+		t.Fatalf("deploy amm-pool: %v", err)
+	}
+	t.Logf("deployed pool=%s", poolID)
+
+	if err := d.setPendulumWhitelistAndRestart(ctx, []string{poolID}); err != nil {
+		dumpDiagnostics(t, d, ctx)
+		t.Fatalf("whitelisting pool + restart: %v", err)
+	}
+
+	// Chain must resume on every node after the restart, and the oracle feed
+	// (in-memory) must re-warm before geometry is computable.
+	head := nodeBlock(t, d, ctx, 1)
+	for n := 1; n <= cfg.Nodes; n++ {
+		if err := d.WaitForBlockProcessing(ctx, n, head+10, 8*time.Minute); err != nil {
+			dumpDiagnostics(t, d, ctx)
+			t.Fatalf("magi-%d did not resume after whitelist restart: %v", n, err)
+		}
+	}
+	t.Log("nodes resumed post-whitelist-restart; warming oracle feed...")
+	waitForFeedWarmup(t, d, ctx)
+
+	// Fund the pool with real HBD (backs the node-share drain): deposit HBD to
+	// witness-1, then have the pool draw 10 HBD via a transfer.allow intent.
+	// Deposit 70 (witness-1 has ~90 TBD on L1 after the 10 TBD deploy fee) so it
+	// covers the draw PLUS the RC/HBD reservation PullBalance applies
+	// (rc_limit - free_rc, see below).
+	if _, err := d.Deposit(ctx, 1, "70.000", "hbd"); err != nil {
+		t.Fatalf("deposit hbd: %v", err)
+	}
+	if !waitForL2Balance(t, d, ctx, 1, witnessHive(d, 1), "hbd", 65_000, 4*time.Minute) {
+		dumpDiagnostics(t, d, ctx)
+		t.Fatal("witness-1 HBD deposit never credited on L2")
+	}
+
+	// Publish under-secured geometry: r0 (HBD reserve) huge so V = 2*r0 >> c*E.
+	if _, err := d.CallContract(ctx, 1, poolID, "setup", "1000000000000,1000000000"); err != nil {
+		t.Fatalf("setup call: %v", err)
+	}
+	if !waitStateKey(t, d, ctx, 2, poolID, "a0n", "hbd", 4*time.Minute) {
+		dumpDiagnostics(t, d, ctx)
+		t.Fatal("pool geometry (a0n=hbd) never published")
+	}
+
+	// Draw 15 HBD into the pool. CRITICAL: a low rc_limit (20000, ~2x the free
+	// RC tier) — PullBalance reserves (rc_limit - free_rc) HBD of the caller's
+	// balance against RC during an intent draw, so the default 500000 rc_limit
+	// would reserve ~490 HBD and starve the 15 HBD draw.
+	fundIntents := []map[string]interface{}{
+		{"type": "transfer.allow", "args": map[string]string{"token": "hbd", "limit": "15.000"}},
+	}
+	if _, err := d.CallContractWithIntents(ctx, 1, poolID, "fund", "10000", fundIntents, 20000); err != nil {
+		t.Fatalf("fund call: %v", err)
+	}
+	if !waitForStateKeyAtLeast(t, d, ctx, 2, poolID, "funded_hbd", 10_000, 4*time.Minute) {
+		dumpDiagnostics(t, d, ctx)
+		t.Fatal("pool never received drawn HBD (funded_hbd state key)")
+	}
+
+	// Fire the swap. A small swap keeps the node-share well under the funded
+	// 10 HBD; the under-secured geometry + 0.2.0 floor cap it at 75%. Retry a
+	// few times — right after the restart the in-memory oracle feed may not be
+	// warm yet, so the first swap can revert with snapshot-unavailable.
+	swapJSON := `{"asset_in":"hive","asset_out":"hbd","x":"50000","x_reserve":"1000000","y_reserve":"1000000"}`
+	swapLanded := false
+	for attempt := 0; attempt < 6 && !swapLanded; attempt++ {
+		if _, err := d.CallContract(ctx, 1, poolID, "swap", swapJSON); err != nil {
+			t.Fatalf("swap call: %v", err)
+		}
+		// Read the split on a DIFFERENT node (node 3): if nodes hadn't processed
+		// it identically the keys would never appear.
+		swapLanded = waitStateKeyPresent(t, d, ctx, 3, poolID, "node_share", 90*time.Second)
+		if !swapLanded {
+			t.Logf("swap attempt %d not recorded yet (feed warming?), retrying...", attempt+1)
+		}
+	}
+	if !swapLanded {
+		dumpDiagnostics(t, d, ctx)
+		t.Fatal("swap split never recorded — swap reverted (feed/geometry?) or nodes diverged")
+	}
+
+	// Read the split on every node and assert (a) it is byte-identical
+	// everywhere (consensus determinism) and (b) it is the floored ~75/25.
+	type split struct{ lp, node, sAfter, bucket int64 }
+	splits := make([]split, cfg.Nodes)
+	for n := 1; n <= cfg.Nodes; n++ {
+		st, err := d.GetStateByKeys(ctx, n, poolID, []string{"lp_share", "node_share", "s_after", "node_bucket"})
+		if err != nil {
+			t.Fatalf("magi-%d read split: %v", n, err)
+		}
+		splits[n-1] = split{
+			lp:     mustStateInt(t, n, st, "lp_share"),
+			node:   mustStateInt(t, n, st, "node_share"),
+			sAfter: mustStateInt(t, n, st, "s_after"),
+			bucket: mustStateInt(t, n, st, "node_bucket"),
+		}
+		t.Logf("magi-%d: lp=%d node=%d s_after_bps=%d node_bucket=%d",
+			n, splits[n-1].lp, splits[n-1].node, splits[n-1].sAfter, splits[n-1].bucket)
+	}
+
+	first := splits[0]
+	for n := 2; n <= cfg.Nodes; n++ {
+		if splits[n-1] != first {
+			t.Fatalf("split diverged across nodes: magi-1=%+v magi-%d=%+v (consensus break)", first, n, splits[n-1])
+		}
+	}
+
+	// Sanity: under-secured (s_after well past the cliff) and money actually moved.
+	if first.sAfter <= 30_000 { // CliffSBps = 30000 (c = 3.0)
+		t.Fatalf("expected under-secured geometry (s_after_bps > 30000), got %d", first.sAfter)
+	}
+	if first.node <= 0 || first.bucket <= 0 {
+		t.Fatalf("expected a positive node share/accrual, got node=%d bucket=%d", first.node, first.bucket)
+	}
+
+	// The LP floor must bind: LPs keep ~25% of the pot, nodes capped at ~75%.
+	pot := first.lp + first.node
+	if pot <= 0 {
+		t.Fatalf("empty pendulum pot")
+	}
+	quarter := pot / 4
+	if first.lp < quarter-2 {
+		t.Fatalf("LP floor not enforced: lp=%d is below ~25%% of pot=%d (under-secured swap)", first.lp, pot)
+	}
+	if first.node > pot-quarter+2 {
+		t.Fatalf("node share=%d exceeds ~75%% cap of pot=%d", first.node, pot)
+	}
+	t.Logf("LP floor holds on-chain across %d nodes: pot=%d lp=%d (%.1f%%) node=%d (%.1f%%)",
+		cfg.Nodes, pot, first.lp, 100*float64(first.lp)/float64(pot),
+		first.node, 100*float64(first.node)/float64(pot))
+}
+
+// setPendulumWhitelistAndRestart rewrites the shared sysconfig.json with the
+// given pool ids in PendulumPoolWhitelist (preserving the other overrides) and
+// restarts every magi node so magid re-reads it. The pool id is only known
+// after deploy, so this is the only way to whitelist it on devnet.
+func (d *Devnet) setPendulumWhitelistAndRestart(ctx context.Context, pools []string) error {
+	if d.cfg.SysConfigOverrides == nil {
+		d.cfg.SysConfigOverrides = &systemconfig.SysConfigOverrides{}
+	}
+	list := append([]string(nil), pools...)
+	d.cfg.SysConfigOverrides.PendulumPoolWhitelist = &list
+	if err := writeSysConfigOverrides(d.cfg, d.devnetDir); err != nil {
+		return fmt.Errorf("rewrite sysconfig: %w", err)
+	}
+	for n := 1; n <= d.cfg.Nodes; n++ {
+		if err := d.StopNode(ctx, n); err != nil {
+			return fmt.Errorf("stop magi-%d: %w", n, err)
+		}
+	}
+	for n := 1; n <= d.cfg.Nodes; n++ {
+		if err := d.StartNode(ctx, n); err != nil {
+			return fmt.Errorf("start magi-%d: %w", n, err)
+		}
+	}
+	return nil
+}
+
+func witnessHive(d *Devnet, node int) string {
+	return "hive:" + fmt.Sprintf("%s%d", d.cfg.WitnessPrefix, node)
+}
+
+// waitForFeedWarmup gives the in-memory oracle FeedTracker time to re-ingest
+// feed_publish ops after the restart so geometry becomes computable. It waits
+// for fresh feed_publish ops to appear in recent blocks on magi-1, then a grace
+// period for the moving-average window to populate.
+func waitForFeedWarmup(t *testing.T, d *Devnet, ctx context.Context) {
+	t.Helper()
+	deadline := time.Now().Add(6 * time.Minute)
+	for time.Now().Before(deadline) {
+		head := nodeBlock(t, d, ctx, 1)
+		from := uint64(1)
+		if head > 40 {
+			from = head - 40
+		}
+		c, err := countHiveBlocksWithFeedPublishOps(ctx, d, 1, from, head)
+		if err == nil && c > 0 {
+			// Let a few more feeds land so the moving-average window is fresh.
+			time.Sleep(45 * time.Second)
+			t.Logf("oracle feed warm (%d recent feed_publish blocks)", c)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("context cancelled during feed warmup: %v", ctx.Err())
+		case <-time.After(10 * time.Second):
+		}
+	}
+	t.Log("warning: proceeding without confirmed feed warmup")
+}
+
+// waitForL2Balance polls until the account's L2 balance for the asset reaches
+// minBaseUnits (base units, precision 3) on the given node.
+func waitForL2Balance(t *testing.T, d *Devnet, ctx context.Context, node int, account, asset string, minBaseUnits int64, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		bal, err := d.GetAccountBalance(ctx, node, account)
+		if err == nil && bal != nil {
+			got := bal.Hive
+			if asset == "hbd" {
+				got = bal.Hbd
+			}
+			if got >= minBaseUnits {
+				return true
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(5 * time.Second):
+		}
+	}
+	return false
+}
+
+// waitForStateKeyAtLeast polls until a contract state key parses to an int >= min.
+func waitForStateKeyAtLeast(t *testing.T, d *Devnet, ctx context.Context, node int, contractID, key string, min int64, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		st, err := d.GetStateByKeys(ctx, node, contractID, []string{key})
+		if err == nil && st[key] != nil {
+			if v, perr := strconv.ParseInt(fmt.Sprintf("%v", st[key]), 10, 64); perr == nil && v >= min {
+				return true
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(5 * time.Second):
+		}
+	}
+	return false
+}
+
+// waitStateKeyPresent polls until a contract state key has any non-nil value.
+func waitStateKeyPresent(t *testing.T, d *Devnet, ctx context.Context, node int, contractID, key string, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		st, err := d.GetStateByKeys(ctx, node, contractID, []string{key})
+		if err == nil && st[key] != nil && fmt.Sprintf("%v", st[key]) != "" {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(5 * time.Second):
+		}
+	}
+	return false
+}
+
+func mustStateInt(t *testing.T, node int, st map[string]any, key string) int64 {
+	t.Helper()
+	v, ok := st[key]
+	if !ok || v == nil {
+		t.Fatalf("magi-%d: state key %q absent", node, key)
+	}
+	n, err := strconv.ParseInt(fmt.Sprintf("%v", v), 10, 64)
+	if err != nil {
+		t.Fatalf("magi-%d: state key %q = %v not an int: %v", node, key, v, err)
+	}
+	return n
+}


### PR DESCRIPTION
This pull request implements the "LP minimum-floor" feature (B12) for the pendulum incentive mechanism, ensuring that liquidity providers (LPs) always retain at least a minimum share of every pool, even in under-secured conditions. The change is consensus-critical, activated only at consensus version 0.2.0, and is designed to be deterministic and replay-safe. The implementation includes code, documentation, and test updates to support the new floor and its activation logic.

**Pendulum LP Minimum-Floor (B12) Implementation**

*Consensus versioning and activation:*
- Introduced a new consensus version line (0.2.0) for activating the LP minimum-floor, with all relevant constants and tests updated to reflect this change. The floor is inert until this version is chain-active, ensuring backward compatibility. [[1]](diffhunk://#diff-8866b2198a2d34c2ff13d1f1a360e19fc9adfc81db16dd75ee2c843030068ec8R28-R36) [[2]](diffhunk://#diff-56a6150fe62d2570418920e5c49fce2f04b9cad66ba47f0de75d40fa45a996bbL47-R47) [[3]](diffhunk://#diff-567fa83f0a30e7e9f19338bbec93ba41c781a701d1f540d2ce769985c5555463R1-R50) [[4]](diffhunk://#diff-947dc71d3150865c9f2188f9871713f902128a4a24d23b7c78104f255320d96cR1-R43)

*Pendulum split logic changes:*
- Updated the swap-fee split logic in `wasm/applier.go` to cap the node share at `BpsScale - MinFractionBps` once the floor is activated. The calculation is deterministic and uses the on-chain consensus version at the relevant block height. [[1]](diffhunk://#diff-d6f9e3f85533bf43c362ee1e49fcd7080cfa08a93436d84f149dfd5e35f9b453L242-R271) [[2]](diffhunk://#diff-d6f9e3f85533bf43c362ee1e49fcd7080cfa08a93436d84f149dfd5e35f9b453L391-R432) [[3]](diffhunk://#diff-d6f9e3f85533bf43c362ee1e49fcd7080cfa08a93436d84f149dfd5e35f9b453L408-R467) [[4]](diffhunk://#diff-d6f9e3f85533bf43c362ee1e49fcd7080cfa08a93436d84f149dfd5e35f9b453R38-R68) [[5]](diffhunk://#diff-d6f9e3f85533bf43c362ee1e49fcd7080cfa08a93436d84f149dfd5e35f9b453R78-R87)

*Configuration and construction:*
- Modified the `Applier` and its constructor to accept a consensus-version reader, which is used to determine when to activate the floor. The default config now sets a 25% LP floor (capping the node share at 75%). [[1]](diffhunk://#diff-d6f9e3f85533bf43c362ee1e49fcd7080cfa08a93436d84f149dfd5e35f9b453R38-R68) [[2]](diffhunk://#diff-d6f9e3f85533bf43c362ee1e49fcd7080cfa08a93436d84f149dfd5e35f9b453R78-R87) [[3]](diffhunk://#diff-099a4b019638152aeaa184ca1258ccf2ff8ac143ef94e16dd7787d33c5ab4e63R346) [[4]](diffhunk://#diff-2a310fd1209343b3e0b19c5086d11732b06a77c695189b8b03a434f393fe9fabR59) [[5]](diffhunk://#diff-2a310fd1209343b3e0b19c5086d11732b06a77c695189b8b03a434f393fe9fabL438-R446)

*Documentation and comments:*
- Updated documentation and code comments to explain the LP minimum-floor policy, its consensus gating, and its economic rationale. The spec and code are now aligned with the implemented behavior. [[1]](diffhunk://#diff-5cd5d713c1e0233ccfc4dbc7714fbf5042a6240b412b38c32673728988e0e4f1L168-R168) [[2]](diffhunk://#diff-7fdbc3aea2110a746e6d0d588a8643040c379f392ca65691f305f9356867a4b8R41-R47)

*Test and utility updates:*
- Added comprehensive tests for the new floor logic, including edge cases, consensus activation, and the default policy pin.

**Other minor fixes:**
- Fixed the asset symbol selection logic in contract deployment and update flows to properly handle devnet/testnet distinction. [[1]](diffhunk://#diff-04a2c713748eb469a108463503a59c5d6c034111fe7fe3a719ea2254a02fa83eR150-R155) [[2]](diffhunk://#diff-04a2c713748eb469a108463503a59c5d6c034111fe7fe3a719ea2254a02fa83eR210-R215)