### PR TITLE
bound swap fee - scale CLP leg, clamp total, gate on height

### DIFF
--- a/modules/common/params/params.go
+++ b/modules/common/params/params.go
@@ -73,6 +73,16 @@ var MINIMUM_RC_LIMIT uint64 = 50
 var CONTRACT_DEPLOYMENT_FEE int64 = 10_000 // 10 HBD per contract
 var CONTRACT_DEPLOYMENT_FEE_START_HEIGHT uint64 = 99410000
 var CONTRACT_UPDATE_HEIGHT uint64 = 102100000
+
+// PENDULUM_FEE_FIX_HEIGHT is the mainnet activation height (Hive L1 block) for
+// the 2026-06 pendulum swap-fee overcharge fix (CLP-leg scaling + total-fee
+// clamp in incentive-pendulum/wasm). Below this height the applier reproduces
+// the pre-fix fee math bit-for-bit so witnesses can upgrade across the rollout
+// window without diverging; at/after it every witness switches to the bounded
+// fee atomically. ~6h after the 2026-06-18 deploy decision (head ≈107,389,200 +
+// 7200 blocks @3s; cf. ELECTION_INTERVAL = 6*60*20). Mainnet only — testnet and
+// devnet run the fix immediately (Config.ActivationHeight 0).
+var PENDULUM_FEE_FIX_HEIGHT uint64 = 107_396_400
 var CONTRACT_CALL_MAX_RECURSION_DEPTH = 20
 
 // review2 LOW #70/#110: contract-call payloads were only UTF-8 checked,

--- a/modules/incentive-pendulum/wasm/applier.go
+++ b/modules/incentive-pendulum/wasm/applier.go
@@ -43,15 +43,36 @@ type Config struct {
 	// means PDF behavior (no floor); leaving as a Config knob so we can dial
 	// it without code change once the team picks a value.
 	MinFractionBps int
+	// CLPScaleBps scales the CLP (slip) fee leg: chargedCLP =
+	// baseCLP·CLPScaleBps/10000. The stabilizer multiplier m does NOT ride this
+	// leg — m applies to the protocol leg only. baseCLP is the THORChain-style
+	// slip fee (≈ the swap's own price impact), so charging it in full and then
+	// ×m overcharged large swaps ~2× their slippage (the 2026-06 incident).
+	// 625 = 1/16 tames it; 0 drops the CLP leg entirely (protocol-fee-only).
+	CLPScaleBps int64
+	// MaxFeeBps hard-caps the total fee at grossOut·MaxFeeBps/10000; any excess
+	// is trimmed from the CLP leg (the protocol tier is preserved). 0 disables
+	// the clamp. Backstop so a misconfigured CLPScaleBps cannot reproduce the
+	// overcharge.
+	MaxFeeBps int64
+	// ActivationHeight gates the CLPScaleBps + MaxFeeBps fix on a Hive L1 block
+	// height. Below it the applier reproduces the pre-fix fee math bit-for-bit
+	// so witnesses can upgrade across a rollout window without diverging; at/
+	// after it the bounded fee is active. 0 = always active (no gate) — the
+	// testnet/devnet default. Mainnet sets params.PENDULUM_FEE_FIX_HEIGHT.
+	ActivationHeight uint64
 }
 
-// DefaultConfig returns the v1 testnet defaults: PDF stabilizer, 25% network
-// share, no LP floor. Override per-network via SystemConfig.
+// DefaultConfig returns the production defaults: PDF stabilizer, 25% network
+// share, no LP floor, the CLP slip leg scaled to 1/16 with m off it, and a 1%
+// total-fee clamp. Override per-network via SystemConfig.
 func DefaultConfig() Config {
 	return Config{
 		Stabilizer:      pendulum.DefaultStabilizerParamsBps(),
 		NetworkShareNum: 1,
 		NetworkShareDen: 4,
+		CLPScaleBps:     625, // 1/16
+		MaxFeeBps:       100, // 1.0% total-fee backstop
 	}
 }
 
@@ -177,10 +198,17 @@ func (a *Applier) ApplySwapFees(
 		big.NewInt(pendulum.BpsScale),
 	)
 
-	// 4. Stabilizer multiplier on both fee legs. PDF §5: total fee is
-	// (baseProtocol + baseCLP) · m; the surplus on each leg funds the
-	// rebalancing incentive and flows through the same 25%/75%
-	// network/pendulum split as the base fee.
+	// 4. Fee legs. The protocol leg is the flat tier and carries the stabilizer
+	// multiplier m. The CLP (slip) leg is scaled by cfg.CLPScaleBps and is
+	// deliberately NOT multiplied by m.
+	//
+	//   baseCLP = x²·Y/(x+X)² is the THORChain-style slip fee, which is
+	//   algebraically ≈ the swap's own price impact (CLP/impact = X/(X+x) ≈ 1).
+	//   The user already pays that impact through the curve, so charging the
+	//   full slip on top — and doubling it with m — overcharged large swaps
+	//   quadratically (≈2× price impact at the m cap; the 2026-06 incident).
+	//   cfg.CLPScaleBps (default 625 = 1/16) tames it to a small,
+	//   slip-proportional surcharge; CLPScaleBps == 0 drops the leg entirely.
 	//
 	// "Exacerbates" is derived from snapshot s and the swap direction — the
 	// SDK has all inputs, so accepting a contract-supplied hint would be a
@@ -201,19 +229,50 @@ func (a *Applier) ApplySwapFees(
 	if err != nil {
 		return sdkErr[wasm_context.PendulumSwapFeeResult](err)
 	}
-	chargedCLP := pendulum.ApplyMultiplierBps(baseCLP, multiplierBps)
 	chargedProtocol := pendulum.ApplyMultiplierBps(baseProtocol, multiplierBps)
 
-	// 5. Total fees per type, all output units. m rides on both legs;
-	// totalX == chargedX == baseX·m (with a floor of baseX so a degenerate
-	// m < 1 cannot subtract from the base fee).
-	totalCLP := chargedCLP
-	if totalCLP.Cmp(baseCLP) < 0 {
-		totalCLP = baseCLP
-	}
+	// 5. Total fees per type, all output units. The protocol leg always carries
+	// m and floors at baseProtocol so a degenerate m < 1 cannot subtract from it.
 	totalProtocol := chargedProtocol
 	if totalProtocol.Cmp(baseProtocol) < 0 {
 		totalProtocol = baseProtocol
+	}
+
+	// feeFixActive gates the 2026-06 overcharge fix on cfg.ActivationHeight — a
+	// Hive L1 block height (0 = always active, the testnet/devnet default).
+	// Before the height the applier reproduces the deployed pre-fix CLP math
+	// bit-for-bit so witnesses upgrading across the rollout window stay in
+	// consensus; at/after it the bounded fee takes effect for everyone atomically.
+	feeFixActive := a.cfg.ActivationHeight == 0 || blockHeight >= a.cfg.ActivationHeight
+
+	var totalCLP *big.Int
+	if feeFixActive {
+		// Fixed: CLP scaled by cfg.CLPScaleBps, m-independent, and no baseCLP
+		// floor (a floor here would defeat the k scaling).
+		totalCLP = pendulum.ApplyMultiplierBps(baseCLP, a.cfg.CLPScaleBps)
+	} else {
+		// Legacy (pre-fix): m rides the CLP leg, floored at baseCLP. This is the
+		// overcharge — baseCLP ≈ the swap's price impact, then doubled by m.
+		totalCLP = pendulum.ApplyMultiplierBps(baseCLP, multiplierBps)
+		if totalCLP.Cmp(baseCLP) < 0 {
+			totalCLP = baseCLP
+		}
+	}
+
+	// 5b. Safety clamp (fix only): bound the total fee to grossOut·MaxFeeBps/
+	// 10000, trimming the CLP leg (protocol tier preserved) before the splits so
+	// every downstream share derives from the capped legs and conservation still
+	// holds. Skipped pre-activation to stay bit-identical to the deployed path.
+	// 0 disables the clamp.
+	if feeFixActive && a.cfg.MaxFeeBps > 0 {
+		feeCap := intmath.MulDivFloor(grossOut, big.NewInt(a.cfg.MaxFeeBps), big.NewInt(pendulum.BpsScale))
+		if new(big.Int).Add(totalCLP, totalProtocol).Cmp(feeCap) > 0 {
+			maxCLP := new(big.Int).Sub(feeCap, totalProtocol)
+			if maxCLP.Sign() < 0 {
+				maxCLP = new(big.Int)
+			}
+			totalCLP = maxCLP
+		}
 	}
 
 	// 6. User pays both fees out of grossOut.

--- a/modules/incentive-pendulum/wasm/applier_test.go
+++ b/modules/incentive-pendulum/wasm/applier_test.go
@@ -1,8 +1,10 @@
 package pendulumwasm
 
 import (
+	"math/big"
 	"testing"
 
+	"vsc-node/lib/intmath"
 	pendulum "vsc-node/modules/incentive-pendulum"
 	pendulumoracle "vsc-node/modules/incentive-pendulum/oracle"
 	wasm_context "vsc-node/modules/wasm/context"
@@ -56,11 +58,7 @@ func newApplier(t *testing.T, geo pendulumoracle.GeometryOutputs, whitelist []st
 	a := New(
 		&stubGeometry{out: geo},
 		func() []string { return whitelist },
-		Config{
-			Stabilizer:      pendulum.DefaultStabilizerParamsBps(),
-			NetworkShareNum: 1,
-			NetworkShareDen: 4,
-		},
+		DefaultConfig(),
 	)
 	return a, &recordingAccrual{}
 }
@@ -303,13 +301,14 @@ func TestReserveConservationHBDIn(t *testing.T) {
 	}
 }
 
-// TestStabilizerMultiplierAppliesToFullFee pins the policy decision from
-// review-and-plan.md issue #7: m rides on (baseProtocol + baseCLP), not
-// protocol alone. The load-bearing assertion is that the extra fee charged
-// when m > 1 is dominated by the CLP leg — under the prior "m on protocol
-// only" code, the delta would be ~baseProtocol·(m−1) (single-digit base
-// units in this scenario), nowhere near baseCLP·(m−1).
-func TestStabilizerMultiplierAppliesToFullFee(t *testing.T) {
+// TestStabilizerMultiplierRidesProtocolLegOnly pins the post-incident policy
+// (it reverses review-and-plan.md issue #7): the stabilizer multiplier m rides
+// the flat protocol leg ONLY. The CLP (slip) leg is scaled by cfg.CLPScaleBps and
+// is independent of m, so a high m can no longer double the price-impact-sized
+// CLP fee. Load-bearing assertion: the extra fee when m climbs 1.0→1.4 is just
+// baseProtocol·(m−1) (a couple base units), NOT the baseCLP·(m−1) blowup (~39
+// units here) the old "m on full fee" code charged.
+func TestStabilizerMultiplierRidesProtocolLegOnly(t *testing.T) {
 	args := wasm_context.PendulumSwapFeeArgs{
 		AssetIn:  "hbd", // HBD-in raises s; with s ≥ s_eq, this exacerbates → push=1.0.
 		AssetOut: "hive",
@@ -318,7 +317,7 @@ func TestStabilizerMultiplierAppliesToFullFee(t *testing.T) {
 		YReserve: 1_000_000,
 	}
 
-	// Baseline: s = 1.0 (s_eq) → m = 1.0 → totalFee == baseCLP + baseProtocol.
+	// Baseline: s = 1.0 (s_eq) → m = 1.0.
 	aBase, accBase := newApplier(t, balancedGeometry(), []string{"contract:pool-1"})
 	resBase := aBase.ApplySwapFees("contract:pool-1", "tx-1", 100, args, accBase.fn)
 	if resBase.IsErr() {
@@ -346,32 +345,178 @@ func TestStabilizerMultiplierAppliesToFullFee(t *testing.T) {
 		t.Fatalf("expected m == 1.4 at s=1.2, r=1%%, got %d bps", outHigh.MultiplierBps)
 	}
 
-	// Reserves identical in both runs → grossOut, baseCLP, baseProtocol all
-	// identical. Any difference in userOutput is the extra fee charged by m.
-	extraFee := outBase.UserOutput - outHigh.UserOutput
-	if extraFee <= 0 {
-		t.Fatalf("expected user output to drop with m>1, got base=%d high=%d", outBase.UserOutput, outHigh.UserOutput)
-	}
-
-	// Hand-computed at args + s=0.7:
+	// Reserves identical → grossOut, baseCLP, baseProtocol identical. Any drop in
+	// userOutput is the extra fee m adds. With m on the protocol leg only:
 	//   grossOut       = floor(10000·1_000_000 / 1_010_000) = 9900
-	//   baseCLP        = floor(10000² · 1_000_000 / 1_010_000²) = 98
 	//   baseProtocol   = floor(9900 · 8 / 10000) = 7
-	//   chargedCLP     = floor(98 · 14000 / 10000) = 137 → surplusCLP = 39
-	//   chargedProtocol= floor(7 · 14000 / 10000) = 9   → surplusProtocol = 2
-	// Total surplus under "m on full fee" = 41.
-	// Under prior "m on protocol only" the surplus would have been just 2.
-	wantExtraFee := int64(41)
-	if extraFee != wantExtraFee {
-		t.Fatalf("extra fee from m=1.4 = %d, want %d (m must ride on full fee, not protocol only)", extraFee, wantExtraFee)
+	//   chargedProtocol(1.0) = 7 ; chargedProtocol(1.4) = floor(7·14000/10000) = 9
+	//   extraFee = 9 − 7 = 2   (the CLP leg is m-independent, identical in both)
+	// Under the OLD "m on full fee" policy this would have been ~41 (baseCLP·0.4).
+	extraFee := outBase.UserOutput - outHigh.UserOutput
+	if extraFee != 2 {
+		t.Fatalf("extra fee from m=1.4 = %d, want 2 (m must ride the protocol leg only)", extraFee)
+	}
+	// Guard against regression back to the m-on-CLP blowup: baseCLP here is ~98,
+	// so m leaking onto it would push extraFee into the tens.
+	const protocolOnlyBound = 5
+	if extraFee > protocolOnlyBound {
+		t.Fatalf("extra fee %d > %d — m is leaking onto the CLP leg", extraFee, protocolOnlyBound)
+	}
+}
+
+// incidentGeometry reproduces the 2026-06 incident snapshot: s ≈ 1.82, far above
+// the s_eq = 1.0 target, which pins the stabilizer multiplier m at its 2× cap.
+func incidentGeometry() pendulumoracle.GeometryOutputs {
+	return pendulumoracle.GeometryOutputs{
+		OK:   true,
+		V:    1_820_000,
+		P:    910_000,
+		E:    1_000_000,
+		T:    1_000_000,
+		SBps: 18_217, // 1.8217
+	}
+}
+
+// incidentArgs reconstructs the overcharged swap (80.861 HBD in → ~1511 HIVE out)
+// from its logged slip x/(x+X) ≈ 3.16%.
+func incidentArgs() wasm_context.PendulumSwapFeeArgs {
+	return wasm_context.PendulumSwapFeeArgs{
+		AssetIn:  "hbd",
+		AssetOut: "hive",
+		X:        80_861,
+		XReserve: 2_474_000,
+		YReserve: 47_755_000,
+	}
+}
+
+// incidentBaseFees recomputes grossOut, baseCLP and baseProtocol with the same
+// integer ops the applier uses, so the regression tests can reason about the
+// pre-/post-fix fee without re-deriving the whole pipeline.
+func incidentBaseFees() (grossOut, baseCLP, baseProtocol *big.Int) {
+	a := incidentArgs()
+	x := big.NewInt(a.X)
+	xPlusX := big.NewInt(a.X + a.XReserve)
+	y := big.NewInt(a.YReserve)
+	grossOut = intmath.MulDivFloor(x, y, xPlusX)
+	x2 := new(big.Int).Mul(x, x)
+	denom2 := new(big.Int).Mul(xPlusX, xPlusX)
+	baseCLP = intmath.MulDivFloor(x2, y, denom2)
+	baseProtocol = intmath.MulDivFloor(grossOut, big.NewInt(8), big.NewInt(pendulum.BpsScale))
+	return
+}
+
+// TestCLPScaleTamesLargeSwap is the regression test for the 2026-06 overcharge.
+// On the real incident swap (m pinned at 2×), the default CLPScaleBps = 1/16 must
+// keep the total fee in the ~0.36% band instead of the ~6.5% the old "full CLP ×
+// m" code charged — an order-of-magnitude reduction — while staying under the 1%
+// clamp.
+func TestCLPScaleTamesLargeSwap(t *testing.T) {
+	a, acc := newApplier(t, incidentGeometry(), []string{"contract:pool-1"})
+	res := a.ApplySwapFees("contract:pool-1", "tx-incident", 100, incidentArgs(), acc.fn)
+	if res.IsErr() {
+		t.Fatalf("incident swap failed: %v", res)
+	}
+	out := res.Unwrap()
+
+	// Sanity: this is the worst case the incident hit — m at the 2× cap.
+	if out.MultiplierBps != pendulum.BpsScale*2 {
+		t.Fatalf("expected m pinned at 2× cap, got %d bps", out.MultiplierBps)
 	}
 
-	// Sanity: the CLP leg alone contributes far more than the protocol leg —
-	// i.e., even if integer rounding shifts the exact value, the delta cannot
-	// collapse back to the "protocol-only" regime.
-	const protocolOnlyBound = 5 // generous upper bound on (chargedProtocol − baseProtocol)
-	if extraFee <= protocolOnlyBound {
-		t.Fatalf("extra fee %d ≤ protocol-only bound %d — CLP leg is not being multiplied", extraFee, protocolOnlyBound)
+	grossOut, baseCLP, baseProtocol := incidentBaseFees()
+	newFee := new(big.Int).Sub(grossOut, big.NewInt(out.UserOutput))
+
+	// Bounded under the 1% clamp.
+	feeCap := intmath.MulDivFloor(grossOut, big.NewInt(100), big.NewInt(pendulum.BpsScale))
+	if newFee.Cmp(feeCap) > 0 {
+		t.Fatalf("new fee %s exceeds 1%% clamp %s", newFee, feeCap)
+	}
+
+	// Pinned to the k=1/16 band: 0.30%–0.60% of grossOut (the model said 0.36%).
+	// Lower bound proves the CLP leg still contributes (k≠0); upper bound proves
+	// the overcharge is gone.
+	lo := intmath.MulDivFloor(grossOut, big.NewInt(30), big.NewInt(pendulum.BpsScale))
+	hi := intmath.MulDivFloor(grossOut, big.NewInt(60), big.NewInt(pendulum.BpsScale))
+	if newFee.Cmp(lo) < 0 || newFee.Cmp(hi) > 0 {
+		t.Fatalf("new fee %s outside the [%s, %s] (0.30–0.60%%) k=1/16 band", newFee, lo, hi)
+	}
+
+	// At least 10× cheaper than the old policy (baseCLP·m + baseProtocol·m).
+	m := big.NewInt(int64(out.MultiplierBps))
+	oldFee := new(big.Int).Add(
+		intmath.MulDivFloor(baseCLP, m, big.NewInt(pendulum.BpsScale)),
+		intmath.MulDivFloor(baseProtocol, m, big.NewInt(pendulum.BpsScale)),
+	)
+	if new(big.Int).Mul(newFee, big.NewInt(10)).Cmp(oldFee) >= 0 {
+		t.Fatalf("new fee %s not ≥10× below old fee %s", newFee, oldFee)
+	}
+}
+
+// TestMaxFeeClampBinds proves the backstop: even if CLPScaleBps is misconfigured
+// all the way back to full slip (k=1), the clamp trims the CLP leg so the total
+// fee lands exactly on grossOut·MaxFeeBps/10000, and the network/pendulum split
+// still conserves against that capped total.
+func TestMaxFeeClampBinds(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.CLPScaleBps = pendulum.BpsScale // 1.0 → full slip, reproduces the overcharge pre-clamp
+	a := New(&stubGeometry{out: incidentGeometry()}, func() []string { return []string{"contract:pool-1"} }, cfg)
+	acc := &recordingAccrual{}
+
+	res := a.ApplySwapFees("contract:pool-1", "tx-clamp", 100, incidentArgs(), acc.fn)
+	if res.IsErr() {
+		t.Fatalf("clamped swap failed: %v", res)
+	}
+	out := res.Unwrap()
+
+	grossOut, _, _ := incidentBaseFees()
+	feeCap := intmath.MulDivFloor(grossOut, big.NewInt(int64(cfg.MaxFeeBps)), big.NewInt(pendulum.BpsScale))
+	newFee := new(big.Int).Sub(grossOut, big.NewInt(out.UserOutput))
+	if newFee.Cmp(feeCap) != 0 {
+		t.Fatalf("clamp did not bind exactly: fee %s, cap %s", newFee, feeCap)
+	}
+
+	// Conservation against the capped total: lp + node + network == total fee.
+	split := big.NewInt(out.LpShareOutput + out.NodeShareOutput + out.NetworkCreditOutput)
+	if split.Cmp(feeCap) != 0 {
+		t.Fatalf("splits %s do not conserve to capped fee %s", split, feeCap)
+	}
+}
+
+// TestActivationHeightGate proves the rollout gate: below cfg.ActivationHeight
+// the applier charges the legacy (overcharged) fee, and at/after it charges the
+// bounded fix. Same incident swap and geometry — only the block height differs.
+func TestActivationHeightGate(t *testing.T) {
+	const H = 107_396_400
+	cfg := DefaultConfig()
+	cfg.ActivationHeight = H
+	mk := func() *Applier {
+		return New(&stubGeometry{out: incidentGeometry()}, func() []string { return []string{"contract:pool-1"} }, cfg)
+	}
+	grossOut, _, _ := incidentBaseFees()
+	fee := func(bh uint64, tx string) *big.Int {
+		res := mk().ApplySwapFees("contract:pool-1", tx, bh, incidentArgs(), (&recordingAccrual{}).fn)
+		if res.IsErr() {
+			t.Fatalf("swap at height %d failed: %v", bh, res)
+		}
+		return new(big.Int).Sub(grossOut, big.NewInt(res.Unwrap().UserOutput))
+	}
+
+	preFee := fee(H-1, "tx-pre") // one block before activation → legacy overcharge
+	atFee := fee(H, "tx-at")     // activation block → bounded fix
+
+	// Pre-activation must be in the overcharge regime (>5% of grossOut here).
+	overchargeBar := intmath.MulDivFloor(grossOut, big.NewInt(500), big.NewInt(pendulum.BpsScale))
+	if preFee.Cmp(overchargeBar) < 0 {
+		t.Fatalf("pre-activation fee %s below the >5%% overcharge regime — gate not holding legacy math", preFee)
+	}
+	// Activation must cut the fee by at least 10×.
+	if new(big.Int).Mul(atFee, big.NewInt(10)).Cmp(preFee) >= 0 {
+		t.Fatalf("activation did not cut the fee ≥10×: pre=%s at=%s", preFee, atFee)
+	}
+	// And the post-activation fee must obey the 1% clamp.
+	feeCap := intmath.MulDivFloor(grossOut, big.NewInt(100), big.NewInt(pendulum.BpsScale))
+	if atFee.Cmp(feeCap) > 0 {
+		t.Fatalf("post-activation fee %s exceeds 1%% clamp %s", atFee, feeCap)
 	}
 }
 

--- a/modules/state-processing/pendulum_conservation_test.go
+++ b/modules/state-processing/pendulum_conservation_test.go
@@ -7,7 +7,6 @@ import (
 	"vsc-node/lib/intmath"
 	"vsc-node/lib/test_utils"
 	ledgerDb "vsc-node/modules/db/vsc/ledger"
-	pendulum "vsc-node/modules/incentive-pendulum"
 	pendulumoracle "vsc-node/modules/incentive-pendulum/oracle"
 	pendulumwasm "vsc-node/modules/incentive-pendulum/wasm"
 	ledgerSystem "vsc-node/modules/ledger-system"
@@ -99,11 +98,7 @@ func TestPendulumAccrualHBDConservation(t *testing.T) {
 	a := pendulumwasm.New(
 		&stubGeometryForConservation{out: balancedConservationGeometry()},
 		func() []string { return []string{contractID} },
-		pendulumwasm.Config{
-			Stabilizer:      pendulum.DefaultStabilizerParamsBps(),
-			NetworkShareNum: 1,
-			NetworkShareDen: 4,
-		},
+		pendulumwasm.DefaultConfig(),
 	)
 
 	const swapBh = uint64(100)
@@ -177,17 +172,15 @@ func TestPendulumAccrualFailsWhenContractUnderfunded(t *testing.T) {
 	a := pendulumwasm.New(
 		&stubGeometryForConservation{out: balancedConservationGeometry()},
 		func() []string { return []string{contractID} },
-		pendulumwasm.Config{
-			Stabilizer:      pendulum.DefaultStabilizerParamsBps(),
-			NetworkShareNum: 1,
-			NetworkShareDen: 4,
-		},
+		pendulumwasm.DefaultConfig(),
 	)
 
 	args := wasm_context.PendulumSwapFeeArgs{
 		AssetIn:  "hive",
 		AssetOut: "hbd",
-		X:        10_000,
+		// Large swap so the (now CLP-scaled) node accrual still robustly exceeds
+		// the contract's tiny seeded HBD balance and the transfer guard fires.
+		X:        200_000,
 		XReserve: 1_000_000,
 		YReserve: 1_000_000,
 	}

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -2549,6 +2549,13 @@ func New(sconf systemconfig.SystemConfig, da *DataLayer.DataLayer,
 		},
 		&pendulumCommitteeBondReader{se: se},
 	)
+	// On mainnet the 2026-06 swap-fee overcharge fix is gated to a coordinated
+	// activation height so witnesses can upgrade across the rollout window
+	// without diverging; testnet/devnet run the fix immediately (height 0).
+	pendulumCfg := pendulumwasm.DefaultConfig()
+	if sconf.OnMainnet() {
+		pendulumCfg.ActivationHeight = params.PENDULUM_FEE_FIX_HEIGHT
+	}
 	se.pendulumApplier = pendulumwasm.New(
 		&liveGeometryReader{
 			computer:          se.pendulumGeometry,
@@ -2558,7 +2565,7 @@ func New(sconf systemconfig.SystemConfig, da *DataLayer.DataLayer,
 			effectiveStakeDen: 3,
 		},
 		func() []string { return sconf.PendulumPoolWhitelist() },
-		pendulumwasm.DefaultConfig(),
+		pendulumCfg,
 	)
 
 	return se


### PR DESCRIPTION
The pendulum swap-fee rewrite (deployed 2026-06-02) overcharged large swaps. The CLP leg `baseCLP = x²·Y/(x+X)²` is the THORChain slip fee, which is algebraically ≈ the swap's own price impact (CLP/impact = X/(X+x) ≈ 1). It was charged on top of the CPMM grossOut (a double charge) and then doubled again by the stabilizer m — pinned at the 2× cap because s_eq=1.0 vs live s≈1.82 — so the effective fee ran ~2× price impact, quadratic in size. A real mainnet swap (80.861 HBD → 1413 HIVE) paid 97.8 HIVE (~6.5%); the worst swap in 7 days paid ~13%.

Fix (incentive-pendulum/wasm/applier.go):
- Scale the CLP leg by Config.CLPScaleBps (default 625 = 1/16) and take the stabilizer m OFF the CLP leg — m now rides the flat protocol leg only. The baseCLP floor is removed (it would defeat the k scaling).
- Add a Config.MaxFeeBps clamp (default 100 = 1%): bound totalFee to grossOut·MaxFeeBps/10000, trimming the CLP leg before the splits so conservation still holds. Defense-in-depth backstop.
- Modelled against 7 days of real fee events: k=1/16 takes the incident swap from 6.5% to ~0.36% and the daily total from ~10% of volume to ~0.17% average.

Mainnet rollout gate:
- params.PENDULUM_FEE_FIX_HEIGHT = 107_396_400 (Hive L1, ~6h out).
- state_engine wires Config.ActivationHeight to that height only on OnMainnet(); testnet/devnet run the fix immediately (height 0).
- Below the height the applier reproduces the deployed pre-fix math bit-for-bit, so witnesses can upgrade across the window without diverging and flip atomically at the height. Mirrors the existing CONTRACT_DEPLOYMENT_FEE_START_HEIGHT + OnMainnet() pattern.

Node operators' swap rewards drop to ~6.6% by design — that income was the overcharge. Funding nodes from swaps is a separate, deliberate decision (flat protocol bps, or node-runner rewards), not this fix.

Tests:
- TestCLPScaleTamesLargeSwap: incident swap pinned to 0.30–0.60%, ≥10× below the old fee.
- TestMaxFeeClampBinds: clamp binds exactly and the splits conserve.
- TestStabilizerMultiplierRidesProtocolLegOnly: replaces the old m-on-both-legs test; m now rides the protocol leg only.
- TestActivationHeightGate: legacy fee below H, bounded fee at/after H.
- pendulum_conservation_test.go: use DefaultConfig (production knobs) and enlarge the underfunded swap so the now-smaller accrual still trips the balance guard.