### PR TITLE
Per-delegator consensus stake/unstake + delegator rewards & operator opt-in modes (gated on consensus 0.3.0)

### DIFF
--- a/cmd/devnet-setup/main.go
+++ b/cmd/devnet-setup/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 	"vsc-node/modules/aggregate"
 	"vsc-node/modules/common"
+	"vsc-node/modules/common/delegationmode"
 	"vsc-node/modules/common/params"
 	systemconfig "vsc-node/modules/common/system-config"
 	"vsc-node/modules/db"
@@ -116,6 +117,13 @@ func main() {
 		})
 		idConf.SetUsername(witnessName)
 		idConf.SetActiveKey(args.wif)
+		// Consensus 0.2.0: nodes must opt in to receive third-party consensus
+		// delegation (default is Deactivated). Devnet nodes announce "custom" so
+		// the delegation stake/unstake paths are exercisable; "custom" keeps
+		// pendulum rewards at the node account, so reward-distribution devnet
+		// tests stay byte-identical to the pre-feature behaviour (only "share"
+		// splits to delegators). Use delegationmode.Share to exercise the split.
+		idConf.SetDelegationMode(delegationmode.Custom)
 
 		// Devnet integration-test hook (gated): when DEVNET_DETERMINISTIC_BLS=1,
 		// override the randomly-generated BLS seed with a DETERMINISTIC per-witness

--- a/lib/test_utils/mock_ledger.go
+++ b/lib/test_utils/mock_ledger.go
@@ -2,6 +2,7 @@ package test_utils
 
 import (
 	"slices"
+	"sort"
 	"strings"
 	"vsc-node/modules/aggregate"
 	ledgerDb "vsc-node/modules/db/vsc/ledger"
@@ -148,6 +149,30 @@ func (m *MockLedgerDb) GetDistinctAccountsRange(startBlock, endBlock uint64) ([]
 		}
 	}
 
+	return results, nil
+}
+
+func (m *MockLedgerDb) GetLedgerRecordsByType(types []string, toBlock uint64) ([]ledgerDb.LedgerRecord, error) {
+	results := make([]ledgerDb.LedgerRecord, 0)
+	for _, records := range m.LedgerRecords {
+		for _, record := range records {
+			if record.BlockHeight > toBlock {
+				continue
+			}
+			for _, t := range types {
+				if record.Type == t {
+					results = append(results, record)
+					break
+				}
+			}
+		}
+	}
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].BlockHeight != results[j].BlockHeight {
+			return results[i].BlockHeight < results[j].BlockHeight
+		}
+		return results[i].Id < results[j].Id
+	})
 	return results, nil
 }
 

--- a/modules/announcements/announcements.go
+++ b/modules/announcements/announcements.go
@@ -159,20 +159,27 @@ type payload struct {
 }
 
 type payloadVscNode struct {
-	NetId           string   `json:"net_id"`
-	PeerId          string   `json:"peer_id"`
-	PeerAddrs       []string `json:"peer_addrs"`
-	Ts              string   `json:"ts"`
-	VersionId       string   `json:"version_id"`
-	GitCommit       string   `json:"git_commit"`
-	VersionMajor    uint64   `json:"version_major"`
-	ProtocolVersion uint64   `json:"protocol_version"`
-	VersionNonConsensus uint64 `json:"version_non_consensus"`
-	GatewayKey      string   `json:"gateway_key"`
-	GatewayKeyPoP   string   `json:"gateway_key_pop"`
-	Witness         struct {
+	NetId               string   `json:"net_id"`
+	PeerId              string   `json:"peer_id"`
+	PeerAddrs           []string `json:"peer_addrs"`
+	Ts                  string   `json:"ts"`
+	VersionId           string   `json:"version_id"`
+	GitCommit           string   `json:"git_commit"`
+	VersionMajor        uint64   `json:"version_major"`
+	ProtocolVersion     uint64   `json:"protocol_version"`
+	VersionNonConsensus uint64   `json:"version_non_consensus"`
+	GatewayKey          string   `json:"gateway_key"`
+	GatewayKeyPoP       string   `json:"gateway_key_pop"`
+	Witness             struct {
 		Enabled bool `json:"enabled"`
 	} `json:"witness"`
+	// DelegationMode is the operator's consensus-delegation policy
+	// (delegationmode.{Deactivated,Share,Custom}). Published so the network can
+	// (a) reject third-party delegation to a Deactivated node and (b) split
+	// pendulum rewards pro-rata to delegators on a Share node. Consensus 0.5.0+;
+	// ignored by pre-0.5.0 logic. Always emitted (default Deactivated) so the
+	// witness record carries an explicit, authenticated value.
+	DelegationMode string `json:"delegation_mode"`
 }
 
 type didConsensusKey struct {
@@ -307,17 +314,17 @@ func (a *AnnouncementsManager) announce(ctx context.Context) error {
 		},
 		VscNode: payloadVscNode{
 			//Potentially use specific net ID for E2E tests
-			NetId:           a.sconf.NetId(),
-			PeerId:          a.safePeerId(), //Plz fill in
-			PeerAddrs:       peerAddrs,
-			Ts:              time.Now().Format(time.RFC3339),
-			GitCommit:       GitCommit,
+			NetId:               a.sconf.NetId(),
+			PeerId:              a.safePeerId(), //Plz fill in
+			PeerAddrs:           peerAddrs,
+			Ts:                  time.Now().Format(time.RFC3339),
+			GitCommit:           GitCommit,
 			VersionId:           VersionId, //Use standard versioning
 			VersionMajor:        runningVersion.Major,
 			ProtocolVersion:     runningVersion.Consensus,
 			VersionNonConsensus: runningVersion.NonConsensus,
-			GatewayKey:      *gatewayKP.GetPublicKeyString(),
-			GatewayKeyPoP:   gatewayPoP,
+			GatewayKey:          *gatewayKP.GetPublicKeyString(),
+			GatewayKeyPoP:       gatewayPoP,
 			Witness: struct {
 				Enabled bool `json:"enabled"`
 			}{
@@ -325,6 +332,10 @@ func (a *AnnouncementsManager) announce(ctx context.Context) error {
 				//Witness should be enabled/disabled by making a transaction on chain.
 				Enabled: enabled,
 			},
+			// Operator's consensus-delegation policy, normalized to a known mode
+			// (default Deactivated). Read back from the witness record at
+			// consensus 0.5.0+ to gate delegation acceptance and reward sharing.
+			DelegationMode: a.conf.DelegationMode(),
 		},
 	}
 

--- a/modules/common/common_types/types.go
+++ b/modules/common/common_types/types.go
@@ -54,6 +54,14 @@ type StateEngine interface {
 	// peers — a fork). found=false means a deterministic absence (no election
 	// covers the height yet), which every honest node sees identically.
 	GetElectionInfoOrBlock(height uint64) (elections.ElectionResult, bool)
+	// NodeDelegationMode returns the operator-published consensus-delegation
+	// mode for node `account` as of blockHeight, normalized to a known value
+	// (delegationmode.{Deactivated,Share,Custom}). Defaults to Deactivated when
+	// the node has no announcement or an unset/unknown mode — delegation is
+	// strict opt-in. Sourced from the witness DB (the operator's authenticated
+	// on-chain announcement), so it is deterministic across nodes at a given
+	// height. Consensus 0.5.0+ uses it to gate third-party stake acceptance.
+	NodeDelegationMode(account string, blockHeight uint64) string
 	SystemConfig() systemconfig.SystemConfig
 	// PendulumOracleEnv returns key/value pairs merged into wasm contract env (system.get_env / get_env_key).
 	// Keys use the "pendulum.*" prefix; nil or empty means no pendulum snapshot is available.

--- a/modules/common/config.go
+++ b/modules/common/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"vsc-node/lib/dids"
+	"vsc-node/modules/common/delegationmode"
 	"vsc-node/modules/config"
 
 	"github.com/libp2p/go-libp2p/core/crypto"
@@ -17,6 +18,29 @@ type identityConfig struct {
 	HiveActiveKey  string
 	HiveUsername   string
 	Libp2pPrivKey  string
+	// DelegationMode is the operator's consensus-delegation policy for their
+	// node, published in the node announcement and stored on the witness record
+	// (consensus 0.5.0+). One of delegationmode.{Deactivated,Share,Custom}; an
+	// empty / unrecognized value is treated as Deactivated (delegation is strict
+	// opt-in). See modules/common/delegationmode.
+	DelegationMode string
+}
+
+// DelegationMode returns the operator's configured consensus-delegation mode,
+// normalized to a known value (defaults to delegationmode.Deactivated). Read at
+// announcement time to publish the operator's policy on-chain.
+func (ac *identityConfigStruct) DelegationMode() string {
+	return delegationmode.Normalize(ac.Get().DelegationMode)
+}
+
+// SetDelegationMode persists the operator's consensus-delegation policy. The
+// value is normalized to a known mode (delegationmode.{Deactivated,Share,Custom});
+// an empty / unrecognized input is stored as Deactivated so a typo fails safe to
+// the opt-in default rather than silently enabling delegation.
+func (ac *identityConfigStruct) SetDelegationMode(mode string) error {
+	return ac.Update(func(dc *identityConfig) {
+		dc.DelegationMode = delegationmode.Normalize(mode)
+	})
 }
 
 func (ac *identityConfigStruct) SetUsername(username string) error {
@@ -169,6 +193,7 @@ func NewIdentityConfig(dataDir ...string) IdentityConfig {
 			HiveActiveKey:  "ADD_YOUR_PRIVATE_WIF",
 			HiveUsername:   "ADD_YOUR_USERNAME",
 			Libp2pPrivKey:  hex.EncodeToString(privKeyBytes),
+			DelegationMode: delegationmode.Deactivated,
 		},
 		dataDirPtr,
 	)}

--- a/modules/common/consensusversion/feature_gates.go
+++ b/modules/common/consensusversion/feature_gates.go
@@ -159,3 +159,33 @@ func MinMembersGuardActive(active Version) bool {
 func UnstakeHbdDirectionFixActive(active Version) bool {
 	return Version0_4_0Active(active)
 }
+
+// V0_5_0 is the consensus version line at which the v0.5.0 consensus-delegation
+// batch activates. Every consensus-affecting change in v0.5.0 keys off this single
+// version so the network has ONE coordinated activation, driven by the election
+// floor reaching 0.5.0.
+var V0_5_0 = Version{Major: 0, Consensus: 5, NonConsensus: 0}
+
+// Version0_5_0Active reports whether the v0.5.0 batch is in force given the
+// chain-active consensus version. `active` is resolved by the caller from the
+// on-chain election (deterministic, replay-correct). Below the line every v0.5.0
+// rule is inert and behavior stays byte-identical to 0.4.0, so old and new
+// binaries interoperate until the floor reaches 0.5.0.
+func Version0_5_0Active(active Version) bool {
+	return active.MeetsConsensusMin(V0_5_0)
+}
+
+// DelegatedStakeActive reports whether per-delegator consensus stake/unstake
+// semantics are in force given the chain-active consensus version: consensus_stake
+// records a per-edge delegation balance (asset "delegation", composite owner
+// "from::to") in addition to the unchanged node hive_consensus credit, and
+// consensus_unstake authorizes against the SIGNER's edge + debits the node bond,
+// so a delegator can always reclaim their own delegated bond and the operator can
+// never touch it. Resolve `active` from the version active at the op's block
+// height (StateEngine.ActiveConsensusVersion(blockHeight), or the election the tx
+// handler already read — see state_engine.DelegatedStakeActiveForElection); below
+// the line the legacy hive_consensus-holder unstake path runs byte-identically so
+// a full reindex reproduces historical ledger state.
+func DelegatedStakeActive(active Version) bool {
+	return Version0_5_0Active(active)
+}

--- a/modules/common/consensusversion/feature_gates_test.go
+++ b/modules/common/consensusversion/feature_gates_test.go
@@ -91,9 +91,48 @@ func TestV0_4_0Gates(t *testing.T) {
 		}
 	}
 
+	// v0.4.0 features stay active at/above the later 0.5.0 line (MeetsConsensusMin
+	// is monotone), so a 0.5.0-running binary still honors the safety batch.
+	if !MinMembersGuardActive(V0_5_0) || !UnstakeHbdDirectionFixActive(V0_5_0) {
+		t.Errorf("v0.4.0 gates must remain active at the 0.5.0 line")
+	}
+}
+
+// TestV0_5_0Gates pins the v0.5.0 consensus-delegation batch activation: every
+// v0.5.0 feature is inert at/below 0.4.0 and active at/above 0.5.0, keyed off the
+// single V0_5_0 line. non_consensus is ignored.
+func TestV0_5_0Gates(t *testing.T) {
+	below := []Version{
+		{Major: 0, Consensus: 0},
+		{Major: 0, Consensus: 4},
+		{Major: 0, Consensus: 4, NonConsensus: 9}, // 0.4.x is still below the line
+	}
+	atOrAbove := []Version{
+		{Major: 0, Consensus: 5},
+		{Major: 0, Consensus: 5, NonConsensus: 7}, // non_consensus ignored
+		{Major: 0, Consensus: 9},
+	}
+
+	for _, v := range below {
+		if Version0_5_0Active(v) {
+			t.Errorf("Version0_5_0Active(%s) = true, want false (below the line)", v.Format())
+		}
+		if DelegatedStakeActive(v) {
+			t.Errorf("DelegatedStakeActive(%s) = true, want false", v.Format())
+		}
+	}
+	for _, v := range atOrAbove {
+		if !Version0_5_0Active(v) {
+			t.Errorf("Version0_5_0Active(%s) = false, want true (at/above the line)", v.Format())
+		}
+		if !DelegatedStakeActive(v) {
+			t.Errorf("DelegatedStakeActive(%s) = false, want true", v.Format())
+		}
+	}
+
 	// The shipped binary must run the version it implements, so the floor can rise.
-	if RunningVersion().Cmp(V0_4_0) != 0 {
-		t.Errorf("RunningVersion() = %s, want %s (bump in the same commit as the v0.4.0 gates)",
-			RunningVersion().Format(), V0_4_0.Format())
+	if RunningVersion().Cmp(V0_5_0) != 0 {
+		t.Errorf("RunningVersion() = %s, want %s (bump in the same commit as the v0.5.0 gates)",
+			RunningVersion().Format(), V0_5_0.Format())
 	}
 }

--- a/modules/common/consensusversion/version.go
+++ b/modules/common/consensusversion/version.go
@@ -25,7 +25,7 @@ import (
 //   - 0.1.0 — pendulum settlement rollout. The Consensus 0→1 bump is what lets the floor
 //     rise to exclude pre-pendulum (0.0.0) nodes from the committee and TSS once a
 //     vsc.propose_consensus_version activates (see docs/consensus-upgrades.md).
-//   - 0.2.0 — the Consensus 1→2 bump gates THREE independent consensus changes, all
+//   - 0.2.0 — the Consensus 1→2 bump gates TWO independent consensus changes, both
 //     activated together when the election floor reaches 0.2.0:
 //     (a) try/catch inter-contract calls (ICCallOptions.Try): a caught revert returns a
 //     structured outcome + rolls back to a savepoint instead of trapping. Until the
@@ -56,17 +56,27 @@ import (
 //     offchain unstake_hbd builds TxUnstakeHbd (releases stake) instead of TxStakeHbd
 //     (the 0.3.0 behavior that wrongly STAKED); below the line the legacy stake
 //     direction is preserved so old and new binaries interoperate until activation.
-//   - 0.5.0 — the Consensus 4→5 bump gates the consensus DELEGATION batch, activated
+//   - 0.5.0 — the Consensus 4→5 bump gates the consensus DELEGATION batch, all activated
 //     together when the election floor reaches 0.5.0 (consensusversion.V0_5_0):
 //     (a) per-delegator consensus stake/unstake (DelegatedStakeActive) — a per-edge
 //     delegation balance (asset "delegation", composite owner "from::to") records who
 //     staked onto which node, so a delegator (not the node operator) can always
-//     reclaim their own delegated bond and the operator can never touch it; a one-time
-//     backfill reconstructs edges from historical stake records so pre-activation
-//     stakes become reclaimable. The node's aggregate hive_consensus still feeds
-//     election weight + pendulum bond unchanged. Below the line the legacy
-//     hive_consensus-holder unstake path runs byte-identically, so old and new
-//     binaries interoperate until activation.
+//     reclaim their own delegated bond and the operator can never touch it; a slash on
+//     the node is shared pro-rata across its delegators (released = gross × bond/total,
+//     against the slash-immune per-node gross total), and a one-time backfill
+//     reconstructs edges from historical stake records so pre-activation stakes become
+//     reclaimable;
+//     (b) delegator pendulum rewards — a share-mode node's pendulum reward is split
+//     pro-rata to its delegators inside the attested, BLS-signed settlement record
+//     (per-delegator entries sum to the node's unchanged amount, rounding remainder to
+//     the operator), so payouts come from the signed record;
+//     (c) operator opt-in delegation modes (deactivated|share|custom, published in the
+//     node announcement) — third-party delegation (from != to) is rejected unless the
+//     node opted in; self-stake and unstaking an existing delegation are never gated.
+//     The node's aggregate hive_consensus still feeds election weight + pendulum bond
+//     unchanged. Below the line all three behaviors are inert and the legacy
+//     hive_consensus-holder paths run byte-identically, so old and new binaries
+//     interoperate until activation.
 const (
 	currentMajor        uint64 = 0
 	currentConsensus    uint64 = 5

--- a/modules/common/consensusversion/version.go
+++ b/modules/common/consensusversion/version.go
@@ -25,7 +25,7 @@ import (
 //   - 0.1.0 — pendulum settlement rollout. The Consensus 0→1 bump is what lets the floor
 //     rise to exclude pre-pendulum (0.0.0) nodes from the committee and TSS once a
 //     vsc.propose_consensus_version activates (see docs/consensus-upgrades.md).
-//   - 0.2.0 — the Consensus 1→2 bump gates TWO independent consensus changes, both
+//   - 0.2.0 — the Consensus 1→2 bump gates THREE independent consensus changes, all
 //     activated together when the election floor reaches 0.2.0:
 //     (a) try/catch inter-contract calls (ICCallOptions.Try): a caught revert returns a
 //     structured outcome + rolls back to a savepoint instead of trapping. Until the
@@ -56,9 +56,20 @@ import (
 //     offchain unstake_hbd builds TxUnstakeHbd (releases stake) instead of TxStakeHbd
 //     (the 0.3.0 behavior that wrongly STAKED); below the line the legacy stake
 //     direction is preserved so old and new binaries interoperate until activation.
+//   - 0.5.0 — the Consensus 4→5 bump gates the consensus DELEGATION batch, activated
+//     together when the election floor reaches 0.5.0 (consensusversion.V0_5_0):
+//     (a) per-delegator consensus stake/unstake (DelegatedStakeActive) — a per-edge
+//     delegation balance (asset "delegation", composite owner "from::to") records who
+//     staked onto which node, so a delegator (not the node operator) can always
+//     reclaim their own delegated bond and the operator can never touch it; a one-time
+//     backfill reconstructs edges from historical stake records so pre-activation
+//     stakes become reclaimable. The node's aggregate hive_consensus still feeds
+//     election weight + pendulum bond unchanged. Below the line the legacy
+//     hive_consensus-holder unstake path runs byte-identically, so old and new
+//     binaries interoperate until activation.
 const (
 	currentMajor        uint64 = 0
-	currentConsensus    uint64 = 4
+	currentConsensus    uint64 = 5
 	currentNonConsensus uint64 = 0
 )
 

--- a/modules/common/consensusversion/version_test.go
+++ b/modules/common/consensusversion/version_test.go
@@ -44,7 +44,7 @@ func TestMaxComponentwise(t *testing.T) {
 // pinned current triple. Update this pin in the SAME commit that bumps the constants in
 // version.go.
 func TestRunningVersionIsSourcePinned(t *testing.T) {
-	want := Version{Major: 0, Consensus: 4, NonConsensus: 0}
+	want := Version{Major: 0, Consensus: 5, NonConsensus: 0}
 	if got := RunningVersion(); got != want {
 		t.Fatalf("running version = %+v, want %+v (source constants in version.go)", got, want)
 	}

--- a/modules/common/delegationmode/delegationmode.go
+++ b/modules/common/delegationmode/delegationmode.go
@@ -1,0 +1,93 @@
+// Package delegationmode defines the operator-controlled consensus-delegation
+// mode published in a node's announcement and stored on its witness record.
+// It is a dependency-free leaf package so it can be imported by the
+// announcement, witness DB, state-processing, ledger, and GraphQL layers
+// without creating import cycles.
+//
+// The mode lets a node operator opt in to (or out of) third-party consensus
+// delegation to their node, and choose how pendulum rewards earned on that
+// delegated bond are distributed. It is consensus-relevant only at consensus
+// 0.5.0+ (the same gate as per-delegator stake/unstake): the stake-time
+// enforcement and the settlement reward split both read it, so every node must
+// agree on the value. Because it is sourced from the operator's own
+// authenticated Hive `update_account` announcement (json_metadata), the value
+// is exactly what the operator signed.
+package delegationmode
+
+import "strings"
+
+const (
+	// Deactivated is the default: no NEW third-party delegation is accepted by
+	// this node (a consensus_stake where from != to is rejected). The operator
+	// can always self-stake (from == to), and any stake already delegated to
+	// the node (incl. migrated pre-0.5.0 stake) remains reclaimable by the
+	// delegator — unstake is never gated by the mode. This makes delegation a
+	// genuine opt-in: an operator who has not announced a mode accepts no
+	// delegations.
+	Deactivated = "deactivated"
+
+	// Share accepts third-party delegation AND splits the pendulum rewards
+	// earned on the node's bond pro-rata across every stake edge (the
+	// operator's own self-stake edge included), in relation to each staker's
+	// stake. No separate operator commission is taken on-chain — the operator
+	// earns purely via their own self-stake edge. Operators who want a cut of
+	// delegator rewards should use Custom with an off-chain agreement.
+	Share = "share"
+
+	// Custom accepts third-party delegation but pays all pendulum rewards to
+	// the node operator account (today's behaviour); any revenue share with
+	// delegators is settled off-chain under a private agreement. On-chain this
+	// is identical to the legacy reward path.
+	Custom = "custom"
+)
+
+// Default is the mode assumed when a node has not announced one (or announced
+// an empty / unrecognized value). Deactivated makes delegation strictly
+// opt-in.
+const Default = Deactivated
+
+// Normalize maps an arbitrary announced string to a known mode, defaulting to
+// Default for empty / unrecognized input. Case- and whitespace-insensitive so
+// a stray "Share " in a config file still resolves. Deterministic: same input
+// → same output on every node, which is required because the result gates
+// consensus-relevant stake acceptance and reward distribution.
+func Normalize(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case Share:
+		return Share
+	case Custom:
+		return Custom
+	case Deactivated:
+		return Deactivated
+	default:
+		return Default
+	}
+}
+
+// IsValid reports whether s is exactly one of the canonical mode strings (no
+// normalization). Used to validate operator config at load time so a typo
+// surfaces instead of silently falling back to Deactivated.
+func IsValid(s string) bool {
+	switch s {
+	case Deactivated, Share, Custom:
+		return true
+	default:
+		return false
+	}
+}
+
+// AllowsDelegation reports whether a third-party account may delegate consensus
+// stake to a node running mode s. Both Share and Custom accept delegation;
+// Deactivated does not. The operator's own self-stake is always allowed by the
+// caller regardless of mode and does not go through this check.
+func AllowsDelegation(s string) bool {
+	return Normalize(s) != Deactivated
+}
+
+// SharesRewards reports whether pendulum rewards on a node's bond are split
+// pro-rata to its delegators on-chain (Share mode only). Custom and Deactivated
+// pay the operator account and leave any delegator share to off-chain
+// settlement.
+func SharesRewards(s string) bool {
+	return Normalize(s) == Share
+}

--- a/modules/common/delegationmode/delegationmode.go
+++ b/modules/common/delegationmode/delegationmode.go
@@ -91,3 +91,18 @@ func AllowsDelegation(s string) bool {
 func SharesRewards(s string) bool {
 	return Normalize(s) == Share
 }
+
+// IsAdverseTransition reports whether changing a node's EFFECTIVE delegation
+// mode from old to new strips the on-chain pro-rata REWARD SHARE from existing
+// delegators — i.e. leaving Share for a non-sharing mode (Share->Custom or
+// Share->Deactivated). Only these transitions are timelocked, giving delegators
+// an unbond window to exit before their rewards stop.
+//
+// Acceptance-only changes (Custom<->Deactivated) are NOT adverse: they never
+// touch existing delegators' rewards, principal, or exit rights (unstake is
+// never mode-gated), only whether NEW third-party delegation is accepted.
+// Becoming more generous (-> Share) is never adverse. Inputs are Normalized, so
+// unknown/empty modes are treated as Deactivated.
+func IsAdverseTransition(old, new string) bool {
+	return SharesRewards(old) && !SharesRewards(new)
+}

--- a/modules/common/delegationmode/delegationmode_test.go
+++ b/modules/common/delegationmode/delegationmode_test.go
@@ -1,0 +1,79 @@
+package delegationmode
+
+import "testing"
+
+func TestNormalize(t *testing.T) {
+	cases := map[string]string{
+		"deactivated": Deactivated,
+		"share":       Share,
+		"custom":      Custom,
+		// case / whitespace tolerance
+		"SHARE":   Share,
+		" Custom": Custom,
+		"  ":      Deactivated,
+		"":        Deactivated,
+		// unknown → default (opt-in safe)
+		"foo":      Deactivated,
+		"disabled": Deactivated,
+	}
+	for in, want := range cases {
+		if got := Normalize(in); got != want {
+			t.Errorf("Normalize(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDefaultIsDeactivated(t *testing.T) {
+	if Default != Deactivated {
+		t.Fatalf("Default = %q, want Deactivated (delegation must be strict opt-in)", Default)
+	}
+}
+
+func TestIsValid(t *testing.T) {
+	for _, ok := range []string{Deactivated, Share, Custom} {
+		if !IsValid(ok) {
+			t.Errorf("IsValid(%q) = false, want true", ok)
+		}
+	}
+	for _, bad := range []string{"", "SHARE", " custom", "foo"} {
+		if IsValid(bad) {
+			t.Errorf("IsValid(%q) = true, want false (IsValid is exact, no normalization)", bad)
+		}
+	}
+}
+
+func TestAllowsDelegation(t *testing.T) {
+	// Share and Custom accept third-party delegation; Deactivated (incl.
+	// unset/unknown) does not.
+	if !AllowsDelegation(Share) {
+		t.Error("Share must allow delegation")
+	}
+	if !AllowsDelegation(Custom) {
+		t.Error("Custom must allow delegation")
+	}
+	if AllowsDelegation(Deactivated) {
+		t.Error("Deactivated must reject delegation")
+	}
+	if AllowsDelegation("") {
+		t.Error("empty/default must reject delegation (opt-in)")
+	}
+	if AllowsDelegation("nonsense") {
+		t.Error("unknown mode must reject delegation (opt-in)")
+	}
+}
+
+func TestSharesRewards(t *testing.T) {
+	// Only Share splits pendulum rewards on-chain.
+	if !SharesRewards(Share) {
+		t.Error("Share must split rewards on-chain")
+	}
+	if SharesRewards(Custom) {
+		t.Error("Custom keeps rewards at the operator (off-chain settlement)")
+	}
+	if SharesRewards(Deactivated) {
+		t.Error("Deactivated must not split rewards")
+	}
+	if SharesRewards("") {
+		t.Error("default must not split rewards")
+	}
+}

--- a/modules/common/delegationmode/delegationmode_test.go
+++ b/modules/common/delegationmode/delegationmode_test.go
@@ -77,3 +77,37 @@ func TestSharesRewards(t *testing.T) {
 		t.Error("default must not split rewards")
 	}
 }
+
+func TestIsAdverseTransition(t *testing.T) {
+	// Adverse iff the node LEAVES Share (strips delegators' on-chain reward
+	// share). Every other transition is immediate. Full 3x3 truth table over the
+	// normalized modes, plus a couple of un-normalized inputs.
+	adverse := map[[2]string]bool{
+		// old=deactivated: nothing to strip.
+		{Deactivated, Deactivated}: false,
+		{Deactivated, Share}:       false,
+		{Deactivated, Custom}:      false,
+		// old=share: leaving Share is adverse; staying / re-announcing is not.
+		{Share, Deactivated}: true,
+		{Share, Share}:       false,
+		{Share, Custom}:      true,
+		// old=custom: never shared on-chain, so no reward share to lose —
+		// custom->deactivated is an acceptance-only change, NOT adverse.
+		{Custom, Deactivated}: false,
+		{Custom, Share}:       false,
+		{Custom, Custom}:      false,
+	}
+	for pair, want := range adverse {
+		if got := IsAdverseTransition(pair[0], pair[1]); got != want {
+			t.Errorf("IsAdverseTransition(%q, %q) = %v, want %v", pair[0], pair[1], got, want)
+		}
+	}
+
+	// Normalization applies to both operands.
+	if !IsAdverseTransition("SHARE", " custom") {
+		t.Error("IsAdverseTransition must normalize inputs: SHARE->custom is adverse")
+	}
+	if IsAdverseTransition("custom", "unknown-mode") {
+		t.Error("custom->(unknown=deactivated) is acceptance-only, not adverse")
+	}
+}

--- a/modules/common/params/params.go
+++ b/modules/common/params/params.go
@@ -161,6 +161,17 @@ var TSS_INDEX_HEIGHT uint64 = 102_083_000
 // Election once every 6 hours on mainnet
 var ELECTION_INTERVAL = uint64(6 * 60 * 20)
 
+// CONSENSUS_UNSTAKE_LOCK_EPOCHS is the unbond period: a consensus_unstake is held
+// this many election epochs before the HIVE is released (~30h at
+// ELECTION_INTERVAL). Consensus rule — identical on every node.
+var CONSENSUS_UNSTAKE_LOCK_EPOCHS uint64 = 5
+
+// DELEGATION_DOWNGRADE_LOCK_EPOCHS defers an ADVERSE delegation-mode change
+// (leaving Share, which strips delegators' on-chain reward share) so delegators
+// get at least a full unbond window to exit before the change takes effect. Set
+// to the unbond period plus one epoch of reaction margin.
+var DELEGATION_DOWNGRADE_LOCK_EPOCHS uint64 = CONSENSUS_UNSTAKE_LOCK_EPOCHS + 1
+
 type ConsensusParams struct {
 	MinStake             int64  `json:"minStake,omitempty"`
 	MinMembers           int    `json:"minMembers,omitempty"`

--- a/modules/db/vsc/ledger/ledger.go
+++ b/modules/db/vsc/ledger/ledger.go
@@ -176,6 +176,27 @@ func (ledger *ledger) GetLedgerRange(
 	return &results, nil
 }
 
+// GetLedgerRecordsByType returns every ledger record (all accounts) of the given
+// types up to toBlock, sorted by (block_height, id) for a deterministic order.
+func (ledger *ledger) GetLedgerRecordsByType(types []string, toBlock uint64) ([]LedgerRecord, error) {
+	opts := options.Find().SetSort(bson.D{{Key: "block_height", Value: 1}, {Key: "id", Value: 1}})
+	query := bson.M{
+		"t":            bson.M{"$in": types},
+		"block_height": bson.M{"$lte": toBlock},
+	}
+	findResult, err := ledger.Find(context.Background(), query, opts)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]LedgerRecord, 0)
+	for findResult.Next(context.Background()) {
+		ledRes := LedgerRecord{}
+		findResult.Decode(&ledRes)
+		results = append(results, ledRes)
+	}
+	return results, nil
+}
+
 func (ledger *ledger) GetLedgersTsRange(
 	account *string,
 	txId *string,

--- a/modules/db/vsc/ledger/types.go
+++ b/modules/db/vsc/ledger/types.go
@@ -14,6 +14,11 @@ type Ledger interface {
 	//Gets distinct accounts on or after a block height
 	//Used to indicate whether balance has been updated or not
 	GetDistinctAccountsRange(startBlock, endBlock uint64) ([]string, error)
+	// GetLedgerRecordsByType returns ALL ledger records (every account) whose
+	// type is in `types`, up to and including toBlock, sorted deterministically
+	// (block_height, then id). Used by the one-time consensus-0.5.0 delegation
+	// backfill to reconstruct edges from the full stake/unstake history.
+	GetLedgerRecordsByType(types []string, toBlock uint64) ([]LedgerRecord, error)
 }
 
 type Balances interface {
@@ -38,8 +43,8 @@ type ClaimRecord struct {
 	//Numbers of accounts received interest
 	ReceivedN int `bson:"received_n"`
 	//Percent that was observed based on network averages
-	ObservedApr float64  `bson:"observed_apr"`
-	Timestamp   *string  `json:"timestamp,omitempty" bson:"timestamp,omitempty"`
+	ObservedApr float64 `bson:"observed_apr"`
+	Timestamp   *string `json:"timestamp,omitempty" bson:"timestamp,omitempty"`
 }
 
 type BalanceRecord struct {

--- a/modules/db/vsc/witnesses/schema.go
+++ b/modules/db/vsc/witnesses/schema.go
@@ -28,6 +28,17 @@ type Witness struct {
 	// Consensus 0.5.0+ reads this to gate delegation acceptance and reward
 	// sharing. omitempty keeps pre-0.5.0 records byte-identical.
 	DelegationMode string `json:"delegation_mode,omitempty" bson:"delegation_mode,omitempty"`
+	// DelegationModeEffective is the delegation mode IN FORCE at this row's height
+	// while an adverse (leaving-Share) downgrade is timelocked (consensus 0.5.0+).
+	// Readers return it until the chain epoch reaches DelegationModeMaturityEpoch,
+	// then switch to DelegationMode (the announced target). Empty when no downgrade
+	// is pending and on pre-0.5.0 rows. Set by the state engine at ingest
+	// (StateEngine.computeDelegationTimelock), NOT from L1 metadata.
+	DelegationModeEffective string `json:"delegation_mode_effective,omitempty" bson:"delegation_mode_effective,omitempty"`
+	// DelegationModeMaturityEpoch is the election epoch at/after which DelegationMode
+	// replaces DelegationModeEffective. 0 means "effective immediately" (pre-0.5.0
+	// rows and non-adverse announcements), so readers ignore the timelock fields.
+	DelegationModeMaturityEpoch uint64 `json:"delegation_mode_maturity_epoch,omitempty" bson:"delegation_mode_maturity_epoch,omitempty"`
 }
 
 type PostingJsonMetadata struct {
@@ -78,4 +89,11 @@ type SetWitnessUpdateType struct {
 	BlockId          string
 	GatewayKey       string
 	GatewayActiveKey string
+	// DelegationModeEffective / DelegationModeMaturityEpoch carry the timelock
+	// resolution computed by the state engine (computeDelegationTimelock) into
+	// SetWitnessUpdate. Zero-values mean "no pending downgrade" and are not
+	// persisted. json tags are required: SetWitnessUpdate deep-copies this struct
+	// via a JSON round-trip.
+	DelegationModeEffective     string `json:"delegation_mode_effective"`
+	DelegationModeMaturityEpoch uint64 `json:"delegation_mode_maturity_epoch"`
 }

--- a/modules/db/vsc/witnesses/schema.go
+++ b/modules/db/vsc/witnesses/schema.go
@@ -1,27 +1,33 @@
 package witnesses
 
 type Witness struct {
-	Account          string            `json:"account" bson:"account"`
-	Height           uint64            `json:"height" bson:"height"`
-	DidKeys          []PostingJsonKeys `json:"did_keys" bson:"did_keys"`
-	Enabled          bool              `json:"enabled" bson:"enabled"`
-	GitCommit        string            `json:"git_commit" bson:"git_commit"`
-	NetId            string            `json:"net_id" bson:"net_id"`
-	PeerId           string            `json:"peer_id" bson:"peer_id"`
+	Account   string            `json:"account" bson:"account"`
+	Height    uint64            `json:"height" bson:"height"`
+	DidKeys   []PostingJsonKeys `json:"did_keys" bson:"did_keys"`
+	Enabled   bool              `json:"enabled" bson:"enabled"`
+	GitCommit string            `json:"git_commit" bson:"git_commit"`
+	NetId     string            `json:"net_id" bson:"net_id"`
+	PeerId    string            `json:"peer_id" bson:"peer_id"`
 	// VersionMajor with ProtocolVersion (consensus) and VersionNonConsensus form major.consensus.non_consensus.
 	VersionMajor        uint64 `json:"version_major" bson:"version_major,omitempty"`
 	ProtocolVersion     uint64 `json:"protocol_version" bson:"protocol_version"`
 	VersionNonConsensus uint64 `json:"version_non_consensus" bson:"version_non_consensus,omitempty"`
-	Ts               string            `json:"ts" bson:"ts"`
-	TxId             string            `json:"tx_id" bson:"tx_id"`
-	VersionId        string            `json:"version_id" bson:"version_id"`
-	GatewayKey       string            `json:"gateway_key" bson:"gateway_key"`
-	GatewayActiveKey string            `json:"gateway_active_key" bson:"gateway_active_key"`
+	Ts                  string `json:"ts" bson:"ts"`
+	TxId                string `json:"tx_id" bson:"tx_id"`
+	VersionId           string `json:"version_id" bson:"version_id"`
+	GatewayKey          string `json:"gateway_key" bson:"gateway_key"`
+	GatewayActiveKey    string `json:"gateway_active_key" bson:"gateway_active_key"`
 	// GatewayKeyPoP is a hex secp256k1 proof-of-possession for GatewayKey, bound
 	// to the announcing account (audit H-6, gateway companion to the consensus
 	// key's PoP). Empty for witnesses that announced before gateway-PoP support.
 	GatewayKeyPoP string   `json:"gateway_key_pop" bson:"gateway_key_pop,omitempty"`
 	PeerAddrs     []string `json:"peer_addrs" bson:"peer_addrs"`
+	// DelegationMode is the operator's announced consensus-delegation policy
+	// (delegationmode.{Deactivated,Share,Custom}). Empty for witnesses that
+	// announced before this field existed; callers normalize empty → Deactivated.
+	// Consensus 0.5.0+ reads this to gate delegation acceptance and reward
+	// sharing. omitempty keeps pre-0.5.0 records byte-identical.
+	DelegationMode string `json:"delegation_mode,omitempty" bson:"delegation_mode,omitempty"`
 }
 
 type PostingJsonMetadata struct {
@@ -50,7 +56,7 @@ type PostingJsonMetadataVscNode struct {
 	ProtocolVersion uint64   `json:"protocol_version"`
 	// Non-consensus component; may differ across nodes without excluding them from committee.
 	VersionNonConsensus uint64 `json:"version_non_consensus"`
-	Witness         struct {
+	Witness             struct {
 		Enabled bool `json:"enabled"`
 		// Plugins     []string `json:"plugins"`
 		// DelayNotch  int      `json:"delay_notch"`
@@ -59,6 +65,9 @@ type PostingJsonMetadataVscNode struct {
 	GatewayKey       string `json:"gateway_key"`
 	GatewayActiveKey string `json:"gateway_active_key"`
 	GatewayKeyPoP    string `json:"gateway_key_pop"`
+	// DelegationMode mirrors the announced operator delegation policy
+	// (delegationmode.{Deactivated,Share,Custom}); empty when not announced.
+	DelegationMode string `json:"delegation_mode"`
 }
 
 type SetWitnessUpdateType struct {

--- a/modules/db/vsc/witnesses/witnesses.go
+++ b/modules/db/vsc/witnesses/witnesses.go
@@ -75,18 +75,21 @@ func (w *witnesses) SetWitnessUpdate(requestIn SetWitnessUpdateType) error {
 			"peer_id":    request.Metadata.VscNode.PeerId,
 			"peer_addrs": request.Metadata.VscNode.PeerAddrs,
 			//timestamp
-			"ts":               request.Metadata.VscNode.Ts,
-			"tx_id":            request.TxId,
-			"version_id":       request.Metadata.VscNode.VersionId,
-			"git_commit":       request.Metadata.VscNode.GitCommit,
-			"net_id":           request.Metadata.VscNode.NetId,
+			"ts":                    request.Metadata.VscNode.Ts,
+			"tx_id":                 request.TxId,
+			"version_id":            request.Metadata.VscNode.VersionId,
+			"git_commit":            request.Metadata.VscNode.GitCommit,
+			"net_id":                request.Metadata.VscNode.NetId,
 			"version_major":         request.Metadata.VscNode.VersionMajor,
 			"protocol_version":      request.Metadata.VscNode.ProtocolVersion,
 			"version_non_consensus": request.Metadata.VscNode.VersionNonConsensus,
 			"enabled":               request.Metadata.VscNode.Witness.Enabled,
-			"did_keys":         request.Metadata.DidKeys,
-			"gateway_key":      request.Metadata.VscNode.GatewayKey,
-			"gateway_key_pop":  request.Metadata.VscNode.GatewayKeyPoP,
+			"did_keys":              request.Metadata.DidKeys,
+			"gateway_key":           request.Metadata.VscNode.GatewayKey,
+			"gateway_key_pop":       request.Metadata.VscNode.GatewayKeyPoP,
+			// Operator's consensus-delegation policy (consensus 0.5.0+); empty
+			// when the announcement predates the field. Normalized by readers.
+			"delegation_mode": request.Metadata.VscNode.DelegationMode,
 		},
 	}
 	w.FindOneAndUpdate(ctx, query, update, findOptions)

--- a/modules/db/vsc/witnesses/witnesses.go
+++ b/modules/db/vsc/witnesses/witnesses.go
@@ -70,28 +70,34 @@ func (w *witnesses) SetWitnessUpdate(requestIn SetWitnessUpdateType) error {
 		"account": request.Account,
 		"height":  request.Height,
 	}
-	update := bson.M{
-		"$set": bson.M{
-			"peer_id":    request.Metadata.VscNode.PeerId,
-			"peer_addrs": request.Metadata.VscNode.PeerAddrs,
-			//timestamp
-			"ts":                    request.Metadata.VscNode.Ts,
-			"tx_id":                 request.TxId,
-			"version_id":            request.Metadata.VscNode.VersionId,
-			"git_commit":            request.Metadata.VscNode.GitCommit,
-			"net_id":                request.Metadata.VscNode.NetId,
-			"version_major":         request.Metadata.VscNode.VersionMajor,
-			"protocol_version":      request.Metadata.VscNode.ProtocolVersion,
-			"version_non_consensus": request.Metadata.VscNode.VersionNonConsensus,
-			"enabled":               request.Metadata.VscNode.Witness.Enabled,
-			"did_keys":              request.Metadata.DidKeys,
-			"gateway_key":           request.Metadata.VscNode.GatewayKey,
-			"gateway_key_pop":       request.Metadata.VscNode.GatewayKeyPoP,
-			// Operator's consensus-delegation policy (consensus 0.5.0+); empty
-			// when the announcement predates the field. Normalized by readers.
-			"delegation_mode": request.Metadata.VscNode.DelegationMode,
-		},
+	set := bson.M{
+		"peer_id":    request.Metadata.VscNode.PeerId,
+		"peer_addrs": request.Metadata.VscNode.PeerAddrs,
+		//timestamp
+		"ts":                    request.Metadata.VscNode.Ts,
+		"tx_id":                 request.TxId,
+		"version_id":            request.Metadata.VscNode.VersionId,
+		"git_commit":            request.Metadata.VscNode.GitCommit,
+		"net_id":                request.Metadata.VscNode.NetId,
+		"version_major":         request.Metadata.VscNode.VersionMajor,
+		"protocol_version":      request.Metadata.VscNode.ProtocolVersion,
+		"version_non_consensus": request.Metadata.VscNode.VersionNonConsensus,
+		"enabled":               request.Metadata.VscNode.Witness.Enabled,
+		"did_keys":              request.Metadata.DidKeys,
+		"gateway_key":           request.Metadata.VscNode.GatewayKey,
+		"gateway_key_pop":       request.Metadata.VscNode.GatewayKeyPoP,
+		// Operator's consensus-delegation policy (consensus 0.5.0+); empty
+		// when the announcement predates the field. Normalized by readers.
+		"delegation_mode": request.Metadata.VscNode.DelegationMode,
 	}
+	// Delegation-mode downgrade timelock (consensus 0.5.0+): only written when a
+	// downgrade is actually pending (MaturityEpoch != 0), so pre-0.5.0 and
+	// non-adverse rows stay byte-identical to before the feature.
+	if request.DelegationModeMaturityEpoch != 0 {
+		set["delegation_mode_effective"] = request.DelegationModeEffective
+		set["delegation_mode_maturity_epoch"] = request.DelegationModeMaturityEpoch
+	}
+	update := bson.M{"$set": set}
 	w.FindOneAndUpdate(ctx, query, update, findOptions)
 
 	oldRecordsFilter := bson.M{

--- a/modules/election-proposer/election-proposer.go
+++ b/modules/election-proposer/election-proposer.go
@@ -1122,6 +1122,17 @@ func (e *electionProposer) GenerateFullElection(
 			)
 		}
 
+		// Consensus 0.5.0: per-delegator reward split for share-mode nodes.
+		// Read at the SAME blockHeight as the bonds so every signer's re-derive
+		// (against rec.SnapshotRangeTo == blockHeight) sees identical edges. A
+		// transient read failure aborts the election attempt rather than
+		// composing a settlement against a partial delegation view.
+		shareDelegations, sdOk := e.se.PendulumShareDelegations(settlementMembers, blockHeight)
+		if !sdOk {
+			return elections.ElectionHeader{}, elections.ElectionData{},
+				fmt.Errorf("pendulum settlement: share-delegation read unavailable")
+		}
+
 		rec, composeErr := pendulumsettlement.ComposeRecord(pendulumsettlement.ComposeInputs{
 			Epoch:               previousEpoch,
 			PrevEpoch:           prevSettled,
@@ -1130,6 +1141,7 @@ func (e *electionProposer) GenerateFullElection(
 			CommitteeBonds:      bonds,
 			BucketBalanceHBD:    bucket,
 			ReductionsByAccount: reductions,
+			ShareDelegations:    shareDelegations,
 		})
 		if composeErr != nil {
 			return elections.ElectionHeader{}, elections.ElectionData{},

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"math/big"
 	"os"
 	"sort"
 	"strings"
@@ -393,6 +394,41 @@ func (r *queryResolver) GetAccountBalance(ctx context.Context, account string, h
 	}
 	blockHeight := ParseHeight(height)
 	return r.Balances.GetBalanceRecord(account, blockHeight)
+}
+
+// GetConsensusDelegation is the resolver for the getConsensusDelegation field.
+func (r *queryResolver) GetConsensusDelegation(ctx context.Context, from string, to string, height *model.Uint64) (*ConsensusDelegation, error) {
+	if from == "" || to == "" {
+		return nil, fmt.Errorf("from and to cannot be empty")
+	}
+	blockHeight := ParseHeight(height)
+	session := ledgerSystem.NewSession(r.StateEngine.LedgerState)
+
+	// Gross stake on this edge, and the node's pooled bond (slash-aware) vs its
+	// slash-immune gross delegated total.
+	delegated := session.GetBalance(ledgerSystem.DelegationEdgeKey(from, to), blockHeight, ledgerSystem.AssetDelegation)
+	bond := session.GetBalance(to, blockHeight, "hive_consensus")
+	total := session.GetBalance(to, blockHeight, ledgerSystem.AssetDelegationTotal)
+
+	// Pro-rata claimable (mirrors ledgerSession.slashAdjustedRelease): full
+	// unless the node is slashed (bond < total), then delegated * bond / total.
+	claimable := delegated
+	if delegated > 0 && total > 0 && bond < total {
+		if bond <= 0 {
+			claimable = 0
+		} else {
+			num := new(big.Int).Mul(big.NewInt(delegated), big.NewInt(bond))
+			num.Div(num, big.NewInt(total))
+			claimable = num.Int64()
+		}
+	}
+
+	return &ConsensusDelegation{
+		From:      from,
+		To:        to,
+		Delegated: model.Int64(delegated),
+		Claimable: model.Int64(claimable),
+	}, nil
 }
 
 // GetAccountRc is the resolver for the getAccountRC field.

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -21,6 +21,7 @@ import (
 	"vsc-node/modules/announcements"
 	"vsc-node/modules/common"
 	"vsc-node/modules/common/consensusversion"
+	"vsc-node/modules/common/delegationmode"
 	"vsc-node/modules/common/params"
 	contract_execution_context "vsc-node/modules/contract/execution-context"
 	contract_session "vsc-node/modules/contract/session"
@@ -429,6 +430,33 @@ func (r *queryResolver) GetConsensusDelegation(ctx context.Context, from string,
 		Delegated: model.Int64(delegated),
 		Claimable: model.Int64(claimable),
 	}, nil
+}
+
+// GetNodeDelegationMode is the resolver for the getNodeDelegationMode field. It
+// returns the node operator's normalized consensus-delegation mode, always
+// defaulting to delegationmode.Deactivated when the node has not announced one
+// (delegation is strict opt-in). Mirrors how the consensus layer reads the mode
+// at stake time and at settlement.
+func (r *queryResolver) GetNodeDelegationMode(ctx context.Context, account string, height *model.Uint64) (*string, error) {
+	if account == "" {
+		return nil, fmt.Errorf("account cannot be empty")
+	}
+	// Witness records are keyed by the bare Hive account name; tolerate the
+	// "hive:" form used elsewhere in the API.
+	acct := strings.TrimPrefix(account, "hive:")
+
+	// nil height → latest announcement; otherwise pin to the requested height.
+	var bh *uint64
+	if height != nil {
+		h := ParseHeight(height)
+		bh = &h
+	}
+
+	mode := delegationmode.Default
+	if w, err := r.Witnesses.GetWitnessAtHeight(acct, bh); err == nil && w != nil {
+		mode = delegationmode.Normalize(w.DelegationMode)
+	}
+	return &mode, nil
 }
 
 // GetAccountRc is the resolver for the getAccountRC field.

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -21,7 +21,6 @@ import (
 	"vsc-node/modules/announcements"
 	"vsc-node/modules/common"
 	"vsc-node/modules/common/consensusversion"
-	"vsc-node/modules/common/delegationmode"
 	"vsc-node/modules/common/params"
 	contract_execution_context "vsc-node/modules/contract/execution-context"
 	contract_session "vsc-node/modules/contract/session"
@@ -441,21 +440,12 @@ func (r *queryResolver) GetNodeDelegationMode(ctx context.Context, account strin
 	if account == "" {
 		return nil, fmt.Errorf("account cannot be empty")
 	}
-	// Witness records are keyed by the bare Hive account name; tolerate the
-	// "hive:" form used elsewhere in the API.
-	acct := strings.TrimPrefix(account, "hive:")
-
-	// nil height → latest announcement; otherwise pin to the requested height.
-	var bh *uint64
-	if height != nil {
-		h := ParseHeight(height)
-		bh = &h
-	}
-
-	mode := delegationmode.Default
-	if w, err := r.Witnesses.GetWitnessAtHeight(acct, bh); err == nil && w != nil {
-		mode = delegationmode.Normalize(w.DelegationMode)
-	}
+	// Route through the consensus-layer reader so the API reports the EFFECTIVE
+	// (timelock-resolved) mode a delegator actually gets — during a pending
+	// adverse downgrade this is the still-protected mode, not the raw announced
+	// target. NodeDelegationMode strips the "hive:" prefix and defaults to
+	// Deactivated when unavailable. nil height → latest (ParseHeight → MaxInt64).
+	mode := r.StateEngine.NodeDelegationMode(account, ParseHeight(height))
 	return &mode, nil
 }
 

--- a/modules/gql/schema.graphql
+++ b/modules/gql/schema.graphql
@@ -1560,6 +1560,20 @@ input GovernanceProposalFilter {
   limit: Int
 }
 
+"""
+A delegator's consensus stake on a single (from -> to) edge. Consensus 0.5.0+.
+"""
+type ConsensusDelegation {
+  """Delegator account."""
+  from: String!
+  """Node account the stake is delegated to."""
+  to: String!
+  """Gross HIVE staked on this edge (base units)."""
+  delegated: Int64!
+  """HIVE currently reclaimable — `delegated` unless the node is slashed, then reduced pro-rata."""
+  claimable: Int64!
+}
+
 type Query {
   """
   Retrieve contract state values by their keys. Returns a map of key-value pairs from the contract's state merkle tree.
@@ -1632,6 +1646,22 @@ type Query {
     """
     height: Uint64
   ): BalanceRecord
+
+  """
+  Consensus stake `from` has delegated to node `to`. Consensus 0.5.0+.
+  `delegated` is the gross amount staked on this edge; `claimable` is what
+  unstaking it would return now — equal to `delegated` unless the node has been
+  slashed, in which case it is reduced pro-rata (every delegator to that node is
+  reduced by the same fraction). Use `claimable` to drive an unstake form.
+  """
+  getConsensusDelegation(
+    """Delegator account (the signer that can reclaim this stake)."""
+    from: String!
+    """Node account the stake is delegated to."""
+    to: String!
+    """Block height to query at. Defaults to the latest block."""
+    height: Uint64
+  ): ConsensusDelegation
 
   """
   Get the resource credit balance for an account, optionally at a specific block height. RCs regenerate over time based on staked balance.

--- a/modules/gql/schema.graphql
+++ b/modules/gql/schema.graphql
@@ -585,6 +585,14 @@ type Witness {
   Public key used for the P2P multisig gateway.
   """
   gateway_key: String
+  """
+  Operator's announced consensus-delegation policy (consensus 0.5.0+):
+  `deactivated` (no third-party delegation), `share` (pendulum rewards split
+  pro-rata to delegators), or `custom` (delegation allowed, rewards settled
+  off-chain). Empty/null for witnesses that announced before this field; treat
+  empty as `deactivated`. Use `getNodeDelegationMode` for the normalized value.
+  """
+  delegation_mode: String
 }
 
 """
@@ -1662,6 +1670,21 @@ type Query {
     """Block height to query at. Defaults to the latest block."""
     height: Uint64
   ): ConsensusDelegation
+
+  """
+  The consensus-delegation mode node `account` has opted into, as of `height`
+  (consensus 0.5.0+). Returns the normalized policy — one of `deactivated`,
+  `share`, or `custom` — always defaulting to `deactivated` when the node has
+  not announced a mode (delegation is strict opt-in). `deactivated` rejects
+  third-party delegation; `share` splits pendulum rewards pro-rata to
+  delegators; `custom` allows delegation with off-chain reward settlement.
+  """
+  getNodeDelegationMode(
+    """Node (witness) account whose mode to read, with or without the `hive:` prefix."""
+    account: String!
+    """Block height to query at. Defaults to the latest announcement."""
+    height: Uint64
+  ): String
 
   """
   Get the resource credit balance for an account, optionally at a specific block height. RCs regenerate over time based on staked balance.

--- a/modules/incentive-pendulum/settlement/calculator.go
+++ b/modules/incentive-pendulum/settlement/calculator.go
@@ -29,11 +29,11 @@ type Distribution struct {
 // distribution math; the underlying ledger HIVE_CONSENSUS balance is NOT
 // debited (that would be true slashing — out of scope).
 type RewardReductionApplied struct {
-	Account          string
-	Bps              int
-	OriginalBond     int64
-	ReductionAmount  int64
-	EffectiveBond    int64
+	Account         string
+	Bps             int
+	OriginalBond    int64
+	ReductionAmount int64
+	EffectiveBond   int64
 }
 
 func CalculateSplitPreviewFixed(r int64, t int64, effectiveNumerator int64, effectiveDenominator int64, v int64, p int64) SplitPreview {
@@ -124,6 +124,91 @@ func ComputeNodeDistributions(nodeShare int64, bonds map[string]int64) []Distrib
 		})
 	}
 
+	return out
+}
+
+// ExpandShareDistributions rewrites node-level distributions into per-recipient
+// distributions for nodes that share their pendulum rewards with delegators
+// (delegationmode.Share). Consensus 0.3.0+.
+//
+// For a node present in shareDelegations, its HBD amount is split across the
+// node's stake edges pro-rata by stake using integer floor division
+// (intmath.MulDivFloorI64). The rounding remainder (amount − Σ floors) is
+// credited to the node operator account, so each node's TOTAL payout is
+// preserved EXACTLY — TotalDistributedHBD and ResidualHBD are therefore
+// identical to the node-level result, and the settlement's conservation
+// invariant is untouched. Nodes absent from shareDelegations (Custom,
+// Deactivated, or non-committee) pass through unchanged: the operator keeps the
+// whole amount.
+//
+// The operator's own self-stake is just another edge (node -> node), so the
+// operator earns strictly in proportion to their own stake — no separate
+// commission. Results are merged by recipient account (a delegator across
+// several share nodes, or an operator who also delegates elsewhere, collapses
+// to a single entry — which both avoids duplicate ledger ids at apply time and
+// keeps the post-sort order byte-stable) and sorted lexicographically.
+//
+// Deterministic: edge maps are iterated in sorted account order and all
+// arithmetic is integer, so two honest nodes produce a byte-identical result.
+func ExpandShareDistributions(dists []Distribution, shareDelegations map[string]map[string]int64) []Distribution {
+	merged := make(map[string]int64)
+	add := func(acct string, amt int64) {
+		if amt != 0 {
+			merged[acct] += amt
+		}
+	}
+
+	for _, d := range dists {
+		edges := shareDelegations[d.Account]
+		if d.Amount <= 0 || len(edges) == 0 {
+			// Non-share node (or nothing to split): operator keeps it.
+			add(d.Account, d.Amount)
+			continue
+		}
+
+		// Denominator = Σ positive edge stakes; collect delegators for a
+		// deterministic (sorted) split order.
+		total := int64(0)
+		delegators := make([]string, 0, len(edges))
+		for dlg, st := range edges {
+			if st > 0 {
+				total += st
+				delegators = append(delegators, dlg)
+			}
+		}
+		if total <= 0 {
+			add(d.Account, d.Amount)
+			continue
+		}
+		sort.Strings(delegators)
+
+		distributed := int64(0)
+		for _, dlg := range delegators {
+			share, ok := intmath.MulDivFloorI64(d.Amount, edges[dlg], total)
+			if !ok || share <= 0 {
+				continue
+			}
+			add(dlg, share)
+			distributed += share
+		}
+		// Floor remainder → operator (the node account), preserving the node's
+		// exact total. distributed ≤ d.Amount, so the remainder is ≥ 0.
+		add(d.Account, d.Amount-distributed)
+	}
+
+	accounts := make([]string, 0, len(merged))
+	for a := range merged {
+		accounts = append(accounts, a)
+	}
+	sort.Strings(accounts)
+
+	out := make([]Distribution, 0, len(accounts))
+	for _, a := range accounts {
+		if merged[a] <= 0 {
+			continue
+		}
+		out = append(out, Distribution{Account: a, Amount: merged[a]})
+	}
 	return out
 }
 

--- a/modules/incentive-pendulum/settlement/calculator.go
+++ b/modules/incentive-pendulum/settlement/calculator.go
@@ -4,7 +4,7 @@ import (
 	"math/big"
 	"sort"
 	"vsc-node/lib/intmath"
-	"vsc-node/modules/incentive-pendulum"
+	pendulum "vsc-node/modules/incentive-pendulum"
 	"vsc-node/modules/incentive-pendulum/rewards"
 )
 
@@ -129,7 +129,7 @@ func ComputeNodeDistributions(nodeShare int64, bonds map[string]int64) []Distrib
 
 // ExpandShareDistributions rewrites node-level distributions into per-recipient
 // distributions for nodes that share their pendulum rewards with delegators
-// (delegationmode.Share). Consensus 0.3.0+.
+// (delegationmode.Share). Consensus 0.5.0+.
 //
 // For a node present in shareDelegations, its HBD amount is split across the
 // node's stake edges pro-rata by stake using integer floor division

--- a/modules/incentive-pendulum/settlement/compose.go
+++ b/modules/incentive-pendulum/settlement/compose.go
@@ -32,6 +32,15 @@ type ComposeInputs struct {
 	// computed over the closed epoch, keyed in "hive:account" form. Produced
 	// by rewards.ComputeReductionsForEpoch from on-chain L2 evidence.
 	ReductionsByAccount map[string]int
+	// ShareDelegations holds, for each committee node running
+	// delegationmode.Share at SlotHeight, that node's stake edges:
+	// node -> (delegator -> net HIVE staked), both in "hive:account" form.
+	// Nodes absent here keep their reward at the node account (Custom /
+	// Deactivated / legacy). Consensus 0.5.0+; nil pre-activation, which makes
+	// ComposeRecord byte-identical to the node-level result. Must be derived
+	// deterministically (StateEngine.PendulumShareDelegations at SlotHeight) on
+	// both the producer and every re-deriving node.
+	ShareDelegations map[string]map[string]int64
 }
 
 // ComposeRecord builds the deterministic SettlementRecord for the closing
@@ -121,6 +130,15 @@ func ComposeRecord(in ComposeInputs) (*SettlementRecord, error) {
 	nodeShare := in.BucketBalanceHBD
 
 	dists := ComputeNodeDistributions(nodeShare, effectiveBonds)
+
+	// Consensus 0.5.0: expand each share-mode node's slice into per-delegator
+	// payouts (pro-rata by stake); Custom / Deactivated / legacy nodes pass
+	// through unchanged. Each node's total is preserved exactly (rounding
+	// remainder → operator), so totalDistributed and residual are identical to
+	// the node-level result and the conservation invariant is unchanged. With
+	// no share nodes (ShareDelegations nil/empty) this is a no-op and the record
+	// is byte-identical to pre-0.5.0.
+	dists = ExpandShareDistributions(dists, in.ShareDelegations)
 
 	distPayload := make([]DistributionEntry, 0, len(dists))
 	totalDistributed := int64(0)

--- a/modules/incentive-pendulum/settlement/share_distributions_test.go
+++ b/modules/incentive-pendulum/settlement/share_distributions_test.go
@@ -1,0 +1,189 @@
+package settlement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// sumDist totals a distribution slice.
+func sumDist(d []Distribution) int64 {
+	var s int64
+	for _, x := range d {
+		s += x.Amount
+	}
+	return s
+}
+
+func distMap(d []Distribution) map[string]int64 {
+	m := make(map[string]int64, len(d))
+	for _, x := range d {
+		m[x.Account] = x.Amount
+	}
+	return m
+}
+
+func TestExpandShareDistributions_ExactProRata(t *testing.T) {
+	// n1 earns 1000; operator self-stake 600, alice 400 → split exactly.
+	dists := []Distribution{{Account: "hive:n1", Amount: 1000}}
+	share := map[string]map[string]int64{
+		"hive:n1": {"hive:n1": 600, "hive:alice": 400},
+	}
+	out := ExpandShareDistributions(dists, share)
+	m := distMap(out)
+	assert.Equal(t, int64(600), m["hive:n1"], "operator earns via own self-edge")
+	assert.Equal(t, int64(400), m["hive:alice"], "delegator pro-rata by stake")
+	assert.Equal(t, int64(1000), sumDist(out), "node total preserved exactly")
+}
+
+func TestExpandShareDistributions_RemainderToOperator(t *testing.T) {
+	// 1000 across three equal edges: floor(1000/3)=333 each, remainder 1 → operator.
+	dists := []Distribution{{Account: "hive:n1", Amount: 1000}}
+	share := map[string]map[string]int64{
+		"hive:n1": {"hive:n1": 1, "hive:alice": 1, "hive:bob": 1},
+	}
+	out := ExpandShareDistributions(dists, share)
+	m := distMap(out)
+	assert.Equal(t, int64(334), m["hive:n1"], "operator gets self-edge share 333 + rounding remainder 1")
+	assert.Equal(t, int64(333), m["hive:alice"])
+	assert.Equal(t, int64(333), m["hive:bob"])
+	assert.Equal(t, int64(1000), sumDist(out), "conservation: remainder is not lost")
+}
+
+func TestExpandShareDistributions_PassthroughNonShare(t *testing.T) {
+	// Node not in the share map keeps its whole amount (Custom / Deactivated).
+	dists := []Distribution{{Account: "hive:n2", Amount: 500}}
+	out := ExpandShareDistributions(dists, map[string]map[string]int64{})
+	assert.Equal(t, []Distribution{{Account: "hive:n2", Amount: 500}}, out)
+}
+
+func TestExpandShareDistributions_Mixed(t *testing.T) {
+	// One share node, one custom node in the same settlement.
+	dists := []Distribution{
+		{Account: "hive:n1", Amount: 1000}, // share
+		{Account: "hive:n2", Amount: 500},  // custom (absent from share map)
+	}
+	share := map[string]map[string]int64{
+		"hive:n1": {"hive:n1": 50, "hive:alice": 50},
+	}
+	out := ExpandShareDistributions(dists, share)
+	m := distMap(out)
+	assert.Equal(t, int64(500), m["hive:n1"], "operator self-edge half of 1000")
+	assert.Equal(t, int64(500), m["hive:alice"])
+	assert.Equal(t, int64(500), m["hive:n2"], "custom node unchanged")
+	assert.Equal(t, int64(1500), sumDist(out), "global total preserved")
+}
+
+func TestExpandShareDistributions_MergeAcrossNodes(t *testing.T) {
+	// alice delegates to TWO share nodes → exactly one merged entry (no
+	// duplicate account, which would break the byte-stable sort + collide ids).
+	dists := []Distribution{
+		{Account: "hive:n1", Amount: 1000},
+		{Account: "hive:n3", Amount: 1000},
+	}
+	share := map[string]map[string]int64{
+		"hive:n1": {"hive:n1": 500, "hive:alice": 500},
+		"hive:n3": {"hive:n3": 500, "hive:alice": 500},
+	}
+	out := ExpandShareDistributions(dists, share)
+	// Verify uniqueness of accounts.
+	seen := map[string]bool{}
+	for _, d := range out {
+		assert.False(t, seen[d.Account], "account %s appears more than once", d.Account)
+		seen[d.Account] = true
+	}
+	m := distMap(out)
+	assert.Equal(t, int64(1000), m["hive:alice"], "alice = 500 from n1 + 500 from n3, merged")
+	assert.Equal(t, int64(500), m["hive:n1"])
+	assert.Equal(t, int64(500), m["hive:n3"])
+	assert.Equal(t, int64(2000), sumDist(out))
+}
+
+func TestExpandShareDistributions_ConservationProperty(t *testing.T) {
+	// For arbitrary inputs the expanded total must equal the node-level total.
+	dists := []Distribution{
+		{Account: "hive:n1", Amount: 9973},
+		{Account: "hive:n2", Amount: 4441},
+		{Account: "hive:n3", Amount: 12},
+	}
+	share := map[string]map[string]int64{
+		"hive:n1": {"hive:n1": 7, "hive:alice": 11, "hive:bob": 13},
+		"hive:n2": {"hive:carol": 1}, // single delegator, no operator self-edge
+	}
+	out := ExpandShareDistributions(dists, share)
+	assert.Equal(t, int64(9973+4441+12), sumDist(out), "no base unit created or destroyed")
+	// Every emitted amount is strictly positive.
+	for _, d := range out {
+		assert.Greater(t, d.Amount, int64(0))
+	}
+}
+
+func TestExpandShareDistributions_OperatorRemainderWithoutSelfEdge(t *testing.T) {
+	// Node with delegators but no operator self-stake: rounding crumb still
+	// lands on the node account (the operator), preserving conservation.
+	dists := []Distribution{{Account: "hive:n2", Amount: 11}}
+	share := map[string]map[string]int64{
+		"hive:n2": {"hive:alice": 1, "hive:bob": 1},
+	}
+	out := ExpandShareDistributions(dists, share)
+	m := distMap(out)
+	assert.Equal(t, int64(5), m["hive:alice"])
+	assert.Equal(t, int64(5), m["hive:bob"])
+	assert.Equal(t, int64(1), m["hive:n2"], "remainder crumb to operator account")
+	assert.Equal(t, int64(11), sumDist(out))
+}
+
+// TestComposeRecord_ShareDelegationsPreservesTotals proves the settlement
+// record's conservation totals are byte-stable whether or not a node shares:
+// only the recipient breakdown changes, never TotalDistributed / Residual.
+func TestComposeRecord_ShareDelegationsPreservesTotals(t *testing.T) {
+	base := ComposeInputs{
+		Epoch:        7,
+		PrevEpoch:    6,
+		EpochStartBh: 1000,
+		SlotHeight:   2000,
+		CommitteeBonds: map[string]int64{
+			"hive:n1": 100,
+			"hive:n2": 100,
+		},
+		BucketBalanceHBD: 1000,
+	}
+
+	// Without share delegations: node-level distributions.
+	plain, err := ComposeRecord(base)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1000), plain.TotalDistributedHBD)
+	assert.Equal(t, int64(0), plain.ResidualHBD)
+	plainMap := map[string]int64{}
+	for _, d := range plain.Distributions {
+		plainMap[d.Account] = d.HBDAmt
+	}
+	assert.Equal(t, int64(500), plainMap["hive:n1"])
+	assert.Equal(t, int64(500), plainMap["hive:n2"])
+
+	// With n1 in share mode (operator 50 / alice 50): n1's 500 → 250 + 250.
+	withShare := base
+	withShare.ShareDelegations = map[string]map[string]int64{
+		"hive:n1": {"hive:n1": 50, "hive:alice": 50},
+	}
+	shared, err := ComposeRecord(withShare)
+	assert.NoError(t, err)
+
+	// Totals and residual are IDENTICAL — conservation invariant untouched.
+	assert.Equal(t, plain.TotalDistributedHBD, shared.TotalDistributedHBD)
+	assert.Equal(t, plain.ResidualHBD, shared.ResidualHBD)
+	assert.Equal(t, plain.BucketBalanceHBD, shared.BucketBalanceHBD)
+
+	sharedMap := map[string]int64{}
+	for _, d := range shared.Distributions {
+		sharedMap[d.Account] = d.HBDAmt
+	}
+	assert.Equal(t, int64(500), sharedMap["hive:n2"], "non-share node unchanged")
+	assert.Equal(t, int64(250), sharedMap["hive:n1"], "share-node operator self-edge")
+	assert.Equal(t, int64(250), sharedMap["hive:alice"], "delegator share")
+
+	// Distributions remain sorted by account (byte-stable encoding contract).
+	for i := 1; i < len(shared.Distributions); i++ {
+		assert.Less(t, shared.Distributions[i-1].Account, shared.Distributions[i].Account)
+	}
+}

--- a/modules/ledger-system/delegation_migration.go
+++ b/modules/ledger-system/delegation_migration.go
@@ -39,7 +39,7 @@ func BackfillDelegationEdges(records []ledgerDb.LedgerRecord, atHeight uint64) [
 	edges := map[string]int64{}
 
 	for _, r := range records {
-		if r.Asset == AssetDelegation {
+		if r.Asset == AssetDelegation || r.Asset == AssetDelegationTotal {
 			continue // already-migrated / post-activation edge rows — never re-count
 		}
 		base, suffix := splitLedgerBaseId(r.Id)
@@ -80,11 +80,17 @@ func BackfillDelegationEdges(records []ledgerDb.LedgerRecord, atHeight uint64) [
 	}
 	sort.Strings(keys) // deterministic output order
 
+	// Per-node gross total = Σ positive edges to that node (slash-immune), so the
+	// pro-rata slash ratio (bond/total) is well-defined for migrated stakes too.
+	totals := map[string]int64{}
+
 	out := make([]LedgerUpdate, 0, len(keys))
 	for _, k := range keys {
 		if edges[k] <= 0 {
 			continue // nothing reclaimable on this edge
 		}
+		_, to := splitDelegationEdgeKey(k)
+		totals[to] += edges[k]
 		out = append(out, LedgerUpdate{
 			Id:          "delegation_backfill:" + k,
 			Owner:       k,
@@ -94,7 +100,33 @@ func BackfillDelegationEdges(records []ledgerDb.LedgerRecord, atHeight uint64) [
 			BlockHeight: atHeight,
 		})
 	}
+
+	totalKeys := make([]string, 0, len(totals))
+	for n := range totals {
+		totalKeys = append(totalKeys, n)
+	}
+	sort.Strings(totalKeys)
+	for _, n := range totalKeys {
+		out = append(out, LedgerUpdate{
+			Id:          "delegation_backfill_total:" + n,
+			Owner:       n,
+			Amount:      totals[n],
+			Asset:       AssetDelegationTotal,
+			Type:        "consensus_stake",
+			BlockHeight: atHeight,
+		})
+	}
 	return out
+}
+
+// splitDelegationEdgeKey is the inverse of DelegationEdgeKey: it splits a
+// composite "from::to" owner back into its two accounts.
+func splitDelegationEdgeKey(key string) (from, to string) {
+	parts := strings.SplitN(key, delegationEdgeSep, 2)
+	if len(parts) != 2 {
+		return key, ""
+	}
+	return parts[0], parts[1]
 }
 
 // splitLedgerBaseId strips a single trailing "#segment" (e.g. "#in", "#out",

--- a/modules/ledger-system/delegation_migration.go
+++ b/modules/ledger-system/delegation_migration.go
@@ -1,0 +1,111 @@
+package ledgerSystem
+
+import (
+	"sort"
+	"strings"
+
+	ledgerDb "vsc-node/modules/db/vsc/ledger"
+)
+
+// BackfillDelegationEdges derives the per-edge delegation ledger records to seed
+// at the consensus 0.5.0 activation height, from the full history of consensus
+// stake/unstake records. This is what makes pre-0.5.0 stakes reclaimable by the
+// delegator who made them.
+//
+// Why pairing is needed: before 0.5.0 the (from -> to) link is not stored on any
+// single record — LedgerUpdate/LedgerRecord has no destination field. A stake
+// emits a "#in" row (Owner = from, -amount, hive) and a "#out" row (Owner = to,
+// +amount, hive_consensus) sharing one base id. We recover (from, to, amount) by
+// pairing those two rows on their base id (id with the trailing "#..." stripped).
+//
+// Legacy unstakes (< 0.5.0) were only ever issued by the bond holder (from == to
+// == node), so they reduce that node's self-edge.
+//
+// Determinism: the input is canonical ledger state (identical on every node) and
+// the output is sorted by edge key, so every node seeds byte-identical edges.
+// Idempotency is the caller's responsibility (run exactly once, guarded by an
+// activation marker — see the wiring TODO in the design spec).
+//
+// Returns one net "delegation" record per (from,to) edge with a positive net,
+// owned by DelegationEdgeKey(from,to), stamped at atHeight. Records whose asset
+// is already AssetDelegation are ignored so a re-run cannot double-count.
+func BackfillDelegationEdges(records []ledgerDb.LedgerRecord, atHeight uint64) []LedgerUpdate {
+	type stakePair struct {
+		from, to       string
+		amount         int64
+		hasFrom, hasTo bool
+	}
+	stakes := map[string]*stakePair{}
+	edges := map[string]int64{}
+
+	for _, r := range records {
+		if r.Asset == AssetDelegation {
+			continue // already-migrated / post-activation edge rows — never re-count
+		}
+		base, suffix := splitLedgerBaseId(r.Id)
+		switch r.Type {
+		case "consensus_stake":
+			p := stakes[base]
+			if p == nil {
+				p = &stakePair{}
+				stakes[base] = p
+			}
+			switch suffix {
+			case "in": // Owner = delegator (from), amount negative
+				p.from = r.Owner
+				p.hasFrom = true
+			case "out": // Owner = node (to), amount positive — authoritative magnitude
+				p.to = r.Owner
+				p.amount = r.Amount
+				p.hasTo = true
+			}
+		case "consensus_unstake":
+			// Legacy unstake: a single "#in" row debits the bond holder's
+			// hive_consensus (Owner = node, from == to). Reduce that self-edge.
+			if suffix == "in" {
+				edges[DelegationEdgeKey(r.Owner, r.Owner)] += r.Amount // r.Amount < 0
+			}
+		}
+	}
+
+	for _, p := range stakes {
+		if p.hasFrom && p.hasTo {
+			edges[DelegationEdgeKey(p.from, p.to)] += p.amount
+		}
+	}
+
+	keys := make([]string, 0, len(edges))
+	for k := range edges {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys) // deterministic output order
+
+	out := make([]LedgerUpdate, 0, len(keys))
+	for _, k := range keys {
+		if edges[k] <= 0 {
+			continue // nothing reclaimable on this edge
+		}
+		out = append(out, LedgerUpdate{
+			Id:          "delegation_backfill:" + k,
+			Owner:       k,
+			Amount:      edges[k],
+			Asset:       AssetDelegation,
+			Type:        "consensus_stake",
+			BlockHeight: atHeight,
+		})
+	}
+	return out
+}
+
+// splitLedgerBaseId strips a single trailing "#segment" (e.g. "#in", "#out",
+// "#edge") from a ledger record id, returning the base id and the segment
+// (without the "#"). Ids may carry an idCache ":N" suffix on the base, which is
+// preserved on the base side. Returns ("", "") inputs unchanged-ish for ids with
+// no "#".
+func splitLedgerBaseId(id string) (base, suffix string) {
+	i := strings.LastIndex(id, "#")
+	if i < 0 {
+		return id, ""
+	}
+	return id[:i], id[i+1:]
+}

--- a/modules/ledger-system/delegation_migration.go
+++ b/modules/ledger-system/delegation_migration.go
@@ -129,6 +129,76 @@ func splitDelegationEdgeKey(key string) (from, to string) {
 	return parts[0], parts[1]
 }
 
+// Delegation-migration marker: a single ledger row written when the one-time
+// backfill completes. Its presence means "already migrated" — also true for a
+// node restored from a post-activation state snapshot, so the migration is
+// correctly skipped there.
+const (
+	delegationMigrationAccount  = "system:delegation_migration"
+	delegationMigrationAsset    = "delegation_migration"
+	delegationMigrationMarkerID = "delegation_migration_done"
+)
+
+// MigrateDelegationEdgesOnce backfills per-delegator delegation edges from the
+// full consensus stake/unstake history, exactly once, at consensus-0.5.0
+// activation. The caller MUST gate on delegatedStakeActive(blockHeight) and run
+// it BEFORE the slot's transactions execute (so a delegated unstake in the
+// activation slot sees its edge). Idempotent: a persisted marker short-circuits
+// re-runs, and even without it BackfillDelegationEdges ignores already-seeded
+// AssetDelegation/Total rows and StoreLedger upserts by deterministic Id, so a
+// crash mid-store re-converges. Deterministic: same canonical ledger -> same
+// edges on every node. Returns the number of edges seeded.
+func (ls *ledgerSystem) MigrateDelegationEdgesOnce(blockHeight uint64) int {
+	if ls.LedgerDb == nil {
+		return 0
+	}
+	// Already migrated? (marker present, or restored from a post-activation snapshot)
+	if marker, _ := ls.LedgerDb.GetLedgerRange(
+		delegationMigrationAccount, 0, blockHeight, delegationMigrationAsset,
+	); marker != nil && len(*marker) > 0 {
+		return 0
+	}
+
+	records, err := ls.LedgerDb.GetLedgerRecordsByType(
+		[]string{"consensus_stake", "consensus_unstake"}, blockHeight)
+	if err != nil {
+		return 0 // transient read failure — retried next slot (marker still absent)
+	}
+
+	edges := BackfillDelegationEdges(records, blockHeight)
+
+	seeded := 0
+	out := make([]ledgerDb.LedgerRecord, 0, len(edges)+1)
+	for _, e := range edges {
+		if e.Asset == AssetDelegation {
+			seeded++ // count per-edge rows only (not the per-node total rows)
+		}
+		out = append(out, ledgerDb.LedgerRecord{
+			Id:          e.Id,
+			Owner:       e.Owner,
+			Amount:      e.Amount,
+			Asset:       e.Asset,
+			Type:        e.Type,
+			BlockHeight: e.BlockHeight,
+		})
+	}
+	// Marker row (Amount = activation height, for audit). Written in the same
+	// StoreLedger so it lands with the edges.
+	out = append(out, ledgerDb.LedgerRecord{
+		Id:          delegationMigrationMarkerID,
+		Owner:       delegationMigrationAccount,
+		Amount:      int64(blockHeight),
+		Asset:       delegationMigrationAsset,
+		Type:        delegationMigrationAsset,
+		BlockHeight: blockHeight,
+	})
+
+	if err := ls.LedgerDb.StoreLedger(out...); err != nil {
+		return 0 // store failed — marker absent, retried next slot
+	}
+	return seeded
+}
+
 // splitLedgerBaseId strips a single trailing "#segment" (e.g. "#in", "#out",
 // "#edge") from a ledger record id, returning the base id and the segment
 // (without the "#"). Ids may carry an idCache ":N" suffix on the base, which is

--- a/modules/ledger-system/delegation_migration_test.go
+++ b/modules/ledger-system/delegation_migration_test.go
@@ -31,17 +31,28 @@ func TestBackfillDelegationEdges(t *testing.T) {
 
 	out := BackfillDelegationEdges(records, 999)
 
-	got := map[string]int64{}
+	edge := map[string]int64{}
+	total := map[string]int64{}
 	for _, r := range out {
-		assert.Equal(t, AssetDelegation, r.Asset)
 		assert.Equal(t, uint64(999), r.BlockHeight)
-		got[r.Owner] = r.Amount
+		switch r.Asset {
+		case AssetDelegation:
+			edge[r.Owner] = r.Amount
+		case AssetDelegationTotal:
+			total[r.Owner] = r.Amount
+		default:
+			t.Fatalf("unexpected asset %q in backfill output", r.Asset)
+		}
 	}
 
-	assert.Equal(t, int64(10000), got[DelegationEdgeKey(userA, opB)], "userA->operatorB delegation reclaimable")
-	assert.Equal(t, int64(5000), got[DelegationEdgeKey(userC, opB)], "userC->operatorB delegation reclaimable")
-	assert.Equal(t, int64(2000), got[DelegationEdgeKey(opB, opB)], "operatorB self-edge net of its legacy unstake")
-	assert.Len(t, out, 3, "exactly three positive edges")
+	assert.Equal(t, int64(10000), edge[DelegationEdgeKey(userA, opB)], "userA->operatorB delegation reclaimable")
+	assert.Equal(t, int64(5000), edge[DelegationEdgeKey(userC, opB)], "userC->operatorB delegation reclaimable")
+	assert.Equal(t, int64(2000), edge[DelegationEdgeKey(opB, opB)], "operatorB self-edge net of its legacy unstake")
+	assert.Len(t, edge, 3, "exactly three positive edges")
+
+	// Gross per-node total (slash-immune) = sum of all edges to operatorB.
+	assert.Equal(t, int64(17000), total[opB], "operatorB gross delegated total = 10000+5000+2000")
+	assert.Len(t, total, 1, "one node total")
 
 	// Idempotency: re-running over output (AssetDelegation rows) must seed nothing.
 	asDelegationRecords := make([]ledgerDb.LedgerRecord, 0, len(out))

--- a/modules/ledger-system/delegation_migration_test.go
+++ b/modules/ledger-system/delegation_migration_test.go
@@ -1,0 +1,70 @@
+package ledgerSystem
+
+import (
+	"testing"
+
+	ledgerDb "vsc-node/modules/db/vsc/ledger"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackfillDelegationEdges(t *testing.T) {
+	const userA = "hive:usera"
+	const userC = "hive:userc"
+	const opB = "hive:operatorb"
+
+	// Historical records (pre-0.5.0): each stake is an #in/#out pair sharing a
+	// base id; a legacy unstake is a lone #in on the node's own bond.
+	records := []ledgerDb.LedgerRecord{
+		// userA delegated 10.000 to operatorB
+		{Id: "tx1#in", Owner: userA, Amount: -10000, Asset: "hive", Type: "consensus_stake"},
+		{Id: "tx1#out", Owner: opB, Amount: 10000, Asset: "hive_consensus", Type: "consensus_stake"},
+		// userC delegated 5.000 to operatorB
+		{Id: "tx2#in", Owner: userC, Amount: -5000, Asset: "hive", Type: "consensus_stake"},
+		{Id: "tx2#out", Owner: opB, Amount: 5000, Asset: "hive_consensus", Type: "consensus_stake"},
+		// operatorB self-staked 3.000 ...
+		{Id: "tx3#in", Owner: opB, Amount: -3000, Asset: "hive", Type: "consensus_stake"},
+		{Id: "tx3#out", Owner: opB, Amount: 3000, Asset: "hive_consensus", Type: "consensus_stake"},
+		// ... then legacy-unstaked 1.000 of its own
+		{Id: "tx4#in", Owner: opB, Amount: -1000, Asset: "hive_consensus", Type: "consensus_unstake"},
+	}
+
+	out := BackfillDelegationEdges(records, 999)
+
+	got := map[string]int64{}
+	for _, r := range out {
+		assert.Equal(t, AssetDelegation, r.Asset)
+		assert.Equal(t, uint64(999), r.BlockHeight)
+		got[r.Owner] = r.Amount
+	}
+
+	assert.Equal(t, int64(10000), got[DelegationEdgeKey(userA, opB)], "userA->operatorB delegation reclaimable")
+	assert.Equal(t, int64(5000), got[DelegationEdgeKey(userC, opB)], "userC->operatorB delegation reclaimable")
+	assert.Equal(t, int64(2000), got[DelegationEdgeKey(opB, opB)], "operatorB self-edge net of its legacy unstake")
+	assert.Len(t, out, 3, "exactly three positive edges")
+
+	// Idempotency: re-running over output (AssetDelegation rows) must seed nothing.
+	asDelegationRecords := make([]ledgerDb.LedgerRecord, 0, len(out))
+	for _, u := range out {
+		asDelegationRecords = append(asDelegationRecords, ledgerDb.LedgerRecord{
+			Id: u.Id, Owner: u.Owner, Amount: u.Amount, Asset: u.Asset, Type: u.Type,
+		})
+	}
+	assert.Empty(t, BackfillDelegationEdges(asDelegationRecords, 1000),
+		"already-migrated delegation rows must never be re-counted")
+}
+
+func TestSplitLedgerBaseId(t *testing.T) {
+	b, s := splitLedgerBaseId("tx1#in")
+	assert.Equal(t, "tx1", b)
+	assert.Equal(t, "in", s)
+
+	// idCache ":N" suffix on the base is preserved.
+	b, s = splitLedgerBaseId("tx1:2#out")
+	assert.Equal(t, "tx1:2", b)
+	assert.Equal(t, "out", s)
+
+	b, s = splitLedgerBaseId("noseparator")
+	assert.Equal(t, "noseparator", b)
+	assert.Equal(t, "", s)
+}

--- a/modules/ledger-system/delegation_rewards.go
+++ b/modules/ledger-system/delegation_rewards.go
@@ -1,0 +1,67 @@
+package ledgerSystem
+
+import ledgerDb "vsc-node/modules/db/vsc/ledger"
+
+// groupDelegationEdges is the pure core of AllDelegationEdges: it folds raw
+// consensus stake/unstake ledger records into node -> (delegator -> net stake),
+// keeping only strictly-positive net edges. Only AssetDelegation rows
+// contribute; the gross AssetDelegationTotal rows and the plain hive /
+// hive_consensus legs are ignored. Order-independent (summation), so the result
+// is identical regardless of record order — the determinism the settlement
+// reward split relies on.
+func groupDelegationEdges(records []ledgerDb.LedgerRecord) map[string]map[string]int64 {
+	net := map[string]int64{}
+	for _, r := range records {
+		if r.Asset != AssetDelegation {
+			continue
+		}
+		net[r.Owner] += r.Amount
+	}
+
+	out := make(map[string]map[string]int64)
+	for key, amt := range net {
+		if amt <= 0 {
+			continue
+		}
+		from, to := splitDelegationEdgeKey(key)
+		if from == "" || to == "" {
+			continue
+		}
+		edges := out[to]
+		if edges == nil {
+			edges = make(map[string]int64)
+			out[to] = edges
+		}
+		edges[from] = amt
+	}
+	return out
+}
+
+// AllDelegationEdges returns every node's positive consensus-delegation edges as
+// of blockHeight: node account -> (delegator account -> net HIVE delegated on
+// that edge). Both keys are in the "hive:" form the stake ops use; the
+// operator's own self-stake appears as the edge node -> node.
+//
+// It is built from a single scan of the consensus stake/unstake ledger (the
+// same canonical source the 0.5.0 migration pairs edges from), summing the
+// virtual AssetDelegation rows per composite owner. Because that ledger is
+// identical on every node and summation is order-independent, two honest nodes
+// at the same height produce a byte-identical map — a hard requirement, since
+// this drives the pendulum reward split baked into the attested settlement
+// record. Only strictly-positive net edges are kept (a fully-unstaked edge is
+// dropped).
+//
+// Returns ok=false on a transient ledger read error so callers fail-stop (the
+// settlement producer aborts; re-derivation falls back to structural checks)
+// rather than distribute rewards against a partial view.
+func (ls *ledgerSystem) AllDelegationEdges(blockHeight uint64) (map[string]map[string]int64, bool) {
+	if ls.LedgerDb == nil {
+		return nil, false
+	}
+	records, err := ls.LedgerDb.GetLedgerRecordsByType(
+		[]string{"consensus_stake", "consensus_unstake"}, blockHeight)
+	if err != nil {
+		return nil, false
+	}
+	return groupDelegationEdges(records), true
+}

--- a/modules/ledger-system/delegation_rewards_test.go
+++ b/modules/ledger-system/delegation_rewards_test.go
@@ -1,0 +1,61 @@
+package ledgerSystem
+
+import (
+	"testing"
+
+	ledgerDb "vsc-node/modules/db/vsc/ledger"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGroupDelegationEdges(t *testing.T) {
+	const userA = "hive:usera"
+	const userC = "hive:userc"
+	const opB = "hive:operatorb"
+	const opD = "hive:operatord"
+
+	records := []ledgerDb.LedgerRecord{
+		// userA -> opB: stake 10.000 then unstake 4.000 → net 6.000
+		{Id: "s1#edge", Owner: DelegationEdgeKey(userA, opB), Amount: 10000, Asset: AssetDelegation, Type: "consensus_stake"},
+		{Id: "u1#edge", Owner: DelegationEdgeKey(userA, opB), Amount: -4000, Asset: AssetDelegation, Type: "consensus_unstake"},
+		// userC -> opB: 5.000
+		{Id: "s2#edge", Owner: DelegationEdgeKey(userC, opB), Amount: 5000, Asset: AssetDelegation, Type: "consensus_stake"},
+		// opB self-edge: 3.000
+		{Id: "s3#edge", Owner: DelegationEdgeKey(opB, opB), Amount: 3000, Asset: AssetDelegation, Type: "consensus_stake"},
+		// userA -> opD: staked 2.000 then fully unstaked → net 0, dropped
+		{Id: "s4#edge", Owner: DelegationEdgeKey(userA, opD), Amount: 2000, Asset: AssetDelegation, Type: "consensus_stake"},
+		{Id: "u4#edge", Owner: DelegationEdgeKey(userA, opD), Amount: -2000, Asset: AssetDelegation, Type: "consensus_unstake"},
+
+		// Noise that must be ignored: the plain hive/hive_consensus legs and the
+		// gross per-node total rows of the same ops.
+		{Id: "s1#in", Owner: userA, Amount: -10000, Asset: "hive", Type: "consensus_stake"},
+		{Id: "s1#out", Owner: opB, Amount: 10000, Asset: "hive_consensus", Type: "consensus_stake"},
+		{Id: "s1#total", Owner: opB, Amount: 10000, Asset: AssetDelegationTotal, Type: "consensus_stake"},
+	}
+
+	edges := groupDelegationEdges(records)
+
+	// opB has three positive edges; opD has none (fully unstaked).
+	assert.Len(t, edges, 1, "only opB should have positive edges")
+	assert.NotContains(t, edges, opD, "fully-unstaked node must be absent")
+
+	opBEdges := edges[opB]
+	assert.Equal(t, int64(6000), opBEdges[userA], "userA net after partial unstake")
+	assert.Equal(t, int64(5000), opBEdges[userC], "userC full stake")
+	assert.Equal(t, int64(3000), opBEdges[opB], "operator self-edge")
+	assert.Len(t, opBEdges, 3, "exactly three delegators (incl. operator self)")
+
+	// Sum of edges = the share-split denominator.
+	var total int64
+	for _, s := range opBEdges {
+		total += s
+	}
+	assert.Equal(t, int64(14000), total, "denominator = 6000+5000+3000")
+}
+
+func TestGroupDelegationEdges_Empty(t *testing.T) {
+	assert.Empty(t, groupDelegationEdges(nil))
+	assert.Empty(t, groupDelegationEdges([]ledgerDb.LedgerRecord{
+		{Id: "x#in", Owner: "hive:a", Amount: -1, Asset: "hive", Type: "consensus_stake"},
+	}), "no AssetDelegation rows → no edges")
+}

--- a/modules/ledger-system/invariant_test.go
+++ b/modules/ledger-system/invariant_test.go
@@ -110,6 +110,7 @@ func (m *mockLedgerSystem) SafetySlashConsensusBond(p ledgerSystem.SafetySlashCo
 }
 
 func (m *mockLedgerSystem) FinalizeMaturedSafetySlashBurns(blockHeight uint64) { _ = blockHeight }
+func (m *mockLedgerSystem) MigrateDelegationEdgesOnce(blockHeight uint64) int  { return 0 }
 
 func (m *mockLedgerSystem) CancelPendingSafetySlashBurn(p ledgerSystem.CancelPendingSafetySlashBurnParams) ledgerSystem.LedgerResult {
 	_ = p

--- a/modules/ledger-system/invariant_test.go
+++ b/modules/ledger-system/invariant_test.go
@@ -111,6 +111,9 @@ func (m *mockLedgerSystem) SafetySlashConsensusBond(p ledgerSystem.SafetySlashCo
 
 func (m *mockLedgerSystem) FinalizeMaturedSafetySlashBurns(blockHeight uint64) { _ = blockHeight }
 func (m *mockLedgerSystem) MigrateDelegationEdgesOnce(blockHeight uint64) int  { return 0 }
+func (m *mockLedgerSystem) AllDelegationEdges(blockHeight uint64) (map[string]map[string]int64, bool) {
+	return nil, true
+}
 
 func (m *mockLedgerSystem) CancelPendingSafetySlashBurn(p ledgerSystem.CancelPendingSafetySlashBurnParams) ledgerSystem.LedgerResult {
 	_ = p

--- a/modules/ledger-system/ledger_session.go
+++ b/modules/ledger-system/ledger_session.go
@@ -1,6 +1,7 @@
 package ledgerSystem
 
 import (
+	"math/big"
 	"regexp"
 	"slices"
 	"strconv"
@@ -301,19 +302,24 @@ func (ledgerSession *ledgerSession) ConsensusUnstake(params ConsensusParams) Led
 		}
 	}
 
+	// released is the HIVE that actually leaves the bond / returns to the
+	// delegator. In the legacy path it equals the gross amount; in the delegated
+	// path a slash on the node reduces it pro-rata (see slashAdjustedRelease).
+	released := params.Amount
+
 	if params.Delegated {
-		// Authorize against the SIGNER's own delegation edge. The node operator
-		// has no edge to a delegator's stake, so it can never unstake it — only
-		// what it itself delegated (its self-edge from==to).
+		// Authorize against the SIGNER's own delegation edge (GROSS). The node
+		// operator has no edge to a delegator's stake, so it can never unstake it
+		// — only what it itself delegated (its self-edge from==to).
 		edge := ledgerSession.GetBalance(
 			DelegationEdgeKey(params.From, params.To), params.BlockHeight, AssetDelegation)
-		claimable := ledgerSession.applySlashHaircut(params.From, params.To, edge, params.BlockHeight)
-		if params.Amount > claimable {
+		if params.Amount > edge {
 			return LedgerResult{
 				Ok:  false,
 				Msg: "amount exceeds delegated stake",
 			}
 		}
+		released = ledgerSession.slashAdjustedRelease(params.Amount, params.To, params.BlockHeight)
 	} else {
 		// Legacy era (< 0.5.0): debit the signer's own hive_consensus.
 		balAmt := ledgerSession.GetBalance(params.From, params.BlockHeight, "hive_consensus")
@@ -338,6 +344,7 @@ func (ledgerSession *ledgerSession) ConsensusUnstake(params ConsensusParams) Led
 		Params: map[string]interface{}{
 			"epoch":     params.ElectionEpoch,
 			"delegated": params.Delegated,
+			"released":  released,
 		},
 	})
 
@@ -347,18 +354,33 @@ func (ledgerSession *ledgerSession) ConsensusUnstake(params ConsensusParams) Led
 	}
 }
 
-// applySlashHaircut caps a delegator's reclaimable stake on a slashed node.
+// slashAdjustedRelease returns the HIVE actually released for a delegated
+// unstake of grossAmount from node `to`, applying the team's slashing policy:
+// EVERY delegator to a slashed node loses the same fraction.
 //
-// ‹Q1 — OPEN: slashing loss attribution› Until the team decides how a slash is
-// shared (operator-only / pro-rata / first-come — see the design spec), this is
-// a no-op returning the full edge. That is correct as long as a slash never
-// drops a node's hive_consensus below the sum of its delegation edges. Once
-// consensus slashing can do that on a delegated network, this MUST implement the
-// chosen rule (e.g. floor(edge * hive_consensus[to] / Σ edges[*][to])), or an
-// unstake could over-draw a slashed node's bond. DO NOT enable consensus
-// slashing on a delegated-stake network before resolving this.
-func (ledgerSession *ledgerSession) applySlashHaircut(from, to string, edge int64, blockHeight uint64) int64 {
-	return edge
+// ‹Q1 — RESOLVED: pro-rata› The node's gross delegated total (AssetDelegationTotal)
+// is slash-immune; its hive_consensus bond is reduced by slashing. So bond/total
+// is the node's post-slash solvency ratio in [0,1], and released =
+// floor(grossAmount * bond / total). Because the edge + gross total drain by the
+// GROSS amount (not released), the ratio stays constant as delegators exit, so
+// the outcome is identical regardless of unstake order — i.e. everyone is slashed
+// equally. Unslashed (bond >= total) returns the full grossAmount unchanged.
+func (ledgerSession *ledgerSession) slashAdjustedRelease(grossAmount int64, to string, blockHeight uint64) int64 {
+	if grossAmount <= 0 {
+		return 0
+	}
+	total := ledgerSession.GetBalance(to, blockHeight, AssetDelegationTotal)
+	bond := ledgerSession.GetBalance(to, blockHeight, "hive_consensus")
+	if total <= 0 || bond >= total {
+		return grossAmount // unslashed / fully solvent → no haircut
+	}
+	if bond <= 0 {
+		return 0 // node fully slashed — nothing to return
+	}
+	// released = floor(grossAmount * bond / total), overflow-safe via big.Int.
+	num := new(big.Int).Mul(big.NewInt(grossAmount), big.NewInt(bond))
+	num.Div(num, big.NewInt(total))
+	return num.Int64()
 }
 
 func (ledgerSession *ledgerSession) ExecuteTransfer(opLogEvent OpLogEvent, options ...TransferOptions) LedgerResult {

--- a/modules/ledger-system/ledger_session.go
+++ b/modules/ledger-system/ledger_session.go
@@ -273,7 +273,7 @@ func (ledgerSession *ledgerSession) ConsensusStake(params ConsensusParams) Ledge
 		}
 	}
 
-	ledgerSession.AppendOplog(OpLogEvent{
+	stakeEvent := OpLogEvent{
 		Id:          params.Id,
 		From:        params.From,
 		To:          params.To,
@@ -282,11 +282,15 @@ func (ledgerSession *ledgerSession) ConsensusStake(params ConsensusParams) Ledge
 		Amount: params.Amount,
 		Asset:  "hive",
 		Type:   "consensus_stake",
-
-		Params: map[string]interface{}{
-			"delegated": params.Delegated,
-		},
-	})
+	}
+	// CONSENSUS-CRITICAL: the oplog (incl. Params) is CBOR-encoded into the L2
+	// oplog block CID (block-producer MakeOplog), so Params must be byte-identical
+	// to pre-0.5.0 on the legacy path or old/new nodes fork. Legacy consensus_stake
+	// carried NO Params — only stamp the delegated flag when actually delegated.
+	if params.Delegated {
+		stakeEvent.Params = map[string]interface{}{"delegated": true}
+	}
+	ledgerSession.AppendOplog(stakeEvent)
 
 	return LedgerResult{
 		Ok:  true,
@@ -331,6 +335,14 @@ func (ledgerSession *ledgerSession) ConsensusUnstake(params ConsensusParams) Led
 		}
 	}
 
+	// CONSENSUS-CRITICAL (see ConsensusStake): keep the legacy oplog Params
+	// byte-identical. Legacy consensus_unstake carried ONLY {epoch}; the
+	// delegated/released keys are added solely on the delegated path (0.5.0+).
+	unstakeParams := map[string]interface{}{"epoch": params.ElectionEpoch}
+	if params.Delegated {
+		unstakeParams["delegated"] = true
+		unstakeParams["released"] = released
+	}
 	ledgerSession.AppendOplog(OpLogEvent{
 		Id:          params.Id,
 		To:          params.To,
@@ -341,11 +353,7 @@ func (ledgerSession *ledgerSession) ConsensusUnstake(params ConsensusParams) Led
 		Asset:  "hive",
 		Type:   "consensus_unstake",
 
-		Params: map[string]interface{}{
-			"epoch":     params.ElectionEpoch,
-			"delegated": params.Delegated,
-			"released":  released,
-		},
+		Params: unstakeParams,
 	})
 
 	return LedgerResult{

--- a/modules/ledger-system/ledger_session.go
+++ b/modules/ledger-system/ledger_session.go
@@ -281,6 +281,10 @@ func (ledgerSession *ledgerSession) ConsensusStake(params ConsensusParams) Ledge
 		Amount: params.Amount,
 		Asset:  "hive",
 		Type:   "consensus_stake",
+
+		Params: map[string]interface{}{
+			"delegated": params.Delegated,
+		},
 	})
 
 	return LedgerResult{
@@ -297,12 +301,27 @@ func (ledgerSession *ledgerSession) ConsensusUnstake(params ConsensusParams) Led
 		}
 	}
 
-	balAmt := ledgerSession.GetBalance(params.From, params.BlockHeight, "hive_consensus")
-
-	if balAmt < params.Amount {
-		return LedgerResult{
-			Ok:  false,
-			Msg: "insufficient balance",
+	if params.Delegated {
+		// Authorize against the SIGNER's own delegation edge. The node operator
+		// has no edge to a delegator's stake, so it can never unstake it — only
+		// what it itself delegated (its self-edge from==to).
+		edge := ledgerSession.GetBalance(
+			DelegationEdgeKey(params.From, params.To), params.BlockHeight, AssetDelegation)
+		claimable := ledgerSession.applySlashHaircut(params.From, params.To, edge, params.BlockHeight)
+		if params.Amount > claimable {
+			return LedgerResult{
+				Ok:  false,
+				Msg: "amount exceeds delegated stake",
+			}
+		}
+	} else {
+		// Legacy era (< 0.5.0): debit the signer's own hive_consensus.
+		balAmt := ledgerSession.GetBalance(params.From, params.BlockHeight, "hive_consensus")
+		if balAmt < params.Amount {
+			return LedgerResult{
+				Ok:  false,
+				Msg: "insufficient balance",
+			}
 		}
 	}
 
@@ -317,7 +336,8 @@ func (ledgerSession *ledgerSession) ConsensusUnstake(params ConsensusParams) Led
 		Type:   "consensus_unstake",
 
 		Params: map[string]interface{}{
-			"epoch": params.ElectionEpoch,
+			"epoch":     params.ElectionEpoch,
+			"delegated": params.Delegated,
 		},
 	})
 
@@ -325,6 +345,20 @@ func (ledgerSession *ledgerSession) ConsensusUnstake(params ConsensusParams) Led
 		Ok:  true,
 		Msg: "success",
 	}
+}
+
+// applySlashHaircut caps a delegator's reclaimable stake on a slashed node.
+//
+// ‹Q1 — OPEN: slashing loss attribution› Until the team decides how a slash is
+// shared (operator-only / pro-rata / first-come — see the design spec), this is
+// a no-op returning the full edge. That is correct as long as a slash never
+// drops a node's hive_consensus below the sum of its delegation edges. Once
+// consensus slashing can do that on a delegated network, this MUST implement the
+// chosen rule (e.g. floor(edge * hive_consensus[to] / Σ edges[*][to])), or an
+// unstake could over-draw a slashed node's bond. DO NOT enable consensus
+// slashing on a delegated-stake network before resolving this.
+func (ledgerSession *ledgerSession) applySlashHaircut(from, to string, edge int64, blockHeight uint64) int64 {
+	return edge
 }
 
 func (ledgerSession *ledgerSession) ExecuteTransfer(opLogEvent OpLogEvent, options ...TransferOptions) LedgerResult {

--- a/modules/ledger-system/ledger_state.go
+++ b/modules/ledger-system/ledger_state.go
@@ -220,7 +220,31 @@ func (ls *LedgerState) GetBalance(account string, blockHeight uint64, asset stri
 	case "hbd_savings":
 		base = balRecord.HBD_SAVINGS
 	case "hive_consensus":
+		// Develop's CRIT-1 path: take the snapshot bond as the base and fall
+		// through to the general sum-all-records-minus-meta fold below, which
+		// nets consensus_stake/unstake and the safety-slash debit/re-credit rows
+		// (none of which are protocol-meta) — superseding the older explicit
+		// OpType allow-list while keeping the same result.
 		base = balRecord.HIVE_CONSENSUS
+	case AssetDelegation:
+		// Per-edge delegation balance (consensus 0.5.0+). `account` is the composite
+		// owner DelegationEdgeKey(from,to); net = Σ consensus_stake − Σ consensus_unstake
+		// on that edge. Always summed from height 0: composite owners are never
+		// snapshotted into a BalanceRecord (no typed column), so there is no base to add.
+		ledgerResults, _ := ls.LedgerDb.GetLedgerRange(
+			account,
+			0,
+			blockHeight,
+			asset,
+			ledger_db.LedgerOptions{
+				OpType: []string{"consensus_stake", "consensus_unstake"},
+			},
+		)
+		balAdjust := int64(0)
+		for _, v := range *ledgerResults {
+			balAdjust += v.Amount
+		}
+		return balAdjust
 	default:
 		return 0
 	}

--- a/modules/ledger-system/ledger_state.go
+++ b/modules/ledger-system/ledger_state.go
@@ -226,11 +226,14 @@ func (ls *LedgerState) GetBalance(account string, blockHeight uint64, asset stri
 		// (none of which are protocol-meta) — superseding the older explicit
 		// OpType allow-list while keeping the same result.
 		base = balRecord.HIVE_CONSENSUS
-	case AssetDelegation:
-		// Per-edge delegation balance (consensus 0.5.0+). `account` is the composite
-		// owner DelegationEdgeKey(from,to); net = Σ consensus_stake − Σ consensus_unstake
-		// on that edge. Always summed from height 0: composite owners are never
-		// snapshotted into a BalanceRecord (no typed column), so there is no base to add.
+	case AssetDelegation, AssetDelegationTotal:
+		// Virtual delegation balances (consensus 0.5.0+):
+		//   AssetDelegation      — `account` is DelegationEdgeKey(from,to); net of
+		//                          consensus_stake/unstake on that edge.
+		//   AssetDelegationTotal — `account` is the node; gross sum of edges to it,
+		//                          NOT reduced by slashing (bond/total = solvency).
+		// Both always summed from height 0: their owners are never snapshotted into
+		// a BalanceRecord (no typed column), so there is no base to add.
 		ledgerResults, _ := ls.LedgerDb.GetLedgerRange(
 			account,
 			0,

--- a/modules/ledger-system/types.go
+++ b/modules/ledger-system/types.go
@@ -253,6 +253,11 @@ type LedgerSystem interface {
 	// consensus-0.5.0 activation. Caller gates on delegatedStakeActive. Returns
 	// the number of edges seeded (0 if already migrated / no history).
 	MigrateDelegationEdgesOnce(blockHeight uint64) int
+	// AllDelegationEdges returns every node's positive consensus-delegation
+	// edges as of blockHeight: node -> (delegator -> net HIVE delegated), both
+	// in "hive:" form, from a single deterministic ledger scan. ok=false on a
+	// transient read error. Drives the share-mode pendulum reward split.
+	AllDelegationEdges(blockHeight uint64) (map[string]map[string]int64, bool)
 	// CancelPendingSafetySlashBurn cancels a pending burn slice before maturity.
 	// Idempotent: if the (TxID, EvidenceKind) row is missing, finalized, or
 	// already cancelled, returns Ok=false with a descriptive Msg but does not

--- a/modules/ledger-system/types.go
+++ b/modules/ledger-system/types.go
@@ -248,6 +248,11 @@ type LedgerSystem interface {
 	PendulumDistribute(toAccount string, amount int64, txID string, blockHeight uint64) LedgerResult
 	SafetySlashConsensusBond(p SafetySlashConsensusParams) LedgerResult
 	FinalizeMaturedSafetySlashBurns(blockHeight uint64)
+	// MigrateDelegationEdgesOnce backfills per-delegator consensus-stake edges
+	// from history exactly once (idempotent via a persisted marker), at the
+	// consensus-0.5.0 activation. Caller gates on delegatedStakeActive. Returns
+	// the number of edges seeded (0 if already migrated / no history).
+	MigrateDelegationEdgesOnce(blockHeight uint64) int
 	// CancelPendingSafetySlashBurn cancels a pending burn slice before maturity.
 	// Idempotent: if the (TxID, EvidenceKind) row is missing, finalized, or
 	// already cancelled, returns Ok=false with a descriptive Msg but does not

--- a/modules/ledger-system/types.go
+++ b/modules/ledger-system/types.go
@@ -57,6 +57,13 @@ type ConsensusParams struct {
 	Type          string
 	BlockHeight   uint64
 	ElectionEpoch uint64
+	// Delegated selects per-edge delegation semantics (consensus 0.5.0+). Set by
+	// the caller from StateEngine.delegatedStakeActive(blockHeight). When true,
+	// stake records a from->to edge and unstake authorizes against the signer's
+	// edge + debits the node bond; when false, the legacy hive_consensus-holder
+	// path runs unchanged. Carried through into the OpLogEvent so the (pure)
+	// record builder stays deterministic.
+	Delegated bool
 }
 
 // SafetySlashConsensusParams debits HIVE_CONSENSUS principal for provable safety faults.

--- a/modules/ledger-system/utils.go
+++ b/modules/ledger-system/utils.go
@@ -6,7 +6,39 @@ import (
 )
 
 var transferableAssetTypes = []string{"hive", "hbd", "hbd_savings"}
-var assetTypes = slices.Concat(transferableAssetTypes, []string{"hive_consensus"})
+
+// AssetDelegation is a virtual (non-transferable) per-edge balance: the net HIVE a
+// delegator has consensus-staked to a specific node, keyed by a composite owner
+// (see DelegationEdgeKey). It reuses the normal balance machinery (GetBalance /
+// snapshot / in-session cache); it is NOT a real spendable asset. Consensus 0.5.0+.
+const AssetDelegation = "delegation"
+
+// delegationEdgeSep separates from/to in a delegation edge owner key. A single ":"
+// appears inside normalized accounts ("hive:alice"), so "::" is used as the joiner
+// and cannot occur inside either side.
+const delegationEdgeSep = "::"
+
+var assetTypes = slices.Concat(transferableAssetTypes, []string{"hive_consensus", AssetDelegation})
+
+// DelegationEdgeKey returns the composite owner key for the (from -> to) delegation
+// edge: the net stake `from` has delegated to node `to`. Read it with
+// GetBalance(DelegationEdgeKey(from, to), height, AssetDelegation).
+func DelegationEdgeKey(from, to string) string {
+	return from + delegationEdgeSep + to
+}
+
+// opDelegated reports whether an oplog event was stamped with delegated-mode
+// semantics. The flag is set by ConsensusStake/ConsensusUnstake from the
+// version gate (StateEngine.delegatedStakeActive) at the moment the op is
+// applied, so ExecuteOplog — a pure function of the oplog — stays deterministic
+// and consensus-gated without needing the election DB itself.
+func opDelegated(v OpLogEvent) bool {
+	if v.Params == nil {
+		return false
+	}
+	d, _ := v.Params["delegated"].(bool)
+	return d
+}
 
 const ETH_REGEX = "^0x[a-fA-F0-9]{40}$"
 const HIVE_REGEX = `^[a-z][0-9a-z\-]*[0-9a-z](\.[a-z][0-9a-z\-]*[0-9a-z])*$`
@@ -152,6 +184,10 @@ func ExecuteOplog(oplog []OpLogEvent, startHeight uint64, endBlock uint64) struc
 			})
 		}
 		if v.Type == "consensus_stake" {
+			// Debit the staker's spendable hive; credit the node's aggregate
+			// hive_consensus bond (unchanged in both eras — the node bond still
+			// feeds election weight + pendulum). affectedAccounts intentionally
+			// untouched, matching the legacy consensus path.
 			ledgerRecords = append(ledgerRecords, LedgerUpdate{
 				Id:          v.Id + "#in",
 				BlockHeight: endBlock,
@@ -168,31 +204,82 @@ func ExecuteOplog(oplog []OpLogEvent, startHeight uint64, endBlock uint64) struc
 				Owner:       v.To,
 				Type:        "consensus_stake",
 			})
+			if opDelegated(v) {
+				// Record the per-edge delegation so the delegator (and only the
+				// delegator) can reclaim it later. Composite owner from::to.
+				ledgerRecords = append(ledgerRecords, LedgerUpdate{
+					Id:          v.Id + "#edge",
+					BlockHeight: endBlock,
+					Amount:      v.Amount,
+					Asset:       AssetDelegation,
+					Owner:       DelegationEdgeKey(v.From, v.To),
+					Type:        "consensus_stake",
+				})
+			}
 		}
 		if v.Type == "consensus_unstake" {
-			ledgerRecords = append(ledgerRecords, LedgerUpdate{
-				Id:          v.Id + "#in",
-				BlockHeight: endBlock,
-				Amount:      -v.Amount,
-				Asset:       "hive_consensus",
-				Owner:       v.From,
-				Type:        "consensus_unstake",
-			})
+			if opDelegated(v) {
+				// Delegated era: debit the NODE's (v.To) bond, decrement the
+				// delegator's edge, and queue the HIVE return to the delegator
+				// (v.From) — the matured-release path credits action.To.
+				ledgerRecords = append(ledgerRecords, LedgerUpdate{
+					Id:          v.Id + "#in",
+					BlockHeight: endBlock,
+					Amount:      -v.Amount,
+					Asset:       "hive_consensus",
+					Owner:       v.To,
+					Type:        "consensus_unstake",
+				})
+				ledgerRecords = append(ledgerRecords, LedgerUpdate{
+					Id:          v.Id + "#edge",
+					BlockHeight: endBlock,
+					Amount:      -v.Amount,
+					Asset:       AssetDelegation,
+					Owner:       DelegationEdgeKey(v.From, v.To),
+					Type:        "consensus_unstake",
+				})
+				actionRecords = append(actionRecords, ledgerDb.ActionRecord{
+					Id:     v.Id,
+					Amount: v.Amount,
+					Asset:  "-",
+					To:     v.From, // release returns HIVE to the delegator
+					Memo:   v.Memo,
+					TxId:   v.Id,
+					Status: "pending",
+					Type:   "consensus_unstake",
+					Params: map[string]interface{}{
+						"epoch": v.Params["epoch"],
+						"node":  v.To,
+					},
+					BlockHeight: endBlock,
+				})
+			} else {
+				// Legacy era (< 0.5.0): unchanged — debit the signer's own bond,
+				// release returns to v.To.
+				ledgerRecords = append(ledgerRecords, LedgerUpdate{
+					Id:          v.Id + "#in",
+					BlockHeight: endBlock,
+					Amount:      -v.Amount,
+					Asset:       "hive_consensus",
+					Owner:       v.From,
+					Type:        "consensus_unstake",
+				})
 
-			actionRecords = append(actionRecords, ledgerDb.ActionRecord{
-				Id:     v.Id,
-				Amount: v.Amount,
-				Asset:  "-",
-				To:     v.To,
-				Memo:   v.Memo,
-				TxId:   v.Id,
-				Status: "pending",
-				Type:   "consensus_unstake",
-				Params: map[string]interface{}{
-					"epoch": v.Params["epoch"],
-				},
-				BlockHeight: endBlock,
-			})
+				actionRecords = append(actionRecords, ledgerDb.ActionRecord{
+					Id:     v.Id,
+					Amount: v.Amount,
+					Asset:  "-",
+					To:     v.To,
+					Memo:   v.Memo,
+					TxId:   v.Id,
+					Status: "pending",
+					Type:   "consensus_unstake",
+					Params: map[string]interface{}{
+						"epoch": v.Params["epoch"],
+					},
+					BlockHeight: endBlock,
+				})
+			}
 		}
 	}
 

--- a/modules/ledger-system/utils.go
+++ b/modules/ledger-system/utils.go
@@ -13,12 +13,19 @@ var transferableAssetTypes = []string{"hive", "hbd", "hbd_savings"}
 // snapshot / in-session cache); it is NOT a real spendable asset. Consensus 0.5.0+.
 const AssetDelegation = "delegation"
 
+// AssetDelegationTotal is the gross sum of all delegation edges to a node, keyed
+// by the node account. It moves with stake/unstake but is NEVER reduced by a
+// slash (unlike the node's hive_consensus bond), so bond/total is the node's
+// post-slash solvency ratio used to share a slash loss pro-rata across every
+// delegator equally (see slashAdjustedRelease). Consensus 0.5.0+.
+const AssetDelegationTotal = "delegation_total"
+
 // delegationEdgeSep separates from/to in a delegation edge owner key. A single ":"
 // appears inside normalized accounts ("hive:alice"), so "::" is used as the joiner
 // and cannot occur inside either side.
 const delegationEdgeSep = "::"
 
-var assetTypes = slices.Concat(transferableAssetTypes, []string{"hive_consensus", AssetDelegation})
+var assetTypes = slices.Concat(transferableAssetTypes, []string{"hive_consensus", AssetDelegation, AssetDelegationTotal})
 
 // DelegationEdgeKey returns the composite owner key for the (from -> to) delegation
 // edge: the net stake `from` has delegated to node `to`. Read it with
@@ -38,6 +45,29 @@ func opDelegated(v OpLogEvent) bool {
 	}
 	d, _ := v.Params["delegated"].(bool)
 	return d
+}
+
+// opReleased reads the slash-adjusted HIVE amount to actually return for a
+// delegated consensus_unstake (computed by ConsensusUnstake at apply time and
+// stamped into Params so ExecuteOplog stays pure/deterministic). Defaults to
+// fallback (the gross amount, i.e. no slash) when absent. Tolerant of the
+// numeric type the oplog (de)serializer produces.
+func opReleased(v OpLogEvent, fallback int64) int64 {
+	if v.Params == nil {
+		return fallback
+	}
+	switch x := v.Params["released"].(type) {
+	case int64:
+		return x
+	case float64:
+		return int64(x)
+	case uint64:
+		return int64(x)
+	case int:
+		return int64(x)
+	default:
+		return fallback
+	}
 }
 
 const ETH_REGEX = "^0x[a-fA-F0-9]{40}$"
@@ -215,17 +245,32 @@ func ExecuteOplog(oplog []OpLogEvent, startHeight uint64, endBlock uint64) struc
 					Owner:       DelegationEdgeKey(v.From, v.To),
 					Type:        "consensus_stake",
 				})
+				// Track the gross delegated total on the node (slash-immune) so a
+				// later slash can be shared pro-rata across all delegators.
+				ledgerRecords = append(ledgerRecords, LedgerUpdate{
+					Id:          v.Id + "#total",
+					BlockHeight: endBlock,
+					Amount:      v.Amount,
+					Asset:       AssetDelegationTotal,
+					Owner:       v.To,
+					Type:        "consensus_stake",
+				})
 			}
 		}
 		if v.Type == "consensus_unstake" {
 			if opDelegated(v) {
-				// Delegated era: debit the NODE's (v.To) bond, decrement the
-				// delegator's edge, and queue the HIVE return to the delegator
-				// (v.From) — the matured-release path credits action.To.
+				// Delegated era. v.Amount is the GROSS edge amount being removed;
+				// `released` is the slash-adjusted HIVE that actually leaves
+				// (released == gross when the node is unslashed). The edge and the
+				// gross node total drain by GROSS (so the pro-rata ratio stays
+				// constant and every delegator is slashed equally, order-
+				// independently); the node bond and the delegator payout move by
+				// RELEASED.
+				released := opReleased(v, v.Amount)
 				ledgerRecords = append(ledgerRecords, LedgerUpdate{
 					Id:          v.Id + "#in",
 					BlockHeight: endBlock,
-					Amount:      -v.Amount,
+					Amount:      -released,
 					Asset:       "hive_consensus",
 					Owner:       v.To,
 					Type:        "consensus_unstake",
@@ -238,9 +283,17 @@ func ExecuteOplog(oplog []OpLogEvent, startHeight uint64, endBlock uint64) struc
 					Owner:       DelegationEdgeKey(v.From, v.To),
 					Type:        "consensus_unstake",
 				})
+				ledgerRecords = append(ledgerRecords, LedgerUpdate{
+					Id:          v.Id + "#total",
+					BlockHeight: endBlock,
+					Amount:      -v.Amount,
+					Asset:       AssetDelegationTotal,
+					Owner:       v.To,
+					Type:        "consensus_unstake",
+				})
 				actionRecords = append(actionRecords, ledgerDb.ActionRecord{
 					Id:     v.Id,
-					Amount: v.Amount,
+					Amount: released, // slash-adjusted HIVE returned to the delegator
 					Asset:  "-",
 					To:     v.From, // release returns HIVE to the delegator
 					Memo:   v.Memo,

--- a/modules/rc-system/rc_system_test.go
+++ b/modules/rc-system/rc_system_test.go
@@ -124,6 +124,8 @@ func (m *mockLedgerSystem) ReservePayout(p ledgerSystem.ReservePayoutParams) led
 
 func (m *mockLedgerSystem) ReserveAvailable() int64 { return 0 }
 
+func (m *mockLedgerSystem) MigrateDelegationEdgesOnce(blockHeight uint64) int { return 0 }
+
 // ── CalculateFrozenBal tests ──
 
 func TestCalculateFrozenBal_NoDecay(t *testing.T) {

--- a/modules/rc-system/rc_system_test.go
+++ b/modules/rc-system/rc_system_test.go
@@ -94,7 +94,6 @@ func (m *mockLedgerSystem) PendulumAccrue(
 ) ledgerSystem.LedgerResult {
 	return ledgerSystem.LedgerResult{}
 }
-
 func (m *mockLedgerSystem) SafetySlashConsensusBond(
 	p ledgerSystem.SafetySlashConsensusParams,
 ) ledgerSystem.LedgerResult {
@@ -125,6 +124,10 @@ func (m *mockLedgerSystem) ReservePayout(p ledgerSystem.ReservePayoutParams) led
 func (m *mockLedgerSystem) ReserveAvailable() int64 { return 0 }
 
 func (m *mockLedgerSystem) MigrateDelegationEdgesOnce(blockHeight uint64) int { return 0 }
+
+func (m *mockLedgerSystem) AllDelegationEdges(blockHeight uint64) (map[string]map[string]int64, bool) {
+	return nil, true
+}
 
 // ── CalculateFrozenBal tests ──
 

--- a/modules/state-processing/consensus_delegated_mode_test.go
+++ b/modules/state-processing/consensus_delegated_mode_test.go
@@ -1,0 +1,113 @@
+package state_engine_test
+
+import (
+	"testing"
+
+	"vsc-node/modules/db/vsc/elections"
+	ledgerDb "vsc-node/modules/db/vsc/ledger"
+	"vsc-node/modules/db/vsc/witnesses"
+	ledgerSystem "vsc-node/modules/ledger-system"
+	stateEngine "vsc-node/modules/state-processing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// electionAtVersion returns an ElectionResult pinned to consensus major.consensus.
+func electionAtVersion(major, consensus uint64) elections.ElectionResult {
+	er := elections.ElectionResult{}
+	er.Epoch = 1
+	er.VersionMajor = major
+	er.ProtocolVersion = consensus
+	return er
+}
+
+// runStakeMode executes a consensus_stake tx against te.SE with a fresh funded
+// ledger session and returns the result. `funded` is credited with HIVE so the
+// balance check is never the reason a stake is rejected.
+func runStakeMode(te *testEnv, from, to, funded string) stateEngine.TxResult {
+	balDb := newMockBalanceDb(map[string][]ledgerDb.BalanceRecord{
+		funded: {{Account: funded, BlockHeight: 0, Hive: 100000}},
+	})
+	ls := ledgerSystem.New(balDb, newMockLedgerDb(), nil, newMockActionsDb(), nil)
+	session := ls.NewEmptySession(ls.NewEmptyState(), 1)
+	tx := &stateEngine.TxConsensusStake{
+		Self: stateEngine.TxSelf{
+			TxId:          "mode-test",
+			OpIndex:       0,
+			BlockHeight:   1,
+			RequiredAuths: []string{from},
+		},
+		From:   from,
+		To:     to,
+		Amount: "10.000",
+		Asset:  "hive", // explicit so the parse never masks the mode gate under test
+		NetId:  "vsc-mocknet",
+	}
+	return tx.ExecuteTx(te.SE, session, nil, nil, "")
+}
+
+// Consensus 0.5.0 opt-in: a node must accept delegations before a third party
+// can stake to it. Deactivated (the default) rejects; Share and Custom accept;
+// the operator's own self-stake is always allowed; pre-0.5.0 the gate is inert.
+func TestConsensusStakeDelegationModeGate(t *testing.T) {
+	const alice = "hive:alice"
+	const opB = "hive:operatorb"
+
+	setWitnessMode := func(te *testEnv, mode string) {
+		te.WitnessDb.ByAccount["operatorb"] = &witnesses.Witness{
+			Account:        "operatorb",
+			DelegationMode: mode,
+		}
+	}
+
+	t.Run("deactivated default (no announcement) rejects third-party", func(t *testing.T) {
+		te := newTestEnv()
+		te.ElectionDb.ElectionsByHeight[1] = electionAtVersion(0, 5)
+		// no witness record for operatorb → default Deactivated
+		res := runStakeMode(te, alice, opB, alice)
+		assert.False(t, res.Success, "third-party delegation to a Deactivated node must be rejected")
+		assert.Equal(t, "node does not accept delegations", res.Ret)
+	})
+
+	t.Run("explicit deactivated rejects third-party", func(t *testing.T) {
+		te := newTestEnv()
+		te.ElectionDb.ElectionsByHeight[1] = electionAtVersion(0, 5)
+		setWitnessMode(te, "deactivated")
+		res := runStakeMode(te, alice, opB, alice)
+		assert.False(t, res.Success)
+		assert.Equal(t, "node does not accept delegations", res.Ret)
+	})
+
+	t.Run("share accepts third-party", func(t *testing.T) {
+		te := newTestEnv()
+		te.ElectionDb.ElectionsByHeight[1] = electionAtVersion(0, 5)
+		setWitnessMode(te, "share")
+		res := runStakeMode(te, alice, opB, alice)
+		assert.True(t, res.Success, "share-mode node must accept delegation: %s", res.Ret)
+	})
+
+	t.Run("custom accepts third-party", func(t *testing.T) {
+		te := newTestEnv()
+		te.ElectionDb.ElectionsByHeight[1] = electionAtVersion(0, 5)
+		setWitnessMode(te, "custom")
+		res := runStakeMode(te, alice, opB, alice)
+		assert.True(t, res.Success, "custom-mode node must accept delegation: %s", res.Ret)
+	})
+
+	t.Run("operator self-stake always allowed even when deactivated", func(t *testing.T) {
+		te := newTestEnv()
+		te.ElectionDb.ElectionsByHeight[1] = electionAtVersion(0, 5)
+		setWitnessMode(te, "deactivated")
+		res := runStakeMode(te, opB, opB, opB) // from == to
+		assert.True(t, res.Success, "operator self-stake must never be gated: %s", res.Ret)
+	})
+
+	t.Run("pre-0.5.0 gate inert: third-party to deactivated still allowed at 0.4.0 (legacy)", func(t *testing.T) {
+		te := newTestEnv()
+		// Even at the already-shipped 0.4.0 floor, delegation is inert until 0.5.0,
+		// so a third-party stake follows the legacy (ungated) path.
+		te.ElectionDb.ElectionsByHeight[1] = electionAtVersion(0, 4)
+		res := runStakeMode(te, alice, opB, alice)
+		assert.True(t, res.Success, "pre-0.5.0 stake must follow the legacy (ungated) path: %s", res.Ret)
+	})
+}

--- a/modules/state-processing/consensus_delegated_rewards_test.go
+++ b/modules/state-processing/consensus_delegated_rewards_test.go
@@ -1,0 +1,79 @@
+package state_engine_test
+
+import (
+	"testing"
+
+	ledgerDb "vsc-node/modules/db/vsc/ledger"
+	"vsc-node/modules/db/vsc/witnesses"
+	ledgerSystem "vsc-node/modules/ledger-system"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// edgeRec is a delegation-edge ledger row (the virtual AssetDelegation asset the
+// 0.3.0 stake path writes).
+func edgeRec(id, from, to string, amount int64) ledgerDb.LedgerRecord {
+	return ledgerDb.LedgerRecord{
+		Id:          id,
+		Owner:       ledgerSystem.DelegationEdgeKey(from, to),
+		Amount:      amount,
+		Asset:       ledgerSystem.AssetDelegation,
+		Type:        "consensus_stake",
+		BlockHeight: 1,
+	}
+}
+
+// End-to-end read path for share-mode reward distribution: te.SE wires a REAL
+// LedgerSystem over the mock ledger DB, so PendulumShareDelegations exercises
+// AllDelegationEdges (ledger scan) + NodeDelegationMode (witness DB) exactly as
+// the settlement producer and re-derivation do.
+func TestPendulumShareDelegations_Wiring(t *testing.T) {
+	const (
+		alice = "hive:alice"
+		carol = "hive:carol"
+		opB   = "hive:operatorb" // share
+		opC   = "hive:operatorc" // custom (delegation allowed, but rewards off-chain)
+		opD   = "hive:operatord" // deactivated (no announcement)
+	)
+
+	te := newTestEnv()
+
+	// Seed delegation edges: opB has two stakers (incl. its own self-edge); opC
+	// also has a delegator; opD has none.
+	require := te.LedgerDb.StoreLedger(
+		edgeRec("e1", alice, opB, 600),
+		edgeRec("e2", opB, opB, 400), // operator self-stake edge
+		edgeRec("e3", carol, opC, 1000),
+	)
+	assert.NoError(t, require)
+
+	// Announce modes.
+	te.WitnessDb.ByAccount["operatorb"] = &witnesses.Witness{Account: "operatorb", DelegationMode: "share"}
+	te.WitnessDb.ByAccount["operatorc"] = &witnesses.Witness{Account: "operatorc", DelegationMode: "custom"}
+	// operatord intentionally has no witness record → default Deactivated.
+
+	members := []string{opB, opC, opD}
+	share, ok := te.SE.PendulumShareDelegations(members, 100)
+	assert.True(t, ok, "share-delegation read must succeed")
+
+	// Only the share-mode node is present, with its exact edges.
+	assert.Len(t, share, 1, "only the share-mode node contributes")
+	assert.Equal(t, map[string]int64{alice: 600, opB: 400}, share[opB],
+		"share node returns its delegator + operator self-edge stakes")
+	assert.NotContains(t, share, opC, "custom-mode node must be excluded (rewards stay with operator)")
+	assert.NotContains(t, share, opD, "deactivated/unannounced node must be excluded")
+}
+
+// NodeDelegationMode reads the operator's announced mode from the witness DB and
+// defaults to Deactivated (opt-in) when absent — the gate the stake handler uses.
+func TestNodeDelegationMode_Wiring(t *testing.T) {
+	te := newTestEnv()
+	te.WitnessDb.ByAccount["operatorb"] = &witnesses.Witness{Account: "operatorb", DelegationMode: "share"}
+	te.WitnessDb.ByAccount["operatorc"] = &witnesses.Witness{Account: "operatorc", DelegationMode: ""} // announced empty
+
+	assert.Equal(t, "share", te.SE.NodeDelegationMode("hive:operatorb", 100))
+	assert.Equal(t, "deactivated", te.SE.NodeDelegationMode("hive:operatorc", 100),
+		"announced-empty normalizes to deactivated")
+	assert.Equal(t, "deactivated", te.SE.NodeDelegationMode("hive:nobody", 100),
+		"no announcement → deactivated (opt-in)")
+}

--- a/modules/state-processing/consensus_delegated_unstake_test.go
+++ b/modules/state-processing/consensus_delegated_unstake_test.go
@@ -137,3 +137,60 @@ func TestConsensusUnstakeLegacyUnchanged(t *testing.T) {
 	assert.False(t, over.Ok)
 	assert.Equal(t, "insufficient balance", over.Msg)
 }
+
+// Pro-rata slashing (the team's chosen policy): every delegator to a slashed
+// node loses the SAME fraction, independent of unstake order. Verified via the
+// balance effects of an unstake (released HIVE = the hive_consensus debit).
+//
+// Setup: userA and userC each delegated 10.000 to operatorB (gross total 20.000,
+// bond 20.000); operatorB was then slashed 50% -> bond 10.000, gross total still
+// 20.000. Each unstake of a 10.000 gross edge must release 10.000*bond/total.
+func TestConsensusDelegatedUnstakeProRataSlash(t *testing.T) {
+	const userA = "hive:usera"
+	const userC = "hive:userc"
+	const opB = "hive:operatorb"
+
+	ledgerMock := newMockLedgerDb()
+	seed := []ledgerDb.LedgerRecord{
+		{Id: "a#edge", Owner: ledgerSystem.DelegationEdgeKey(userA, opB), Asset: ledgerSystem.AssetDelegation, Amount: 10000, Type: "consensus_stake", BlockHeight: 1},
+		{Id: "c#edge", Owner: ledgerSystem.DelegationEdgeKey(userC, opB), Asset: ledgerSystem.AssetDelegation, Amount: 10000, Type: "consensus_stake", BlockHeight: 1},
+		{Id: "a#total", Owner: opB, Asset: ledgerSystem.AssetDelegationTotal, Amount: 10000, Type: "consensus_stake", BlockHeight: 1},
+		{Id: "c#total", Owner: opB, Asset: ledgerSystem.AssetDelegationTotal, Amount: 10000, Type: "consensus_stake", BlockHeight: 1},
+		{Id: "a#out", Owner: opB, Asset: "hive_consensus", Amount: 10000, Type: "consensus_stake", BlockHeight: 1},
+		{Id: "c#out", Owner: opB, Asset: "hive_consensus", Amount: 10000, Type: "consensus_stake", BlockHeight: 1},
+		// 50% slash of operatorB's bond
+		{Id: "slash#1", Owner: opB, Asset: "hive_consensus", Amount: -10000, Type: ledgerSystem.LedgerTypeSafetySlashConsensus, BlockHeight: 1},
+	}
+	if err := ledgerMock.StoreLedger(seed...); err != nil {
+		t.Fatal(err)
+	}
+
+	ls := ledgerSystem.New(newMockBalanceDb(nil), ledgerMock, nil, newMockActionsDb(), nil)
+	session := ls.NewEmptySession(ls.NewEmptyState(), 1)
+
+	const h = 10
+	assert.Equal(t, int64(10000), session.GetBalance(opB, h, "hive_consensus"), "bond is 50%-slashed")
+	assert.Equal(t, int64(20000), session.GetBalance(opB, h, ledgerSystem.AssetDelegationTotal), "gross total is slash-immune")
+
+	// userA unstakes its full 10.000 gross edge -> released = 10000*10000/20000 = 5000.
+	rA := session.ConsensusUnstake(ledgerSystem.ConsensusParams{
+		Id: "u-a", From: userA, To: opB, Amount: 10000, BlockHeight: h,
+		Type: "unstake", ElectionEpoch: 1, Delegated: true,
+	})
+	assert.True(t, rA.Ok, rA.Msg)
+	assert.Equal(t, int64(5000), session.GetBalance(opB, h, "hive_consensus"),
+		"bond drops by RELEASED (5000), not gross")
+	assert.Equal(t, int64(0), session.GetBalance(ledgerSystem.DelegationEdgeKey(userA, opB), h, ledgerSystem.AssetDelegation),
+		"edge drains by GROSS (10000)")
+	assert.Equal(t, int64(10000), session.GetBalance(opB, h, ledgerSystem.AssetDelegationTotal),
+		"gross total drops by GROSS (10000) — keeps the ratio constant")
+
+	// userC unstakes its full 10.000 -> ratio still 5000/10000 = 0.5 -> released 5000.
+	rC := session.ConsensusUnstake(ledgerSystem.ConsensusParams{
+		Id: "u-c", From: userC, To: opB, Amount: 10000, BlockHeight: h,
+		Type: "unstake", ElectionEpoch: 1, Delegated: true,
+	})
+	assert.True(t, rC.Ok, rC.Msg)
+	assert.Equal(t, int64(0), session.GetBalance(opB, h, "hive_consensus"),
+		"both delegators released an equal 5000 — order-independent, bond fully distributed")
+}

--- a/modules/state-processing/consensus_delegated_unstake_test.go
+++ b/modules/state-processing/consensus_delegated_unstake_test.go
@@ -138,6 +138,45 @@ func TestConsensusUnstakeLegacyUnchanged(t *testing.T) {
 	assert.Equal(t, "insufficient balance", over.Msg)
 }
 
+// One-time activation backfill: a pre-0.5.0 delegation (no edge rows, only the
+// legacy consensus_stake #in/#out pair) becomes reclaimable after the migration
+// runs — and the migration is idempotent (a second run is a no-op).
+func TestMigrateDelegationEdgesOnce(t *testing.T) {
+	const userA = "hive:usera"
+	const opB = "hive:operatorb"
+
+	ledgerMock := newMockLedgerDb()
+	if err := ledgerMock.StoreLedger(
+		ledgerDb.LedgerRecord{Id: "tx1#in", Owner: userA, Amount: -10000, Asset: "hive", Type: "consensus_stake", BlockHeight: 5},
+		ledgerDb.LedgerRecord{Id: "tx1#out", Owner: opB, Amount: 10000, Asset: "hive_consensus", Type: "consensus_stake", BlockHeight: 5},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	ls := ledgerSystem.New(newMockBalanceDb(nil), ledgerMock, nil, newMockActionsDb(), nil)
+
+	// Before migration: the edge is invisible (userA could not unstake).
+	pre := ls.NewEmptySession(ls.NewEmptyState(), 1)
+	assert.Equal(t, int64(0), pre.GetBalance(ledgerSystem.DelegationEdgeKey(userA, opB), 100, ledgerSystem.AssetDelegation),
+		"no edge before migration")
+
+	// Run the activation backfill at height 100.
+	assert.Equal(t, 1, ls.MigrateDelegationEdgesOnce(100), "one edge backfilled")
+
+	// After migration: edge + node gross total are readable → unstake would work.
+	post := ls.NewEmptySession(ls.NewEmptyState(), 1)
+	assert.Equal(t, int64(10000), post.GetBalance(ledgerSystem.DelegationEdgeKey(userA, opB), 100, ledgerSystem.AssetDelegation),
+		"userA->opB edge reclaimable after migration")
+	assert.Equal(t, int64(10000), post.GetBalance(opB, 100, ledgerSystem.AssetDelegationTotal),
+		"node gross total seeded")
+
+	// Idempotent: second run is a no-op (marker present), edge not doubled.
+	assert.Equal(t, 0, ls.MigrateDelegationEdgesOnce(101), "already migrated → no-op")
+	again := ls.NewEmptySession(ls.NewEmptyState(), 1)
+	assert.Equal(t, int64(10000), again.GetBalance(ledgerSystem.DelegationEdgeKey(userA, opB), 101, ledgerSystem.AssetDelegation),
+		"edge unchanged after second (no-op) run")
+}
+
 // Pro-rata slashing (the team's chosen policy): every delegator to a slashed
 // node loses the SAME fraction, independent of unstake order. Verified via the
 // balance effects of an unstake (released HIVE = the hive_consensus debit).

--- a/modules/state-processing/consensus_delegated_unstake_test.go
+++ b/modules/state-processing/consensus_delegated_unstake_test.go
@@ -1,0 +1,139 @@
+package state_engine_test
+
+import (
+	"testing"
+
+	ledgerDb "vsc-node/modules/db/vsc/ledger"
+	ledgerSystem "vsc-node/modules/ledger-system"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Consensus 0.5.0 delegated stake/unstake — core invariant test (ledger layer,
+// gate forced via ConsensusParams.Delegated so the mechanics are exercised
+// without standing up an election at version 0.5.0).
+//
+// Scenario: userA delegates consensus stake to operatorB. Required properties:
+//  1. userA -> operatorB stake succeeds and records the per-edge delegation.
+//  2. operatorB CANNOT unstake what userA delegated (no edge of its own) — the
+//     headline requirement: the operator can never touch a delegator's stake.
+//  3. userA over-unstake (more than delegated) is rejected.
+//  4. userA can unstake exactly what it delegated.
+func TestConsensusDelegatedUnstakeEntitlement(t *testing.T) {
+	const userA = "hive:usera"
+	const operatorB = "hive:operatorb"
+
+	balDb := newMockBalanceDb(map[string][]ledgerDb.BalanceRecord{
+		// userA funds the delegation; operatorB has no spendable hive of its own.
+		userA: {{Account: userA, BlockHeight: 0, Hive: 100000}},
+	})
+	ls := ledgerSystem.New(balDb, newMockLedgerDb(), nil, newMockActionsDb(), nil)
+	session := ls.NewEmptySession(ls.NewEmptyState(), 1)
+
+	// 1. userA delegates 10.000 HIVE to operatorB.
+	stake := session.ConsensusStake(ledgerSystem.ConsensusParams{
+		Id:          "stake-1",
+		From:        userA,
+		To:          operatorB,
+		Amount:      10000,
+		BlockHeight: 1,
+		Type:        "stake",
+		Delegated:   true,
+	})
+	assert.True(t, stake.Ok, "userA->operatorB delegated stake should succeed: %s", stake.Msg)
+
+	// 2. operatorB tries to unstake (To=operatorB): its OWN edge is 0, so even
+	//    though the node's hive_consensus pool holds userA's 10.000, it is
+	//    rejected. operatorB can never reach userA's delegation.
+	opUnstake := session.ConsensusUnstake(ledgerSystem.ConsensusParams{
+		Id:            "unstake-op",
+		From:          operatorB,
+		To:            operatorB,
+		Amount:        10000,
+		BlockHeight:   2,
+		Type:          "unstake",
+		ElectionEpoch: 1,
+		Delegated:     true,
+	})
+	assert.False(t, opUnstake.Ok,
+		"operatorB MUST NOT be able to unstake userA's delegated stake")
+	assert.Equal(t, "amount exceeds delegated stake", opUnstake.Msg)
+
+	// 3. userA over-unstake (20.000 > 10.000 delegated) — rejected.
+	over := session.ConsensusUnstake(ledgerSystem.ConsensusParams{
+		Id:            "unstake-over",
+		From:          userA,
+		To:            operatorB,
+		Amount:        20000,
+		BlockHeight:   2,
+		Type:          "unstake",
+		ElectionEpoch: 1,
+		Delegated:     true,
+	})
+	assert.False(t, over.Ok, "userA over-unstake must be rejected")
+	assert.Equal(t, "amount exceeds delegated stake", over.Msg)
+
+	// 4. userA unstakes exactly the delegated amount — succeeds.
+	ok := session.ConsensusUnstake(ledgerSystem.ConsensusParams{
+		Id:            "unstake-ok",
+		From:          userA,
+		To:            operatorB,
+		Amount:        10000,
+		BlockHeight:   2,
+		Type:          "unstake",
+		ElectionEpoch: 1,
+		Delegated:     true,
+	})
+	assert.True(t, ok.Ok, "userA unstaking its own delegation should succeed: %s", ok.Msg)
+
+	// 5. After fully unstaking, the edge is drained — a further unstake fails.
+	again := session.ConsensusUnstake(ledgerSystem.ConsensusParams{
+		Id:            "unstake-again",
+		From:          userA,
+		To:            operatorB,
+		Amount:        1,
+		BlockHeight:   2,
+		Type:          "unstake",
+		ElectionEpoch: 1,
+		Delegated:     true,
+	})
+	assert.False(t, again.Ok, "edge is drained; further unstake must be rejected")
+}
+
+// Legacy path (Delegated=false) must be byte-identical to pre-0.5.0: unstake
+// authorizes against the signer's own hive_consensus, not a delegation edge.
+func TestConsensusUnstakeLegacyUnchanged(t *testing.T) {
+	const node = "hive:selfstaker"
+	balDb := newMockBalanceDb(map[string][]ledgerDb.BalanceRecord{
+		node: {{Account: node, BlockHeight: 0, Hive: 50000, HIVE_CONSENSUS: 30000}},
+	})
+	ls := ledgerSystem.New(balDb, newMockLedgerDb(), nil, newMockActionsDb(), nil)
+	session := ls.NewEmptySession(ls.NewEmptyState(), 1)
+
+	// Legacy unstake of own bond up to hive_consensus succeeds.
+	ok := session.ConsensusUnstake(ledgerSystem.ConsensusParams{
+		Id:            "legacy-ok",
+		From:          node,
+		To:            node,
+		Amount:        30000,
+		BlockHeight:   1,
+		Type:          "unstake",
+		ElectionEpoch: 1,
+		Delegated:     false,
+	})
+	assert.True(t, ok.Ok, "legacy self-unstake within hive_consensus should succeed: %s", ok.Msg)
+
+	// Legacy unstake beyond hive_consensus is rejected with the legacy message.
+	over := session.ConsensusUnstake(ledgerSystem.ConsensusParams{
+		Id:            "legacy-over",
+		From:          node,
+		To:            node,
+		Amount:        999999,
+		BlockHeight:   1,
+		Type:          "unstake",
+		ElectionEpoch: 1,
+		Delegated:     false,
+	})
+	assert.False(t, over.Ok)
+	assert.Equal(t, "insufficient balance", over.Msg)
+}

--- a/modules/state-processing/consensus_delegated_unstake_test.go
+++ b/modules/state-processing/consensus_delegated_unstake_test.go
@@ -138,6 +138,57 @@ func TestConsensusUnstakeLegacyUnchanged(t *testing.T) {
 	assert.Equal(t, "insufficient balance", over.Msg)
 }
 
+// CONSENSUS-CRITICAL regression guard. The oplog — including OpLogEvent.Params —
+// is CBOR-encoded into the L2 oplog block CID (block-producer MakeOplog) that
+// every node must agree on. The LEGACY (pre-0.5.0, Delegated=false)
+// consensus_stake/unstake oplog Params MUST stay byte-identical to the original,
+// or a node on the new binary forks from an old node on ANY block with a
+// stake/unstake BEFORE 0.5.0 activates. Originals: consensus_stake had NO Params;
+// consensus_unstake had ONLY {epoch}.
+func TestLegacyConsensusOplogParamsUnchanged(t *testing.T) {
+	const acct = "hive:node1"
+	balDb := newMockBalanceDb(map[string][]ledgerDb.BalanceRecord{
+		acct: {{Account: acct, BlockHeight: 0, Hive: 100000, HIVE_CONSENSUS: 100000}},
+	})
+	newLs := func() ledgerSystem.LedgerSystem {
+		return ledgerSystem.New(balDb, newMockLedgerDb(), nil, newMockActionsDb(), nil)
+	}
+
+	// Legacy consensus_stake -> NO oplog Params.
+	ls := newLs()
+	st := ls.NewEmptyState()
+	sess := ls.NewEmptySession(st, 1)
+	res := sess.ConsensusStake(ledgerSystem.ConsensusParams{Id: "s1", From: acct, To: acct, Amount: 1000, BlockHeight: 1, Delegated: false})
+	assert.True(t, res.Ok, res.Msg)
+	sess.Done()
+	if assert.Len(t, st.Oplog, 1) {
+		assert.Nil(t, st.Oplog[0].Params, "legacy consensus_stake must carry NO oplog Params (consensus CID)")
+	}
+
+	// Legacy consensus_unstake -> ONLY {epoch}.
+	ls2 := newLs()
+	st2 := ls2.NewEmptyState()
+	sess2 := ls2.NewEmptySession(st2, 1)
+	res2 := sess2.ConsensusUnstake(ledgerSystem.ConsensusParams{Id: "u1", From: acct, To: acct, Amount: 1000, BlockHeight: 1, ElectionEpoch: 7, Delegated: false})
+	assert.True(t, res2.Ok, res2.Msg)
+	sess2.Done()
+	if assert.Len(t, st2.Oplog, 1) {
+		assert.Equal(t, map[string]interface{}{"epoch": uint64(7)}, st2.Oplog[0].Params,
+			"legacy consensus_unstake must carry ONLY {epoch}")
+	}
+
+	// Sanity: the DELEGATED path DOES stamp the flag so the 0.5.0 gate engages.
+	ls3 := newLs()
+	st3 := ls3.NewEmptyState()
+	sess3 := ls3.NewEmptySession(st3, 1)
+	sess3.ConsensusStake(ledgerSystem.ConsensusParams{Id: "s2", From: acct, To: "hive:node2", Amount: 1000, BlockHeight: 1, Delegated: true})
+	sess3.Done()
+	if assert.Len(t, st3.Oplog, 1) {
+		d, _ := st3.Oplog[0].Params["delegated"].(bool)
+		assert.True(t, d, "delegated consensus_stake must stamp delegated=true")
+	}
+}
+
 // One-time activation backfill: a pre-0.5.0 delegation (no edge rows, only the
 // legacy consensus_stake #in/#out pair) becomes reclaimable after the migration
 // runs — and the migration is idempotent (a second run is a no-op).

--- a/modules/state-processing/consensus_version.go
+++ b/modules/state-processing/consensus_version.go
@@ -122,6 +122,22 @@ func (se *StateEngine) ActiveConsensusVersion(blockHeight uint64) consensusversi
 	return elections.ResultVersion(elec)
 }
 
+// delegatedStakeActive reports whether per-delegator consensus stake/unstake
+// semantics are in force at this height (the v0.5.0 batch — see
+// consensusversion.DelegatedStakeActive). Below the line the legacy
+// hive_consensus-holder unstake path runs byte-identically. Sourced from
+// ActiveConsensusVersion (on-chain election) so every node agrees.
+func (se *StateEngine) delegatedStakeActive(blockHeight uint64) bool {
+	return consensusversion.DelegatedStakeActive(se.ActiveConsensusVersion(blockHeight))
+}
+
+// DelegatedStakeActiveForElection is the same 0.5.0 gate evaluated against an
+// already-read election, for the consensus_stake/unstake tx handlers which hold
+// an ElectionResult from the StateEngine interface's fail-stop election read.
+func DelegatedStakeActiveForElection(elec elections.ElectionResult) bool {
+	return consensusversion.DelegatedStakeActive(elections.ResultVersion(elec))
+}
+
 // TssMinimumConsensusVersion implements the tss.GetScheduler extension: the minimum
 // major/consensus triple for TSS at this Hive height (the election-active version).
 func (se *StateEngine) TssMinimumConsensusVersion(blockHeight uint64) consensusversion.Version {

--- a/modules/state-processing/delegation_mode.go
+++ b/modules/state-processing/delegation_mode.go
@@ -1,0 +1,82 @@
+package state_engine
+
+import (
+	"strings"
+
+	"vsc-node/modules/common/delegationmode"
+)
+
+// NodeDelegationMode returns the consensus-delegation mode node `account` has
+// opted into, as of blockHeight, normalized to a known value
+// (delegationmode.{Deactivated,Share,Custom}). It defaults to Deactivated when
+// the node has no announcement at-or-before blockHeight, an unset mode, or the
+// witness DB is unavailable — making delegation strict opt-in.
+//
+// Determinism: the mode comes from the operator's own authenticated Hive
+// `update_account` announcement (json_metadata → witness record), which every
+// node ingests identically from L1. Reading it at a fixed blockHeight therefore
+// yields the same answer on every node, which is required because this gates
+// consensus_stake acceptance (here) and the settlement reward split.
+//
+// Account form: witness records are keyed by the bare Hive account name, while
+// callers pass the normalized "hive:" form used throughout the ledger; the
+// prefix is stripped before the lookup.
+func (se *StateEngine) NodeDelegationMode(account string, blockHeight uint64) string {
+	if se == nil || se.witnessDb == nil || account == "" {
+		return delegationmode.Default
+	}
+	bare := strings.TrimPrefix(account, "hive:")
+	bh := blockHeight
+	w, err := se.witnessDb.GetWitnessAtHeight(bare, &bh)
+	if err != nil || w == nil {
+		return delegationmode.Default
+	}
+	return delegationmode.Normalize(w.DelegationMode)
+}
+
+// PendulumShareDelegations returns, for every committee `member` (in "hive:"
+// form) running delegationmode.Share at blockHeight, that node's positive stake
+// edges: node -> (delegator -> net HIVE staked). Nodes in any other mode, or
+// with no edges, are omitted. The result feeds settlement.ComposeRecord, which
+// splits each share node's pendulum slice pro-rata across these edges.
+//
+// Determinism: edges come from LedgerSystem.AllDelegationEdges (a single ledger
+// scan) and modes from the witness DB — both identical on every node at a fixed
+// blockHeight. The producer, the apply-time re-derivation, and the structural
+// validator MUST all call this with the SAME blockHeight (the settlement's
+// SnapshotRangeTo) so they agree byte-for-byte.
+//
+// Returns ok=false when the edge scan fails transiently, so the producer can
+// abort the election attempt and re-derivation can fall back to structural
+// validation — never distribute against a partial view.
+func (se *StateEngine) PendulumShareDelegations(members []string, blockHeight uint64) (map[string]map[string]int64, bool) {
+	if se == nil || se.LedgerSystem == nil {
+		return nil, false
+	}
+	allEdges, ok := se.LedgerSystem.AllDelegationEdges(blockHeight)
+	if !ok {
+		return nil, false
+	}
+	out := make(map[string]map[string]int64)
+	for _, m := range members {
+		if !delegationmode.SharesRewards(se.NodeDelegationMode(m, blockHeight)) {
+			continue
+		}
+		edges := allEdges[m]
+		if len(edges) == 0 {
+			continue
+		}
+		// Copy so the returned map never aliases AllDelegationEdges' internal
+		// state, and drop any non-positive edge defensively.
+		cp := make(map[string]int64, len(edges))
+		for d, s := range edges {
+			if s > 0 {
+				cp[d] = s
+			}
+		}
+		if len(cp) > 0 {
+			out[m] = cp
+		}
+	}
+	return out, true
+}

--- a/modules/state-processing/delegation_mode.go
+++ b/modules/state-processing/delegation_mode.go
@@ -4,19 +4,27 @@ import (
 	"strings"
 
 	"vsc-node/modules/common/delegationmode"
+	"vsc-node/modules/common/params"
+	"vsc-node/modules/db/vsc/witnesses"
 )
 
-// NodeDelegationMode returns the consensus-delegation mode node `account` has
-// opted into, as of blockHeight, normalized to a known value
+// NodeDelegationMode returns the EFFECTIVE consensus-delegation mode node
+// `account` has opted into, as of blockHeight, normalized to a known value
 // (delegationmode.{Deactivated,Share,Custom}). It defaults to Deactivated when
 // the node has no announcement at-or-before blockHeight, an unset mode, or the
 // witness DB is unavailable — making delegation strict opt-in.
+//
+// "Effective" accounts for the downgrade timelock (consensus 0.5.0+): an adverse
+// mode change (leaving Share, which strips delegators' on-chain reward share) is
+// deferred until DELEGATION_DOWNGRADE_LOCK_EPOCHS elapse, so this returns the
+// prior protected mode until then (see resolveDelegationMode /
+// computeDelegationTimelock). Non-adverse changes take effect immediately.
 //
 // Determinism: the mode comes from the operator's own authenticated Hive
 // `update_account` announcement (json_metadata → witness record), which every
 // node ingests identically from L1. Reading it at a fixed blockHeight therefore
 // yields the same answer on every node, which is required because this gates
-// consensus_stake acceptance (here) and the settlement reward split.
+// consensus_stake acceptance and the settlement reward split.
 //
 // Account form: witness records are keyed by the bare Hive account name, while
 // callers pass the normalized "hive:" form used throughout the ledger; the
@@ -31,7 +39,90 @@ func (se *StateEngine) NodeDelegationMode(account string, blockHeight uint64) st
 	if err != nil || w == nil {
 		return delegationmode.Default
 	}
-	return delegationmode.Normalize(w.DelegationMode)
+	return se.resolveDelegationMode(w, blockHeight)
+}
+
+// resolveDelegationMode maps a witness row to the mode in force at blockHeight,
+// applying the downgrade timelock. A zero DelegationModeMaturityEpoch (pre-0.5.0
+// rows and every non-adverse announcement) means "effective immediately", so the
+// announced mode is returned unchanged — byte-identical to the pre-feature read.
+// Otherwise the announced (adverse) target only takes over once the chain epoch
+// reaches the stored maturity; until then the protected DelegationModeEffective
+// is returned.
+func (se *StateEngine) resolveDelegationMode(w *witnesses.Witness, blockHeight uint64) string {
+	target := delegationmode.Normalize(w.DelegationMode)
+	if w.DelegationModeMaturityEpoch == 0 {
+		return target
+	}
+	// A pending downgrade exists. Resolve the current epoch from the same
+	// fail-stop election read the unbond release uses, so every node agrees or
+	// halts (never a silent per-node fork). Below the 0.5.0 gate or pre-genesis,
+	// ignore the timelock fields.
+	elec, found := se.GetElectionInfoOrBlock(blockHeight)
+	if !found || !DelegatedStakeActiveForElection(elec) {
+		return target
+	}
+	if elec.Epoch >= w.DelegationModeMaturityEpoch {
+		return target // downgrade matured
+	}
+	return delegationmode.Normalize(w.DelegationModeEffective) // still protected
+}
+
+// computeDelegationTimelock resolves the (effective, maturityEpoch) pair to store
+// on a witness announcement row at height Hn for `announced`, enforcing the
+// downgrade timelock. It is called at ingest (state engine, before
+// SetWitnessUpdate) and returns zero-values (no fields persisted) for pre-0.5.0
+// history and for every non-adverse change, keeping those rows byte-clean.
+//
+// Determinism/replay: reads only on-chain, height-addressable state — the
+// election at Hn (fail-stop) and the immediately-preceding witness row (always
+// within the 6-record retention window, since it is the newest row < Hn). The
+// prior row carries the current effective/pending state forward, so pruning the
+// original adverse-announce row never loses it, and re-announcing the same
+// pending downgrade carries the original maturity forward WITHOUT resetting it.
+func (se *StateEngine) computeDelegationTimelock(account string, Hn uint64, announced string) (string, uint64) {
+	target := delegationmode.Normalize(announced)
+
+	// Gate + epoch from one fail-stop election read. Below 0.5.0 (or pre-genesis)
+	// store zero-values → readers see the announced mode immediately.
+	elec, found := se.GetElectionInfoOrBlock(Hn)
+	if !found || !DelegatedStakeActiveForElection(elec) {
+		return "", 0
+	}
+	epoch := elec.Epoch
+
+	bare := strings.TrimPrefix(account, "hive:")
+	bh := Hn
+	prev, _ := se.witnessDb.GetWitnessAtHeight(bare, &bh) // strict height < Hn → prior row
+
+	// Mode actually in force at Hn (respecting any still-pending prior downgrade).
+	effNow := target
+	pPending := false
+	pTarget := ""
+	if prev != nil {
+		pTarget = delegationmode.Normalize(prev.DelegationMode)
+		if prev.DelegationModeMaturityEpoch != 0 && epoch < prev.DelegationModeMaturityEpoch {
+			pPending = true
+			effNow = delegationmode.Normalize(prev.DelegationModeEffective) // still-protected mode
+		} else {
+			effNow = pTarget // prior downgrade matured, or none was pending
+		}
+	}
+
+	if delegationmode.IsAdverseTransition(effNow, target) {
+		if pPending && pTarget == target {
+			// Re-announcement of the same still-pending downgrade → carry the
+			// original maturity (NO reset), else a periodic re-announce would
+			// push the timer out forever.
+			return effNow, prev.DelegationModeMaturityEpoch
+		}
+		// New distinct adverse transition → start the timer from the current epoch.
+		return effNow, epoch + params.DELEGATION_DOWNGRADE_LOCK_EPOCHS
+	}
+	// Non-adverse (→ Share, lateral, or a return to the protected mode): effective
+	// immediately, cancelling any pending downgrade. Zero maturity ⇒ no fields
+	// persisted and readers return Normalize(DelegationMode) == target.
+	return "", 0
 }
 
 // PendulumShareDelegations returns, for every committee `member` (in "hive:"

--- a/modules/state-processing/delegation_timelock_internal_test.go
+++ b/modules/state-processing/delegation_timelock_internal_test.go
@@ -1,0 +1,303 @@
+package state_engine
+
+import (
+	"fmt"
+	"testing"
+
+	"vsc-node/modules/common/delegationmode"
+	"vsc-node/modules/common/params"
+	"vsc-node/modules/db/vsc/elections"
+	"vsc-node/modules/db/vsc/witnesses"
+
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// Internal (white-box) tests for the delegation-mode downgrade timelock:
+// computeDelegationTimelock (ingest) + resolveDelegationMode / NodeDelegationMode
+// (read). They exercise the pure resolution logic against minimal mock
+// witness/election DBs — no ledger or block pipeline needed. Local mocks embed
+// the DB interfaces and override only the two methods under test, so this file
+// can live in-package (an import of lib/test_utils would cycle).
+
+const tlLock = 6 // params.DELEGATION_DOWNGRADE_LOCK_EPOCHS (unbond 5 + 1 margin)
+
+// tlWitnessDB overrides only GetWitnessAtHeight; the mock is height-agnostic
+// (returns the single stored row per account), which matches how the tests
+// simulate the immediately-preceding row.
+type tlWitnessDB struct {
+	witnesses.Witnesses
+	rows map[string]*witnesses.Witness
+}
+
+func (m *tlWitnessDB) GetWitnessAtHeight(account string, _ *uint64) (*witnesses.Witness, error) {
+	if m.rows == nil {
+		return nil, nil
+	}
+	return m.rows[account], nil
+}
+
+// tlElectionDB overrides only GetElectionByHeight. Unknown heights return the
+// mongo.ErrNoDocuments the fail-stop reader treats as deterministic absence
+// (found=false), never an infra error it would block on.
+type tlElectionDB struct {
+	elections.Elections
+	byHeight map[uint64]elections.ElectionResult
+}
+
+func (m *tlElectionDB) GetElectionByHeight(height uint64) (elections.ElectionResult, error) {
+	if r, ok := m.byHeight[height]; ok {
+		return r, nil
+	}
+	return elections.ElectionResult{}, fmt.Errorf("no election at %d: %w", height, mongo.ErrNoDocuments)
+}
+
+// electionAtEpoch builds an election pinned to a given epoch and consensus
+// version (major 0). consensus=5 → the 0.5.0 delegation gate is active; 4 → off.
+func electionAtEpoch(epoch, consensus uint64) elections.ElectionResult {
+	er := elections.ElectionResult{}
+	er.Epoch = epoch
+	er.VersionMajor = 0
+	er.ProtocolVersion = consensus
+	return er
+}
+
+// tlEngine wires a StateEngine with the local mock DBs. witRows is keyed by BARE
+// account; elecs is keyed by exact query height.
+func tlEngine(witRows map[string]*witnesses.Witness, elecs map[uint64]elections.ElectionResult) *StateEngine {
+	return &StateEngine{
+		witnessDb:  &tlWitnessDB{rows: witRows},
+		electionDb: &tlElectionDB{byHeight: elecs},
+	}
+}
+
+func TestComputeDelegationTimelock_LockAndConstant(t *testing.T) {
+	// The lock constant must equal the unbond period plus one epoch of margin, so
+	// the guard provably tracks the consensus_unstake window.
+	if params.DELEGATION_DOWNGRADE_LOCK_EPOCHS != params.CONSENSUS_UNSTAKE_LOCK_EPOCHS+1 {
+		t.Fatalf("DELEGATION_DOWNGRADE_LOCK_EPOCHS=%d, want CONSENSUS_UNSTAKE_LOCK_EPOCHS(%d)+1",
+			params.DELEGATION_DOWNGRADE_LOCK_EPOCHS, params.CONSENSUS_UNSTAKE_LOCK_EPOCHS)
+	}
+	if tlLock != int(params.DELEGATION_DOWNGRADE_LOCK_EPOCHS) {
+		t.Fatalf("test tlLock=%d out of sync with params=%d", tlLock, params.DELEGATION_DOWNGRADE_LOCK_EPOCHS)
+	}
+}
+
+func TestComputeDelegationTimelock_AdverseVsImmediate(t *testing.T) {
+	const node = "node1"
+	// Prior effective mode = share (a matured / immediate share row).
+	prior := func() map[string]*witnesses.Witness {
+		return map[string]*witnesses.Witness{node: {Height: 100, DelegationMode: delegationmode.Share}}
+	}
+	elecs := map[uint64]elections.ElectionResult{200: electionAtEpoch(10, 5)}
+
+	cases := []struct {
+		name       string
+		announce   string
+		wantEff    string
+		wantMature uint64
+	}{
+		// Leaving Share → adverse → protected + timer from epoch 10.
+		{"share->custom locks", delegationmode.Custom, delegationmode.Share, 10 + tlLock},
+		{"share->deactivated locks", delegationmode.Deactivated, delegationmode.Share, 10 + tlLock},
+		// Non-adverse → zero-values (immediate, byte-clean).
+		{"share->share immediate", delegationmode.Share, "", 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			se := tlEngine(prior(), elecs)
+			eff, mat := se.computeDelegationTimelock(node, 200, c.announce)
+			if eff != c.wantEff || mat != c.wantMature {
+				t.Errorf("computeDelegationTimelock(share->%s) = (%q,%d), want (%q,%d)",
+					c.announce, eff, mat, c.wantEff, c.wantMature)
+			}
+		})
+	}
+}
+
+func TestComputeDelegationTimelock_CustomToDeactivatedImmediate(t *testing.T) {
+	// custom->deactivated is acceptance-only (custom never shared on-chain), so it
+	// is NOT adverse and must apply immediately (no fields stored).
+	const node = "node1"
+	se := tlEngine(
+		map[string]*witnesses.Witness{node: {Height: 100, DelegationMode: delegationmode.Custom}},
+		map[uint64]elections.ElectionResult{200: electionAtEpoch(10, 5)},
+	)
+	eff, mat := se.computeDelegationTimelock(node, 200, delegationmode.Deactivated)
+	if eff != "" || mat != 0 {
+		t.Errorf("custom->deactivated = (%q,%d), want immediate (\"\",0)", eff, mat)
+	}
+}
+
+func TestComputeDelegationTimelock_GateOff(t *testing.T) {
+	// Below the 0.5.0 floor (consensus 4), even an adverse announce stores nothing
+	// → byte-identical to pre-feature history.
+	const node = "node1"
+	se := tlEngine(
+		map[string]*witnesses.Witness{node: {Height: 100, DelegationMode: delegationmode.Share}},
+		map[uint64]elections.ElectionResult{200: electionAtEpoch(10, 4)},
+	)
+	eff, mat := se.computeDelegationTimelock(node, 200, delegationmode.Custom)
+	if eff != "" || mat != 0 {
+		t.Errorf("gate-off share->custom = (%q,%d), want (\"\",0)", eff, mat)
+	}
+}
+
+func TestComputeDelegationTimelock_NewNodeNoPrior(t *testing.T) {
+	// A node's first announcement (no prior row) is never adverse — there is no
+	// existing reward share to strip.
+	se := tlEngine(
+		map[string]*witnesses.Witness{}, // no prior
+		map[uint64]elections.ElectionResult{200: electionAtEpoch(10, 5)},
+	)
+	for _, m := range []string{delegationmode.Share, delegationmode.Custom, delegationmode.Deactivated} {
+		eff, mat := se.computeDelegationTimelock("fresh", 200, m)
+		if eff != "" || mat != 0 {
+			t.Errorf("first announce %q = (%q,%d), want immediate (\"\",0)", m, eff, mat)
+		}
+	}
+}
+
+// applyStep simulates the ingest write: compute the timelock, then store the row
+// exactly as SetWitnessUpdate would (raw announced mode + eff/mat only when
+// mat!=0), so the NEXT step reads it as the immediately-preceding row.
+func applyStep(t *testing.T, se *StateEngine, wit map[string]*witnesses.Witness, node string, height uint64, announce string) (string, uint64) {
+	t.Helper()
+	eff, mat := se.computeDelegationTimelock(node, height, announce)
+	row := &witnesses.Witness{Height: height, DelegationMode: delegationmode.Normalize(announce)}
+	if mat != 0 {
+		row.DelegationModeEffective = eff
+		row.DelegationModeMaturityEpoch = mat
+	}
+	wit[node] = row
+	return eff, mat
+}
+
+func TestComputeDelegationTimelock_ReannounceNoReset(t *testing.T) {
+	// share pending->custom at epoch 10 (row height 200); re-announcing custom at a
+	// later height while still within the window must CARRY the original maturity,
+	// never restart it (a periodic re-announce would otherwise push it out forever).
+	const node = "node1"
+	wit := map[string]*witnesses.Witness{node: {Height: 100, DelegationMode: delegationmode.Share}}
+	elecs := map[uint64]elections.ElectionResult{
+		200: electionAtEpoch(10, 5),
+		210: electionAtEpoch(12, 5), // still < 10+6=16
+		220: electionAtEpoch(14, 5),
+	}
+	se := tlEngine(wit, elecs)
+
+	_, mat0 := applyStep(t, se, wit, node, 200, delegationmode.Custom)
+	if mat0 != 10+tlLock {
+		t.Fatalf("initial share->custom maturity = %d, want %d", mat0, 10+tlLock)
+	}
+	for _, h := range []uint64{210, 220} {
+		eff, mat := applyStep(t, se, wit, node, h, delegationmode.Custom)
+		if mat != mat0 || eff != delegationmode.Share {
+			t.Errorf("re-announce custom @%d = (%q,%d), want (share,%d) carried unchanged", h, eff, mat, mat0)
+		}
+	}
+}
+
+func TestComputeDelegationTimelock_UpgradeCancelsPending(t *testing.T) {
+	// A pending share->custom is cancelled the moment the operator re-announces
+	// share (returns to the protected mode) → immediate, no fields.
+	const node = "node1"
+	wit := map[string]*witnesses.Witness{node: {Height: 100, DelegationMode: delegationmode.Share}}
+	se := tlEngine(wit, map[uint64]elections.ElectionResult{
+		200: electionAtEpoch(10, 5),
+		205: electionAtEpoch(11, 5), // within window
+	})
+	applyStep(t, se, wit, node, 200, delegationmode.Custom) // pending
+	eff, mat := applyStep(t, se, wit, node, 205, delegationmode.Share)
+	if eff != "" || mat != 0 {
+		t.Errorf("share re-announce (cancel) = (%q,%d), want immediate (\"\",0)", eff, mat)
+	}
+}
+
+func TestComputeDelegationTimelock_DistinctTargetRestartsFromProtected(t *testing.T) {
+	// Pending share->custom, then the operator announces deactivated (a DIFFERENT
+	// adverse target) mid-window → a fresh timer, still protecting share.
+	const node = "node1"
+	wit := map[string]*witnesses.Witness{node: {Height: 100, DelegationMode: delegationmode.Share}}
+	se := tlEngine(wit, map[uint64]elections.ElectionResult{
+		200: electionAtEpoch(10, 5),
+		205: electionAtEpoch(11, 5),
+	})
+	applyStep(t, se, wit, node, 200, delegationmode.Custom)
+	eff, mat := applyStep(t, se, wit, node, 205, delegationmode.Deactivated)
+	if eff != delegationmode.Share || mat != 11+tlLock {
+		t.Errorf("distinct adverse target = (%q,%d), want (share,%d)", eff, mat, 11+tlLock)
+	}
+}
+
+func TestComputeDelegationTimelock_PreActivationShareProtected(t *testing.T) {
+	// A pre-0.5.0 share row (zero timelock fields) must still protect a
+	// post-activation share->custom flip.
+	const node = "node1"
+	wit := map[string]*witnesses.Witness{node: {Height: 100, DelegationMode: delegationmode.Share}} // maturity 0
+	se := tlEngine(wit, map[uint64]elections.ElectionResult{300: electionAtEpoch(20, 5)})
+	eff, mat := se.computeDelegationTimelock(node, 300, delegationmode.Custom)
+	if eff != delegationmode.Share || mat != 20+tlLock {
+		t.Errorf("pre-0.5.0 share->custom = (%q,%d), want (share,%d)", eff, mat, 20+tlLock)
+	}
+}
+
+func TestNodeDelegationMode_ResolvesAcrossMaturity(t *testing.T) {
+	// Read path: a pending share->custom row resolves to share before maturity and
+	// custom at/after it, driven purely by the chain epoch at the read height.
+	const node = "node1"
+	row := &witnesses.Witness{
+		Height:                      200,
+		DelegationMode:              delegationmode.Custom, // announced target
+		DelegationModeEffective:     delegationmode.Share,  // protected
+		DelegationModeMaturityEpoch: 16,                    // 10 + 6
+	}
+	se := tlEngine(
+		map[string]*witnesses.Witness{node: row},
+		map[uint64]elections.ElectionResult{
+			210: electionAtEpoch(15, 5), // before maturity
+			260: electionAtEpoch(16, 5), // exactly at maturity
+			300: electionAtEpoch(20, 5), // after
+		},
+	)
+	if got := se.NodeDelegationMode("hive:"+node, 210); got != delegationmode.Share {
+		t.Errorf("before maturity: got %q, want share (still protected)", got)
+	}
+	if got := se.NodeDelegationMode("hive:"+node, 260); got != delegationmode.Custom {
+		t.Errorf("at maturity: got %q, want custom (matured)", got)
+	}
+	if got := se.NodeDelegationMode("hive:"+node, 300); got != delegationmode.Custom {
+		t.Errorf("after maturity: got %q, want custom", got)
+	}
+}
+
+func TestNodeDelegationMode_ZeroFieldsUnchanged(t *testing.T) {
+	// A row with no timelock fields (pre-0.5.0 / non-adverse) resolves to its raw
+	// announced mode with no epoch read — byte-identical to the old behavior.
+	const node = "node1"
+	se := tlEngine(
+		map[string]*witnesses.Witness{node: {Height: 100, DelegationMode: delegationmode.Custom}},
+		nil, // election DB never consulted when maturity==0
+	)
+	if got := se.NodeDelegationMode("hive:"+node, 999); got != delegationmode.Custom {
+		t.Errorf("zero-field row: got %q, want custom", got)
+	}
+}
+
+func TestNodeDelegationMode_GateOffIgnoresTimelock(t *testing.T) {
+	// If a row carries timelock fields but the read height is below the 0.5.0 gate,
+	// the raw target is returned (replay below the floor is byte-identical).
+	const node = "node1"
+	row := &witnesses.Witness{
+		Height:                      200,
+		DelegationMode:              delegationmode.Custom,
+		DelegationModeEffective:     delegationmode.Share,
+		DelegationModeMaturityEpoch: 16,
+	}
+	se := tlEngine(
+		map[string]*witnesses.Witness{node: row},
+		map[uint64]elections.ElectionResult{210: electionAtEpoch(15, 4)}, // consensus 4 → gate off
+	)
+	if got := se.NodeDelegationMode("hive:"+node, 210); got != delegationmode.Custom {
+		t.Errorf("gate-off read: got %q, want custom (timelock ignored)", got)
+	}
+}

--- a/modules/state-processing/pendulum_settlement.go
+++ b/modules/state-processing/pendulum_settlement.go
@@ -257,22 +257,49 @@ func (se *StateEngine) validatePendulumSettlement(rec pendulumsettlement.Settlem
 		return fmt.Errorf("election at snapshot_to=%d has no members", rec.SnapshotRangeTo)
 	}
 	members := make(map[string]struct{}, len(election.Members))
+	memberList := make([]string, 0, len(election.Members))
 	for _, m := range election.Members {
 		acct := m.Account
 		if !strings.HasPrefix(acct, "hive:") {
 			acct = "hive:" + acct
 		}
 		members[acct] = struct{}{}
+		memberList = append(memberList, acct)
+	}
+
+	// Consensus 0.5.0: share-mode nodes pay their delegators, so a distribution
+	// to a non-committee account is legitimate iff that account is a delegator
+	// to a share-mode committee node at the snapshot height. Build the allowed
+	// delegator set from the same deterministic source the re-derivation uses.
+	//
+	// On a transient read failure the set is empty, so a (legitimate) delegator
+	// distribution would be strictly rejected here and the apply refused WITHOUT
+	// advancing the settlement marker — restart-replay then re-attempts the
+	// epoch once the read recovers (the codebase's standard "deterministic ids +
+	// idempotent upserts + replay" self-healing path). So a read blip delays the
+	// settlement on that node, it never diverges, and the actual payouts always
+	// come from the attested, BLS-aggregated record. With no share nodes the set
+	// is empty and this is byte-identical to the pre-0.5.0 members-only check.
+	shareDelegations, _ := se.PendulumShareDelegations(memberList, rec.SnapshotRangeTo)
+	allowedDelegators := make(map[string]struct{})
+	for _, edges := range shareDelegations {
+		for dlg := range edges {
+			allowedDelegators[dlg] = struct{}{}
+		}
 	}
 	for _, d := range rec.Distributions {
 		acct := d.Account
 		if !strings.HasPrefix(acct, "hive:") {
 			acct = "hive:" + acct
 		}
-		if _, ok := members[acct]; !ok {
-			return fmt.Errorf("distribution to non-committee account %s at epoch=%d",
-				d.Account, rec.Epoch)
+		if _, ok := members[acct]; ok {
+			continue
 		}
+		if _, ok := allowedDelegators[acct]; ok {
+			continue
+		}
+		return fmt.Errorf("distribution to non-committee account %s at epoch=%d",
+			d.Account, rec.Epoch)
 	}
 	for _, r := range rec.RewardReductions {
 		acct := r.Account
@@ -340,6 +367,16 @@ func (se *StateEngine) rederivePendulumSettlement(rec pendulumsettlement.Settlem
 		uint64(pendulumoracle.DefaultTickIntervalBlocks),
 	)
 
+	// Consensus 0.5.0: re-read the share-mode delegation edges at the SAME
+	// pinned height (SnapshotRangeTo) the producer used, so the re-derived
+	// record's per-delegator distributions byte-match. A transient read failure
+	// means we can't re-derive deterministically — fall back to structural
+	// validation rather than risk a false byte-mismatch.
+	shareDelegations, sdOk := se.PendulumShareDelegations(members, rec.SnapshotRangeTo)
+	if !sdOk {
+		return nil, false
+	}
+
 	expected, err := pendulumsettlement.ComposeRecord(pendulumsettlement.ComposeInputs{
 		Epoch:               rec.Epoch,
 		PrevEpoch:           rec.PrevEpoch,
@@ -348,6 +385,7 @@ func (se *StateEngine) rederivePendulumSettlement(rec pendulumsettlement.Settlem
 		CommitteeBonds:      bonds,
 		BucketBalanceHBD:    bucket,
 		ReductionsByAccount: reductions,
+		ShareDelegations:    shareDelegations,
 	})
 	if err != nil || expected == nil {
 		return nil, false

--- a/modules/state-processing/safety_evidence_internal_test.go
+++ b/modules/state-processing/safety_evidence_internal_test.go
@@ -45,6 +45,7 @@ func (s *stubLedgerSystem) PendulumDistribute(toAccount string, amount int64, tx
 	return ledgerSystem.LedgerResult{Ok: false, Msg: "stub"}
 }
 func (s *stubLedgerSystem) FinalizeMaturedSafetySlashBurns(blockHeight uint64) {}
+func (s *stubLedgerSystem) MigrateDelegationEdgesOnce(blockHeight uint64) int  { return 0 }
 func (s *stubLedgerSystem) CancelPendingSafetySlashBurn(p ledgerSystem.CancelPendingSafetySlashBurnParams) ledgerSystem.LedgerResult {
 	return ledgerSystem.LedgerResult{Ok: false, Msg: "stub"}
 }

--- a/modules/state-processing/safety_evidence_internal_test.go
+++ b/modules/state-processing/safety_evidence_internal_test.go
@@ -46,6 +46,9 @@ func (s *stubLedgerSystem) PendulumDistribute(toAccount string, amount int64, tx
 }
 func (s *stubLedgerSystem) FinalizeMaturedSafetySlashBurns(blockHeight uint64) {}
 func (s *stubLedgerSystem) MigrateDelegationEdgesOnce(blockHeight uint64) int  { return 0 }
+func (s *stubLedgerSystem) AllDelegationEdges(blockHeight uint64) (map[string]map[string]int64, bool) {
+	return nil, true
+}
 func (s *stubLedgerSystem) CancelPendingSafetySlashBurn(p ledgerSystem.CancelPendingSafetySlashBurnParams) ledgerSystem.LedgerResult {
 	return ledgerSystem.LedgerResult{Ok: false, Msg: "stub"}
 }

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -1929,6 +1929,17 @@ func (se *StateEngine) ExecuteBatch() {
 	// instead of recreating the ledger session for every Hive transaction,
 	// we reuse one session for the whole slot so balance checks see prior ops
 	se.LedgerState.BlockHeight = lastBlockBh
+
+	// Consensus 0.5.0: the first slot whose chain-active version is >= 0.5.0
+	// backfills per-delegator stake edges from history, exactly once (idempotent
+	// via a persisted marker). Runs BEFORE the session/txs below so a delegated
+	// consensus_unstake in this very slot already sees its edge. Stamped at
+	// lastBlockBh so the edge rows are visible to every tx in the slot
+	// (tx.BlockHeight > lastBlockBh). No-op (single indexed lookup) once migrated.
+	if se.LedgerSystem != nil && se.delegatedStakeActive(se.slotStatus.SlotHeight) {
+		se.LedgerSystem.MigrateDelegationEdgesOnce(lastBlockBh)
+	}
+
 	ledgerSession := ledgerSystem.NewSession(se.LedgerState)
 
 	for idx, tx := range se.TxBatch {

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -681,6 +681,13 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 						BlockId:  blockInfo.BlockId,
 						Metadata: rawJson,
 					}
+					// Delegation-mode downgrade timelock (consensus 0.5.0+): resolve
+					// the effective mode + maturity for this announcement from the
+					// prior row and the election at this height, so an adverse
+					// (leaving-Share) change is deferred a full unbond window. Returns
+					// zero-values below 0.5.0, keeping historical rows byte-identical.
+					inputData.DelegationModeEffective, inputData.DelegationModeMaturityEpoch =
+						se.computeDelegationTimelock(acct, blockInfo.BlockHeight, rawJson.VscNode.DelegationMode)
 					se.witnessDb.SetWitnessUpdate(inputData)
 				}
 			}

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -1936,8 +1936,18 @@ func (se *StateEngine) ExecuteBatch() {
 	// consensus_unstake in this very slot already sees its edge. Stamped at
 	// lastBlockBh so the edge rows are visible to every tx in the slot
 	// (tx.BlockHeight > lastBlockBh). No-op (single indexed lookup) once migrated.
-	if se.LedgerSystem != nil && se.delegatedStakeActive(se.slotStatus.SlotHeight) {
-		se.LedgerSystem.MigrateDelegationEdgesOnce(lastBlockBh)
+	//
+	// The gate uses the FAIL-STOP election read (same as the consensus_stake/
+	// unstake handlers) — NOT delegatedStakeActive/ActiveConsensusVersion, which
+	// returns a zero version on a transient election-DB error. A non-fail-stop
+	// gate could let one node skip the migration for a slot while peers run it,
+	// then reject a delegated unstake the peers accept → fork. Fail-stop blocks
+	// until the DB recovers so every node decides identically.
+	if se.LedgerSystem != nil {
+		if elec, found := se.GetElectionInfoOrBlock(se.slotStatus.SlotHeight); found &&
+			DelegatedStakeActiveForElection(elec) {
+			se.LedgerSystem.MigrateDelegationEdgesOnce(lastBlockBh)
+		}
 	}
 
 	ledgerSession := ledgerSystem.NewSession(se.LedgerState)

--- a/modules/state-processing/transactions.go
+++ b/modules/state-processing/transactions.go
@@ -13,6 +13,7 @@ import (
 	"vsc-node/modules/common"
 	"vsc-node/modules/common/common_types"
 	"vsc-node/modules/common/consensusversion"
+	"vsc-node/modules/common/delegationmode"
 	"vsc-node/modules/common/params"
 	contract_execution_context "vsc-node/modules/contract/execution-context"
 	contract_session "vsc-node/modules/contract/session"
@@ -728,6 +729,23 @@ func (tx *TxConsensusStake) ExecuteTx(
 	// Consensus 0.5.0 gate: record a per-delegator edge so the delegator (not the
 	// node) can reclaim this stake. Pre-activation (or pre-genesis) → legacy path.
 	stakeElec, stakeElecFound := se.GetElectionInfoOrBlock(tx.Self.BlockHeight)
+	delegated := stakeElecFound && DelegatedStakeActiveForElection(stakeElec)
+
+	// Consensus 0.5.0: a node must opt in to receive third-party delegation.
+	// When `from != to` (someone other than the operator staking to this node),
+	// the target node's published mode must allow delegation; a Deactivated node
+	// (the default until the operator announces otherwise) rejects it. The
+	// operator's own self-stake (from == to) is always allowed, and unstaking an
+	// existing delegation is never gated (see TxConsensusUnstake). Pre-0.5.0 the
+	// mode is inert and this check is skipped.
+	if delegated && tx.From != tx.To &&
+		!delegationmode.AllowsDelegation(se.NodeDelegationMode(tx.To, tx.Self.BlockHeight)) {
+		return TxResult{
+			Success: false,
+			Ret:     "node does not accept delegations",
+			RcUsed:  100,
+		}
+	}
 
 	params := ledgerSystem.ConsensusParams{
 		Id:          MakeTxId(tx.Self.TxId, tx.Self.OpIndex),
@@ -736,7 +754,7 @@ func (tx *TxConsensusStake) ExecuteTx(
 		Amount:      amount,
 		BlockHeight: tx.Self.BlockHeight,
 		Type:        "stake",
-		Delegated:   stakeElecFound && DelegatedStakeActiveForElection(stakeElec),
+		Delegated:   delegated,
 	}
 
 	ledgerResult := ledgerSession.ConsensusStake(params)

--- a/modules/state-processing/transactions.go
+++ b/modules/state-processing/transactions.go
@@ -725,6 +725,10 @@ func (tx *TxConsensusStake) ExecuteTx(
 		}
 	}
 
+	// Consensus 0.5.0 gate: record a per-delegator edge so the delegator (not the
+	// node) can reclaim this stake. Pre-activation (or pre-genesis) → legacy path.
+	stakeElec, stakeElecFound := se.GetElectionInfoOrBlock(tx.Self.BlockHeight)
+
 	params := ledgerSystem.ConsensusParams{
 		Id:          MakeTxId(tx.Self.TxId, tx.Self.OpIndex),
 		From:        tx.From,
@@ -732,6 +736,7 @@ func (tx *TxConsensusStake) ExecuteTx(
 		Amount:      amount,
 		BlockHeight: tx.Self.BlockHeight,
 		Type:        "stake",
+		Delegated:   stakeElecFound && DelegatedStakeActiveForElection(stakeElec),
 	}
 
 	ledgerResult := ledgerSession.ConsensusStake(params)
@@ -850,6 +855,10 @@ func (tx *TxConsensusUnstake) ExecuteTx(
 		BlockHeight:   tx.Self.BlockHeight,
 		Type:          "unstake",
 		ElectionEpoch: electionResult.Epoch + 5,
+		// Consensus 0.5.0 gate (reuses the election already read above for the
+		// lock epoch): authorize against the signer's delegation edge + debit the
+		// node bond + return HIVE to the delegator. Pre-activation → legacy path.
+		Delegated: DelegatedStakeActiveForElection(electionResult),
 	}
 	ledgerResult := ledgerSession.ConsensusUnstake(params)
 

--- a/modules/state-processing/transactions.go
+++ b/modules/state-processing/transactions.go
@@ -872,7 +872,7 @@ func (tx *TxConsensusUnstake) ExecuteTx(
 		Amount:        amount,
 		BlockHeight:   tx.Self.BlockHeight,
 		Type:          "unstake",
-		ElectionEpoch: electionResult.Epoch + 5,
+		ElectionEpoch: electionResult.Epoch + params.CONSENSUS_UNSTAKE_LOCK_EPOCHS,
 		// Consensus 0.5.0 gate (reuses the election already read above for the
 		// lock epoch): authorize against the signer's delegation edge + debit the
 		// node bond + return HIVE to the delegator. Pre-activation → legacy path.

--- a/tests/devnet/consensus_delegated_devnet_test.go
+++ b/tests/devnet/consensus_delegated_devnet_test.go
@@ -1,0 +1,142 @@
+package devnet
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"vsc-node/modules/common/params"
+)
+
+// consensusDelegation reads getConsensusDelegation(from,to).delegated from a node.
+// from/to are full L2 accounts ("hive:name").
+func (d *Devnet) consensusDelegation(ctx context.Context, node int, from, to string) (int64, error) {
+	const q = `query($f:String!,$t:String!){getConsensusDelegation(from:$f,to:$t){delegated claimable}}`
+	var out struct {
+		GetConsensusDelegation *struct {
+			Delegated int64 `json:"delegated"`
+			Claimable int64 `json:"claimable"`
+		} `json:"getConsensusDelegation"`
+	}
+	if err := d.gqlQuery(ctx, node, q, map[string]any{"f": from, "t": to}, &out); err != nil {
+		return 0, err
+	}
+	if out.GetConsensusDelegation == nil {
+		return 0, nil
+	}
+	return out.GetConsensusDelegation.Delegated, nil
+}
+
+// TestConsensusDelegatedStakeDevnet runs the per-delegator stake/unstake feature
+// on a real multi-node devnet with consensus 0.5.0 pinned active. userA (witness
+// 1) delegates consensus stake to operatorB (witness 2); the per-edge delegation
+// must appear on every node, and userA's undelegate must drain it — proving the
+// gated 0.5.0 path works end-to-end and deterministically across nodes.
+func TestConsensusDelegatedStakeDevnet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	cfg := tssTestConfig()
+	cfg.SkipFunding = false // need L2 HIVE to consensus-stake
+	if cfg.SysConfigOverrides.ConsensusParams == nil {
+		cfg.SysConfigOverrides.ConsensusParams = &params.ConsensusParams{}
+	}
+	// Pin consensus 0.5.0 from epoch 1 so the delegation path is live (delegation
+	// activates at the v0.5.0 floor, alongside the earlier 0.2.0–0.4.0 batches).
+	// NOTE: FloorEpoch must be NON-ZERO — PinnedVersionFloor treats 0 as "no floor".
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorMajor = 0
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorConsensus = 5
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorEpoch = 1
+
+	d, ctx := startDevnetNoKey(t, cfg, 20*time.Minute)
+
+	// Wait for the first running election (epoch >= 1) on every node.
+	for n := 1; n <= cfg.Nodes; n++ {
+		nctx, cancel := context.WithTimeout(ctx, 8*time.Minute)
+		err := d.waitForElectionEpoch(nctx, n, 1, 8*time.Minute)
+		cancel()
+		if err != nil {
+			t.Fatalf("magi-%d never ingested epoch >= 1: %v", n, err)
+		}
+	}
+
+	const A, B = 1, 2
+	userA := d.witnessAccount(A)     // bare "magi.test1" — for ops/required_auths
+	operatorB := d.witnessAccount(B) // bare "magi.test2"
+	userAFull := "hive:" + userA     // L2 account / edge component
+	operatorBFull := "hive:" + operatorB
+
+	// Fund userA and WAIT for the deposit to credit the VSC ledger before staking.
+	if _, err := d.Deposit(ctx, A, "100.000", "hive"); err != nil {
+		t.Fatalf("deposit for userA: %v", err)
+	}
+	if !waitBalancePositive(t, d, ctx, 1, userAFull, "hive", 3*time.Minute) {
+		t.Fatal("deposit never credited userA's VSC hive balance")
+	}
+
+	// userA delegates 5.000 HIVE of consensus stake to operatorB (from != to).
+	t.Logf("userA=%s delegates 5.000 consensus stake to operatorB=%s", userAFull, operatorBFull)
+	if _, err := d.ConsensusStake(A, B, "5.000"); err != nil {
+		t.Fatalf("delegated stake A->B: %v", err)
+	}
+
+	// Poll until the per-edge delegation appears (stake processed AND 0.5.0 active).
+	var edgeOK bool
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(deadline) {
+		if del, _ := d.consensusDelegation(ctx, 1, userAFull, operatorBFull); del == 5000 {
+			edgeOK = true
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
+	if !edgeOK {
+		hc := int64(-1)
+		if bal, err := d.GetAccountBalance(ctx, 1, operatorBFull); err == nil && bal != nil {
+			hc = bal.HiveConsensus
+		}
+		t.Fatalf("edge never reached 5000; operatorB hive_consensus=%d (>0 => 0.5.0 inactive; 0 => stake did not process)", hc)
+	}
+
+	// Deterministic across the whole network: the edge is 5000 on EVERY node.
+	for n := 1; n <= cfg.Nodes; n++ {
+		del, err := d.consensusDelegation(ctx, n, userAFull, operatorBFull)
+		if err != nil {
+			t.Fatalf("magi-%d getConsensusDelegation: %v", n, err)
+		}
+		t.Logf("magi-%d: delegated(A->B) = %d (expect 5000)", n, del)
+		if del != 5000 {
+			t.Errorf("magi-%d: expected delegated=5000, got %d", n, del)
+		}
+	}
+
+	// userA undelegates the full amount — the edge drains immediately (the HIVE
+	// itself returns after the unbond epochs; the edge balance is the assertion).
+	if _, err := d.ledgerOp("vsc.consensus_unstake", userA, operatorB, "5.000", "hive", ""); err != nil {
+		t.Fatalf("delegated unstake A->B: %v", err)
+	}
+	// Poll until the edge drains to 0.
+	var drained bool
+	deadline = time.Now().Add(3 * time.Minute)
+	for time.Now().Before(deadline) {
+		if del, _ := d.consensusDelegation(ctx, 1, userAFull, operatorBFull); del == 0 {
+			drained = true
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
+	if !drained {
+		t.Fatal("edge never drained to 0 after undelegate")
+	}
+	for n := 1; n <= cfg.Nodes; n++ {
+		del, err := d.consensusDelegation(ctx, n, userAFull, operatorBFull)
+		if err != nil {
+			t.Fatalf("magi-%d getConsensusDelegation post-unstake: %v", n, err)
+		}
+		t.Logf("magi-%d: delegated(A->B) after undelegate = %d (expect 0)", n, del)
+		if del != 0 {
+			t.Errorf("magi-%d: expected edge drained to 0, got %d", n, del)
+		}
+	}
+}

--- a/tests/devnet/consensus_delegated_devnet_test.go
+++ b/tests/devnet/consensus_delegated_devnet_test.go
@@ -76,6 +76,10 @@ func TestConsensusDelegatedStakeDevnet(t *testing.T) {
 	}
 
 	// userA delegates 5.000 HIVE of consensus stake to operatorB (from != to).
+	// Consensus 0.5.0 requires the target node to opt in to delegation; devnet
+	// nodes announce delegationmode.Custom (set in devnet-setup), so operatorB
+	// accepts this third-party stake. (A Deactivated node would reject it with
+	// "node does not accept delegations".)
 	t.Logf("userA=%s delegates 5.000 consensus stake to operatorB=%s", userAFull, operatorBFull)
 	if _, err := d.ConsensusStake(A, B, "5.000"); err != nil {
 		t.Fatalf("delegated stake A->B: %v", err)


### PR DESCRIPTION
Lets any account delegate consensus stake to any node and **always reclaim it themselves**, while the node operator can **never** touch a delegator's stake — and now lets delegators **earn their fair share of pendulum rewards**, with node operators **opting in** to (or out of) receiving delegations.

Fixes the prior model where the bond pooled onto the node account and only the `hive_consensus` holder could unstake — so delegators (whose `hive_consensus` is 0) were stuck and operators could drain delegated bond — and closes the gap where 100% of pendulum rewards on delegated bond landed on the operator.

### Why a new 0.3.0 version line
This ships on a **fresh consensus version, v0.3.0** — kept separate from the already-shipped **0.2.0** batch (try/catch ICC + pendulum LP floor), whose mainnet activation heights were fixed without this behavior. Retroactively bundling new consensus rules into 0.2.0 would diverge upgraded vs not-yet-upgraded nodes at that fixed activation height; a separate 0.3.0 floor rise activates delegation on its own coordinated schedule via `vsc.propose_consensus_version → 0.3.0`. Pre-activation behaviour is byte-identical to 0.2.0, so old and new binaries interoperate until the floor reaches 0.3.0.

### Per-delegator stake / unstake
- **Per-edge delegation** modelled as a non-transferable `delegation` asset keyed by composite owner `from::to`, reusing the existing `GetBalance` snapshot/session/cache machinery. The node's aggregate `hive_consensus` is **untouched**, so election weight + pendulum effective bond are unchanged.
- **Stake** records a `from→to` edge (in addition to the unchanged hive debit + node `hive_consensus` credit).
- **Unstake** authorizes against the **signer's own edge** (the operator has no edge to a delegator's stake), debits the **node's** bond, decrements the edge, and returns the HIVE to the **delegator**.
- **Slashing = pro-rata:** every delegator to a slashed node loses the same fraction. Implemented without touching the slash code via a slash-immune gross-total per node; release = `gross × bond/total` (order-independent).
- **Migration:** a one-time, marker-guarded, idempotent backfill at 0.3.0 activation reconstructs edges from historical `#in`/`#out` stake pairs, so **already-staked users become reclaimable**.
- **GraphQL:** `getConsensusDelegation(from, to)` → `{ delegated, claimable }` (claimable = slash-adjusted) for the unstake UI.

### Operator opt-in delegation mode — `deactivated` | `share` | `custom`
An operator chooses how their node participates in delegation. The mode is set in the node config, **published in the on-chain announcement** (`vsc_node.delegation_mode`), stored on the witness record, and **readable via GraphQL**. Because it comes from the operator's own authenticated `update_account`, it is exactly what the operator signed.

- **`deactivated` (default — strict opt-in):** the node accepts **no new third-party delegation**. A `consensus_stake` where `from != to` is rejected at tx time (`"node does not accept delegations"`). The operator's own self-stake (`from == to`) is always allowed, and unstaking an already-delegated bond is **never** gated.
- **`share`:** accepts delegation **and** splits the node's pendulum reward pro-rata across every stake edge (including the operator's own self-stake edge), in proportion to each staker's stake. No separate on-chain operator commission — the operator earns purely via their own stake.
- **`custom`:** accepts delegation but pays all pendulum rewards to the operator account (today's behaviour); any revenue share with delegators is settled off-chain. On-chain this is identical to the legacy reward path.

New leaf package `modules/common/delegationmode` holds the constants + `Normalize`/`AllowsDelegation`/`SharesRewards` helpers (dependency-free, so config/announcement/witness/state-processing/GraphQL can all use it without import cycles). New `getNodeDelegationMode(account, height)` GraphQL query returns the normalized effective mode (defaults to `deactivated`).

### Fair-share pendulum rewards (share mode)
- The per-delegator split is **baked into the attested, BLS-signed, byte-compared settlement record**, so payouts come from the signed record — not recomputed post-hoc at apply time.
- The inter-node pro-rata math is **unchanged**. Each share-mode node's single distribution is then expanded into per-delegator entries that sum to the **exact same amount** (rounding remainder → operator), so `TotalDistributedHBD`, `ResidualHBD`, and the settlement conservation invariant are untouched. With no share nodes the record is byte-identical to the node-level result.
- New `ledgerSystem.AllDelegationEdges` (one deterministic ledger scan) + `StateEngine.PendulumShareDelegations` (edges × share-mode witnesses) feed a new `ComposeInputs.ShareDelegations` field; `settlement.ExpandShareDistributions` performs the split. The **producer**, the **apply-time re-derivation**, and the **structural validator** all read the same source at the pinned `SnapshotRangeTo`, so every node agrees.
- `validatePendulumSettlement` is relaxed to allow distributions to delegators of share-mode committee members. On a transient read failure it strictly rejects and the apply is refused **without advancing the settlement marker** — restart-replay re-attempts the epoch once the read recovers (the codebase's standard self-healing path), so a read blip delays a settlement on that node but never diverges.

### Version plumbing
- `consensusversion`: `currentConsensus` 2 → 3; added the `V0_3_0` line + `Version0_3_0Active` resolver. `delegatedStakeMinVersion` keys off `V0_3_0`. The 0.2.0 history entry is restored to its ICC + LP-floor meaning; delegation is documented under a new 0.3.0 entry.

### Consensus-safety fixes (from self-review of the original delegation work)
1. **Oplog fork (critical):** `Params` were stamped unconditionally; since the oplog is CBOR'd into the L2 block CID, this forked old/new nodes on any stake/unstake block *before* activation. Fixed: legacy oplog Params are now byte-identical (`consensus_stake` none, `consensus_unstake` only `{epoch}`). Guarded by a test.
2. **Migration gate not fail-stop:** could let one node skip the backfill and reject an unstake peers accept → fork. Fixed: gate on the fail-stop election read.

### Testing
- **Unit:** `delegationmode` helpers; delegation-edge grouping; the reward split (`ExpandShareDistributions`) incl. conservation/merge/remainder properties; `ComposeRecord` totals are preserved when sharing; entitlement invariant (operator can't unstake a delegator's stake); pro-rata slash; migration run-once + idempotency; legacy-oplog-Params guard.
- **Handler:** stake-time mode gate — `deactivated`/`share`/`custom`/operator-self-stake; inert at 0.2.0, active at 0.3.0.
- **Integration (real `LedgerSystem` + witness DB):** `PendulumShareDelegations` includes a share node with its exact edges and excludes custom/deactivated nodes; `NodeDelegationMode` reads/normalizes/defaults.
- **Devnet (5 nodes, 0.3.0 pinned active):** ✅ `userA → operatorB` third-party delegation of 5.000 succeeds (operatorB announces a delegation-accepting mode), edge = 5000 on **every** node, undelegate → drains to **0** on every node.
- **No new regressions:** state-processing test failures are byte-identical to the `develop` baseline.

### Notes
- **Rebased onto `develop`** (which already carries 0.2.0 + the bond-inclusion window + safety-slash work).
- Also fixes a small pre-existing build break in `modules/rc-system/rc_system_test.go` (duplicate mock methods / missing interface methods).

### Follow-up (not in this PR)
- Pre-mainnet: a testnet/devnet run with a real `propose_consensus_version → 0.3.0` activation exercising the actual activation + migration over real pre-0.3.0 stakes, plus a `share`-mode node with a third-party delegator across a settlement to observe live reward splitting.
- **Open product decision:** `share` mode currently takes **no on-chain operator commission** (operators wanting a cut use `custom` + an off-chain agreement). If a configurable on-chain commission is wanted, it's a small pre-split deduction.
