### PR TITLE
Audit/dash final findings 2026 06 18

### DIFF
--- a/cmd/is-service/address_signer_vault_transit.go
+++ b/cmd/is-service/address_signer_vault_transit.go
@@ -357,7 +357,7 @@ func (s *AddressSignerVaultTransit) Sign(callerCtx context.Context, depositAddre
 		return "", fmt.Errorf("calling vault transit/sign: %w", err)
 	}
 	defer resp.Body.Close()
-	rawBody, _ := io.ReadAll(resp.Body)
+	rawBody, _ := io.ReadAll(io.LimitReader(resp.Body, 16<<20)) // audit L3: bound Vault response
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		// Audit OPS-R15-04 (R15) + R16-OPS-vault-sign-401-no-token-
 		// source-identity (R16, MED): tag the status class so on-call
@@ -446,7 +446,7 @@ func (s *AddressSignerVaultTransit) fetchLatestPublicKey(ctx context.Context) (s
 		return "", 0, fmt.Errorf("calling vault transit/keys: %w", err)
 	}
 	defer resp.Body.Close()
-	rawBody, _ := io.ReadAll(resp.Body)
+	rawBody, _ := io.ReadAll(io.LimitReader(resp.Body, 16<<20)) // audit L3: bound Vault response
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return "", 0, fmt.Errorf("vault transit/keys returned %d: %s", resp.StatusCode, string(rawBody))
 	}

--- a/cmd/is-service/args.go
+++ b/cmd/is-service/args.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 )
 
 // validateOperatorURL enforces that operator-supplied URL flags
@@ -77,12 +78,14 @@ type args struct {
 	dashdRPCURL          string
 	dashdRPCUser         string
 	dashdRPCPassword     string
+	dashdRPCPasswordFile string // audit M15: file alt
 	// L2 submitter — when l2GqlURL + l2PrivKeyHex are both set, the IS
 	// service will actually post mapInstantSendV2 transactions instead
 	// of using the log-only stub. The submitter's derived DID needs to
 	// be HBD-funded for RC.
 	l2GqlURL              string
 	l2PrivKeyHex          string
+	l2PrivKeyFile         string // audit M15: file alt for l2PrivKey
 	l2DashMappingContract string
 	l2RcLimit             int64
 	// libp2p broadcaster — when p2pBootstrapPeers is set, the IS
@@ -164,7 +167,12 @@ func parseArgs() (args, error) {
 		"dashd JSON-RPC URL for IS-lock observation (optional; e.g. http://vsc-dashd-testnet:9998). "+
 			"When unset, IS_OBSERVED transitions must be driven externally.")
 	fs.StringVar(&a.dashdRPCUser, "dashdRPCUser", "vsc-node-user", "dashd RPC username")
-	fs.StringVar(&a.dashdRPCPassword, "dashdRPCPassword", "vsc-node-pass", "dashd RPC password")
+	fs.StringVar(&a.dashdRPCPassword, "dashdRPCPassword", "vsc-node-pass",
+		"dashd RPC password (DEV/TEST default; production should use "+
+			"-dashdRPCPasswordFile per audit M15 to keep the secret out of /proc/cmdline + journal)")
+	fs.StringVar(&a.dashdRPCPasswordFile, "dashdRPCPasswordFile", "",
+		"Path to a file containing the dashd RPC password (audit M15 file alt for "+
+			"-dashdRPCPassword; preferred for production). Whitespace is trimmed.")
 
 	fs.StringVar(&a.l2GqlURL, "l2GqlURL", "",
 		"VSC GraphQL endpoint for L2 mapInstantSendV2 submission "+
@@ -172,7 +180,12 @@ func parseArgs() (args, error) {
 			"with the log-only submitter (no on-chain effect).")
 	fs.StringVar(&a.l2PrivKeyHex, "l2PrivKey", "",
 		"L2 signing private key (hex-encoded secp256k1). The derived did:pkh:eip155 "+
-			"needs HBD to pay per-tx RC. Required to enable real L2 submission.")
+			"needs HBD to pay per-tx RC. Required to enable real L2 submission. "+
+			"DEV/TEST inline form; production should use -l2PrivKeyFile per audit M15.")
+	fs.StringVar(&a.l2PrivKeyFile, "l2PrivKeyFile", "",
+		"Path to a file containing the L2 signing private key (audit M15 file alt for "+
+			"-l2PrivKey; preferred for production). File permissions are NOT checked "+
+			"but operators should set 0o600. Whitespace is trimmed.")
 	fs.StringVar(&a.l2DashMappingContract, "l2DashMappingContract", "",
 		"dash-mapping-contract id (vsc1...) for the chain we're submitting to. "+
 			"Required when l2GqlURL+l2PrivKey are set.")
@@ -334,5 +347,38 @@ func parseArgs() (args, error) {
 	if err := validateOperatorURL("-l2GqlURL", a.l2GqlURL); err != nil {
 		return a, err
 	}
+
+	// Audit M15: resolve file-based secret alternatives. Each file
+	// is read once at startup, trimmed of whitespace, and treated as
+	// the secret's inline equivalent. The file-form is preferred for
+	// production because the secret doesn't appear in /proc/cmdline,
+	// `ps`, or journald argv captures.
+	if a.dashdRPCPasswordFile != "" {
+		if a.dashdRPCPassword != "" && a.dashdRPCPassword != "vsc-node-pass" {
+			return a, fmt.Errorf("-dashdRPCPassword and -dashdRPCPasswordFile are mutually exclusive")
+		}
+		b, err := os.ReadFile(a.dashdRPCPasswordFile)
+		if err != nil {
+			return a, fmt.Errorf("could not read -dashdRPCPasswordFile: %w", err)
+		}
+		a.dashdRPCPassword = strings.TrimSpace(string(b))
+		if a.dashdRPCPassword == "" {
+			return a, fmt.Errorf("-dashdRPCPasswordFile is empty")
+		}
+	}
+	if a.l2PrivKeyFile != "" {
+		if a.l2PrivKeyHex != "" {
+			return a, fmt.Errorf("-l2PrivKey and -l2PrivKeyFile are mutually exclusive")
+		}
+		b, err := os.ReadFile(a.l2PrivKeyFile)
+		if err != nil {
+			return a, fmt.Errorf("could not read -l2PrivKeyFile: %w", err)
+		}
+		a.l2PrivKeyHex = strings.TrimSpace(string(b))
+		if a.l2PrivKeyHex == "" {
+			return a, fmt.Errorf("-l2PrivKeyFile is empty")
+		}
+	}
+
 	return a, nil
 }

--- a/cmd/is-service/attestation_collector.go
+++ b/cmd/is-service/attestation_collector.go
@@ -167,20 +167,43 @@ func (c *attestationCollector) Collect(
 			if !ok {
 				return out
 			}
-			if _, dup := seen[resp.ValidatorDID]; dup {
-				continue
-			}
-			seen[resp.ValidatorDID] = struct{}{}
-			out = append(out, resp)
-			countsTowardThreshold := true
-			if verifier != nil {
-				countsTowardThreshold = verifier(resp)
-			}
-			if countsTowardThreshold {
+			// Audit M20 (4.5 — DEVNET-PROVEN): when a verifier is
+			// supplied, the previous code took the dedup slot on
+			// first-arrival regardless of signature validity. A
+			// forged bad-sig response that arrived first claimed the
+			// slot for a real validator's DID; the genuine response
+			// was then dropped at the dup check → verifiedCount
+			// stayed at 0 even though the validator did sign.
+			//
+			// Fix: the dedup slot is reserved for VERIFIED responses
+			// when a verifier is active. Unverified responses are
+			// still appended to `out` so the caller can surface them
+			// in diagnostics. The no-verifier path keeps the original
+			// dedup-on-DID behavior (TestCollector_DedupesByValidatorDID).
+			if verifier == nil {
+				if _, dup := seen[resp.ValidatorDID]; dup {
+					continue
+				}
+				seen[resp.ValidatorDID] = struct{}{}
+				out = append(out, resp)
 				verifiedCount++
 				if verifiedCount >= threshold {
 					return out
 				}
+				continue
+			}
+			// verifier != nil branch — diagnostic-friendly:
+			out = append(out, resp)
+			if !verifier(resp) {
+				continue
+			}
+			if _, dup := seen[resp.ValidatorDID]; dup {
+				continue
+			}
+			seen[resp.ValidatorDID] = struct{}{}
+			verifiedCount++
+			if verifiedCount >= threshold {
+				return out
 			}
 		case <-deadline.C:
 			return out

--- a/cmd/is-service/dashd_watcher.go
+++ b/cmd/is-service/dashd_watcher.go
@@ -105,7 +105,12 @@ func (c *DashdRPCClient) call(ctx context.Context, method string, params []any, 
 		return err
 	}
 	defer resp.Body.Close()
-	respBody, err := io.ReadAll(resp.Body)
+	// Audit L3 (LOW): bound the response body to prevent an
+	// unbounded-ReadAll slow-loris / OOM. 32 MiB comfortably exceeds
+	// any legitimate dashd JSON-RPC response (largest is getblock at
+	// ~megabytes for an oversized block).
+	const maxDashdRespBytes = 32 << 20
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxDashdRespBytes))
 	if err != nil {
 		return err
 	}

--- a/cmd/is-service/dashd_watcher.go
+++ b/cmd/is-service/dashd_watcher.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -127,6 +129,12 @@ type RawTransactionResult struct {
 	TxID        string `json:"txid"`
 	Hex         string `json:"hex"`
 	InstantLock bool   `json:"instantlock"`
+	// Blockhash + Confirmations are populated once the tx lands in a
+	// block; absent on mempool-only txs. The SPV-proof-fetcher
+	// requires Blockhash to fetch the block's tx list + build the
+	// Merkle proof (audit C2).
+	Blockhash     string `json:"blockhash,omitempty"`
+	Confirmations uint32 `json:"confirmations,omitempty"`
 	// Vout carries the output set so the watcher can pre-match watched
 	// addresses BEFORE firing onObserved. Without this filter every
 	// session-watching the watcher would mass-transition on every
@@ -196,6 +204,136 @@ func (c *DashdRPCClient) GetRawMempool(ctx context.Context) ([]string, error) {
 	return ids, nil
 }
 
+// BlockVerboseResult is the projection of dashd's getblock(verbose=1)
+// response we consume to build SPV proofs.
+type BlockVerboseResult struct {
+	Hash   string   `json:"hash"`
+	Height uint32   `json:"height"`
+	Tx     []string `json:"tx"`
+}
+
+// GetBlock fetches a block's metadata + tx list (getblock <hash> 1).
+// Used by BuildSpvProof to find the tx's index in the block and to
+// collect the sibling hashes for the Merkle proof.
+func (c *DashdRPCClient) GetBlock(ctx context.Context, blockhash string) (*BlockVerboseResult, error) {
+	var b BlockVerboseResult
+	if err := c.call(ctx, "getblock", []any{blockhash, 1}, &b); err != nil {
+		return nil, err
+	}
+	return &b, nil
+}
+
+// SpvProof carries the inclusion proof for a confirmed Dash tx, in the
+// wire format the dash-mapping-contract's mapInstantSendV2 expects.
+type SpvProof struct {
+	BlockHeight    uint32
+	TxIndex        uint32
+	MerkleProofHex string
+}
+
+// BuildSpvProof fetches `txid`'s containing block from dashd, computes
+// the Merkle proof path, and returns it in the wire format the
+// contract's mapInstantSendV2 expects. Audit C2 (CRIT 9.1): the fast
+// path requires this proof before crediting.
+//
+// Implementation: txid → getrawtransaction → blockhash → getblock →
+// txid list → tx's position in the block + sibling hash chain.
+//
+// The proof bytes are concatenated 32-byte sibling hashes (Dash uses
+// the standard double-SHA256 Merkle tree, same as Bitcoin), formatted
+// as hex. The contract's verifyMerkleProof walks the sibling list +
+// the tx position to reconstruct the merkle root.
+func (c *DashdRPCClient) BuildSpvProof(ctx context.Context, txid string) (*SpvProof, error) {
+	rtx, err := c.GetRawTransaction(ctx, txid)
+	if err != nil {
+		return nil, fmt.Errorf("getrawtransaction(%s): %w", txid, err)
+	}
+	if rtx.Blockhash == "" {
+		return nil, fmt.Errorf("tx %s has no blockhash (mempool-only; await confirmation)", txid)
+	}
+	block, err := c.GetBlock(ctx, rtx.Blockhash)
+	if err != nil {
+		return nil, fmt.Errorf("getblock(%s): %w", rtx.Blockhash, err)
+	}
+	var txIndex uint32
+	found := false
+	for i, t := range block.Tx {
+		if t == txid {
+			txIndex = uint32(i)
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("tx %s not found in block %s tx list", txid, rtx.Blockhash)
+	}
+	proofHex, err := buildMerkleProofHex(block.Tx, txIndex)
+	if err != nil {
+		return nil, fmt.Errorf("build merkle proof: %w", err)
+	}
+	return &SpvProof{
+		BlockHeight:    block.Height,
+		TxIndex:        txIndex,
+		MerkleProofHex: proofHex,
+	}, nil
+}
+
+// buildMerkleProofHex walks the bitcoin/dash Merkle tree built from
+// the block's tx list and returns the sibling-hash chain for `index`
+// as hex (each sibling is 32 bytes, concatenated).
+//
+// Dashd's tx-id list is in big-endian display order (the reverse of
+// the raw double-SHA256 bytes that go into the Merkle hashes). We
+// reverse each txid into wire-order, build the tree of doubleHash
+// combinations, and emit the sibling-hash list in the order the
+// contract walks (least-significant level first, mirroring its
+// verifyMerkleProof).
+func buildMerkleProofHex(txList []string, index uint32) (string, error) {
+	if int(index) >= len(txList) {
+		return "", fmt.Errorf("txIndex %d out of range (len=%d)", index, len(txList))
+	}
+	hashes := make([][32]byte, len(txList))
+	for i, t := range txList {
+		b, err := hex.DecodeString(t)
+		if err != nil || len(b) != 32 {
+			return "", fmt.Errorf("invalid txid %s", t)
+		}
+		// Reverse bytes (display → wire).
+		var h [32]byte
+		for k := 0; k < 32; k++ {
+			h[k] = b[31-k]
+		}
+		hashes[i] = h
+	}
+	var proof []byte
+	pos := int(index)
+	for len(hashes) > 1 {
+		if len(hashes)%2 == 1 {
+			hashes = append(hashes, hashes[len(hashes)-1]) // bitcoin's odd-leaf convention
+		}
+		var siblingIdx int
+		if pos%2 == 0 {
+			siblingIdx = pos + 1
+		} else {
+			siblingIdx = pos - 1
+		}
+		proof = append(proof, hashes[siblingIdx][:]...)
+		// Combine pairs into the next level.
+		next := make([][32]byte, len(hashes)/2)
+		for i := 0; i < len(hashes); i += 2 {
+			var combined [64]byte
+			copy(combined[:32], hashes[i][:])
+			copy(combined[32:], hashes[i+1][:])
+			h := sha256.Sum256(combined[:])
+			h = sha256.Sum256(h[:])
+			next[i/2] = h
+		}
+		hashes = next
+		pos /= 2
+	}
+	return hex.EncodeToString(proof), nil
+}
+
 // ===== watcher =====
 
 // DashdWatcher polls dashd for IS-lock observations on a set of
@@ -242,6 +380,12 @@ func NewDashdWatcher(client *DashdRPCClient) *DashdWatcher {
 		pollInterval: 2 * time.Second,
 	}
 }
+
+// RpcClient exposes the underlying dashd RPC handle so other consumers
+// (notably the orchestrator's SPV proof fetcher per audit C2) can
+// share the same connection + retry config without each constructing
+// their own client.
+func (w *DashdWatcher) RpcClient() *DashdRPCClient { return w.client }
 
 // SetBypassISLockCheck toggles the test-only IS-lock bypass. See the
 // `bypassISLockCheck` field comment. Should only be called from main

--- a/cmd/is-service/handlers.go
+++ b/cmd/is-service/handlers.go
@@ -779,20 +779,50 @@ func (s *Server) handleSessionStatus(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "session not found")
 		return
 	}
+	// Audit M14 part A (5.0 — DEVNET-PROVEN IDOR): the previous
+	// response unconditionally included sess.SessionToken. The path
+	// `/session/{sid}/status` has no caller-binding (a polling client
+	// proves only that it knows sid, which is itself low-entropy in
+	// the current scheme — sids were observed accepting 2-char
+	// values). An attacker who guesses or harvests a sid (e.g. via
+	// browser history of a victim's prior tab) could fetch the
+	// SessionToken on the ON_CHAIN transition and impersonate the
+	// authenticated session.
+	//
+	// Mitigation: require a caller-proof header in addition to the
+	// path sid before returning the SessionToken field. The
+	// addressSignature returned by /session/start is bound to
+	// (depositAddress || instruction) and is known only to the
+	// originating client. Treat it as the per-session bearer secret.
+	// /status without the header still works (state-machine polling
+	// is the legitimate use) — only the SessionToken field is hidden.
+	clientToken := r.Header.Get("X-Session-Auth")
+	allowToken := clientToken != "" && constantTimeEqual(clientToken, sess.AddressSignature)
 	resp := SessionStatusResponse{
 		Sid:           sess.Sid,
 		State:         string(sess.State),
 		DashTxId:      sess.DashTxId,
 		SenderAddress: sess.SenderAddress,
-		SessionToken:  sess.SessionToken,
 		L2TxId:        sess.L2TxId,
 		ForwardError:  sess.ForwardError,
 		ExpiresAt:     sess.ExpiresAt.Format(time.RFC3339),
+	}
+	if allowToken {
+		resp.SessionToken = sess.SessionToken
 	}
 	if sess.OnChainAt != nil {
 		resp.ForwardedAt = sess.OnChainAt.Format(time.RFC3339)
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// constantTimeEqual is a small wrapper around crypto/subtle's
+// ConstantTimeCompare so the M14 auth check doesn't leak timing.
+func constantTimeEqual(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
 
 func (s *Server) handleSessionCancel(w http.ResponseWriter, r *http.Request) {

--- a/cmd/is-service/handlers.go
+++ b/cmd/is-service/handlers.go
@@ -646,6 +646,25 @@ func (s *Server) handleSessionStart(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	// Audit M14 part B: enforce a minimum-entropy floor on
+	// client-supplied sids. The devnet IDOR PoC accepted a
+	// 2-char sid `"aa"`; on a public mainnet that's
+	// brute-forceable. Reject anything below 16 hex chars
+	// (~64 bits) — well above any IS-service legitimate use
+	// (server-generated sids are 32-hex). hasReservedRune still
+	// runs below for control/delimiter checks.
+	const minSidLen = 16
+	const maxSidLen = 128 // L5: bound the upper end too
+	if len(sid) < minSidLen {
+		writeError(w, http.StatusBadRequest,
+			"sid too short — must be at least 16 chars (use the empty sid to let the server generate one)")
+		return
+	}
+	if len(sid) > maxSidLen {
+		writeError(w, http.StatusBadRequest,
+			"sid too long — must be at most 128 chars")
+		return
+	}
 	// Round-3 audit R3-005: the existence check is done atomically by
 	// PutNew below (TOCTOU between Get and Put let two concurrent same-
 	// sid requests silently clobber each other). No pre-check needed.

--- a/cmd/is-service/handlers_test.go
+++ b/cmd/is-service/handlers_test.go
@@ -97,9 +97,9 @@ func TestSessionStart_Auth_ClientSuppliedSid(t *testing.T) {
 
 func TestSessionStart_Auth_DuplicateSidRejected(t *testing.T) {
 	srv := newTestServer(t)
-	first := doRequest(t, srv, "POST", "/session/start", SessionStartRequest{Op: "auth", Sid: "same"})
+	first := doRequest(t, srv, "POST", "/session/start", SessionStartRequest{Op: "auth", Sid: "same-sid-padded-to-meet-min-entropy"})
 	require.Equal(t, http.StatusCreated, first.Code)
-	second := doRequest(t, srv, "POST", "/session/start", SessionStartRequest{Op: "auth", Sid: "same"})
+	second := doRequest(t, srv, "POST", "/session/start", SessionStartRequest{Op: "auth", Sid: "same-sid-padded-to-meet-min-entropy"})
 	assert.Equal(t, http.StatusConflict, second.Code,
 		"second session with same sid must conflict; body=%s", second.Body.String())
 }

--- a/cmd/is-service/main.go
+++ b/cmd/is-service/main.go
@@ -354,6 +354,18 @@ func main() {
 		slog.Info("ValidatorSetForEpoch hook NOT wired — log-only submitter (no L2 RC at risk)")
 	}
 
+	// Audit C2 / H1 / FD3-1: re-use the dashd client the watcher
+	// already constructed to build the SPV inclusion proof the
+	// contract's fast-path mapInstantSendV2 now requires. The
+	// orchestrator falls into a recoverable failure path when the
+	// proof is unavailable (tx still in mempool, RPC down) — the
+	// contract REJECTS bundles without a valid proof, so passing
+	// nil here would just produce contract-side failures instead
+	// of clear orchestrator-side ones.
+	var dashdClient *DashdRPCClient
+	if dashd != nil {
+		dashdClient = dashd.RpcClient()
+	}
 	orch := NewOrchestrator(OrchestratorConfig{
 		Sessions:             sessions,
 		Collector:            collector,
@@ -363,6 +375,7 @@ func main() {
 		ValidatorSetForEpoch: validatorSetForEpoch,
 		EpochFor:             epochFor,
 		ValidatorSetSource:   args.l2GqlURL,
+		DashdClient:          dashdClient,
 	})
 
 	// /healthz probe — surfaces LIVE libp2p connected-peer count + mesh

--- a/cmd/is-service/main.go
+++ b/cmd/is-service/main.go
@@ -134,6 +134,14 @@ func main() {
 			"pubkey", pubHex)
 		signer = s
 	case args.addressSignerSecret != "":
+		// Audit M4 (MED 6.0): the HMAC stub is dev-only per spec §5.7 —
+		// the frontend can't verify HMAC without sharing the symmetric
+		// secret. Refuse to start on mainnet, mirroring the
+		// -signerVaultToken default-rejection pattern (args.go:149).
+		if args.network == "mainnet" {
+			slog.Error("address signer: HMAC stub (-addressSignerSecret) is DEV-ONLY and refused on -network=mainnet; use -signerVaultAddr or -addressSignerEd25519KeyFile (§5.7)")
+			os.Exit(1)
+		}
 		slog.Warn("address signer: HMAC stub (DEV/TEST ONLY — production must use -signerVaultAddr (Vault Transit) or -addressSignerEd25519KeyFile per §5.7)")
 		signer = NewAddressSignerHMAC([]byte(args.addressSignerSecret))
 	default:

--- a/cmd/is-service/orchestrator.go
+++ b/cmd/is-service/orchestrator.go
@@ -714,13 +714,34 @@ func (o *Orchestrator) reconcileL2(ctx context.Context, sid, dashTxID, chainID, 
 		slog.Debug("L2 status not yet terminal",
 			"sid", sid, "l2TxId", l2TxID, "status", status, "attempt", attempt+1)
 	}
-	// Deadline elapsed without terminal status. Don't mint the token.
-	// Mark as forward-failed so frontend doesn't see a stuck session.
-	// The L2 tx may still land eventually — an operator can recover
-	// manually by inspecting Session.L2TxId in /healthz / /status.
+	// Deadline elapsed without terminal status. Audit M8: this case is
+	// NOT the same as a genuine FORWARD_FAILED — the L2 tx is still in
+	// the mempool (last seen status was INCLUDED / UNKNOWN, NOT FAILED).
+	// Transition to SLOW_PATH_PENDING with the L2 txid recorded so the
+	// frontend can show "your tx is being mined; check back later" and
+	// a recovery scanner can re-poll to mint the SessionToken once the
+	// L2 tx confirms. The contract's slow-path mined-block proof will
+	// also still credit if the L2 tx eventually lands but the IS-
+	// service is gone by then.
 	o.counters.ReconcileTimeouts.Add(1)
-	o.fail(sid, fmt.Sprintf("L2 reconcile timed out (l2TxId=%s); inspect chain state to recover", l2TxID))
+	o.pending(sid, fmt.Sprintf("L2 reconcile timed out (l2TxId=%s); tx may still confirm", l2TxID))
 	return false
+}
+
+// pending transitions the session to SLOW_PATH_PENDING (audit M8).
+// Distinct from o.fail which routes to FORWARD_FAILED — pending is for
+// "submission succeeded; awaiting confirmation that may still arrive,"
+// fail is for "submission is dead." A recovery scanner can poll
+// SLOW_PATH_PENDING sessions for the L2 tx terminal state and promote
+// to ON_CHAIN or FORWARD_FAILED as appropriate.
+func (o *Orchestrator) pending(sid, reason string) {
+	slog.Info("orchestrator: session entered slow-path-pending", "sid", sid, "reason", reason)
+	o.sessions.MutateState(sid, func(s *Session) {
+		if !s.State.IsTerminal() {
+			s.State = StateSlowPathPending
+			s.ForwardError = reason // re-use ForwardError as the human-readable hint surface; /status already serializes it
+		}
+	})
 }
 
 func (o *Orchestrator) fail(sid, reason string) {

--- a/cmd/is-service/orchestrator.go
+++ b/cmd/is-service/orchestrator.go
@@ -108,6 +108,19 @@ type Orchestrator struct {
 	// via /healthz. Round-4 audit R4-007 — the existing
 	// per-event slog lines are not aggregable.
 	counters orchestratorCounters
+	// spvFetcher builds the SPV inclusion proof the contract's
+	// mapInstantSendV2 requires (audit C2 / H1 / FD3-1). Default
+	// production impl is the dashd JSON-RPC client. Tests pass a
+	// stub that returns canned proof bytes.
+	spvFetcher spvProofFetcher
+}
+
+// spvProofFetcher abstracts the SPV proof source so the orchestrator
+// can be unit-tested without a live dashd. The production impl
+// (DashdRPCClient.BuildSpvProof) walks the block's tx list and builds
+// the Merkle proof; the test fake returns canned values.
+type spvProofFetcher interface {
+	BuildSpvProof(ctx context.Context, txid string) (*SpvProof, error)
 }
 
 // orchestratorCounters aggregates per-event tallies for /healthz.
@@ -193,6 +206,18 @@ type OrchestratorConfig struct {
 	// roster-divergence slog.Error so operators know which upstream
 	// to investigate. Round-6 audit R6-OP-01.
 	ValidatorSetSource string
+	// DashdClient is the production SPV proof source. When wired, the
+	// orchestrator builds the audit-C2 inclusion proof from dashd's
+	// getrawtransaction + getblock + Merkle proof. Mutually exclusive
+	// with SpvFetcher (use one or the other).
+	DashdClient *DashdRPCClient
+	// SpvFetcher overrides the default DashdClient-based proof source.
+	// Used by unit tests to inject canned proofs. When nil, the
+	// orchestrator falls back to DashdClient. If both are nil, the
+	// orchestrator skips the SPV step entirely — submission will
+	// fail at the contract, which is the intended behavior for any
+	// production deploy that forgot to set -dashdRPC.
+	SpvFetcher spvProofFetcher
 }
 
 func NewOrchestrator(cfg OrchestratorConfig) *Orchestrator {
@@ -221,7 +246,21 @@ func NewOrchestrator(cfg OrchestratorConfig) *Orchestrator {
 		epochFor:             cfg.EpochFor,
 		validatorSetForEpoch: cfg.ValidatorSetForEpoch,
 		validatorSetSource:   cfg.ValidatorSetSource,
+		spvFetcher:           resolveSpvFetcher(cfg.SpvFetcher, cfg.DashdClient),
 	}
+}
+
+// resolveSpvFetcher picks the orchestrator's SPV source: explicit
+// SpvFetcher wins, then DashdClient, then nil (tests get fakeSpvFetcher
+// from their own config).
+func resolveSpvFetcher(explicit spvProofFetcher, dashd *DashdRPCClient) spvProofFetcher {
+	if explicit != nil {
+		return explicit
+	}
+	if dashd != nil {
+		return dashd
+	}
+	return nil
 }
 
 // Drive runs the full ATTESTING → ON_CHAIN flow for a single session in
@@ -479,13 +518,40 @@ func (o *Orchestrator) Drive(ctx context.Context, sid, txid, rawTxHex string) {
 		return
 	}
 
+	// Audit C2 + H1 + FD3-1: fetch the SPV inclusion proof before
+	// assembling the bundle. The contract REJECTS submissions without
+	// a valid proof — the credit fires only after the tx is proven
+	// included in a confirmed block. Failing to fetch the proof (tx
+	// still in mempool, dashd RPC down) is a transient error; the
+	// session moves to a recoverable terminal state.
+	//
+	// If no spvFetcher is wired (cfg.DashdClient + cfg.SpvFetcher both
+	// nil), the orchestrator submits an empty-proof bundle — the
+	// contract will reject. Tests that bypass the contract pass a
+	// fake fetcher with canned values.
+	var spvBlockHeight uint32
+	var spvMerkleProofHex string
+	var spvTxIndex uint32
+	if o.spvFetcher != nil {
+		spv, err := o.spvFetcher.BuildSpvProof(ctx, txid)
+		if err != nil {
+			o.fail(sid, fmt.Sprintf("SPV proof fetch failed (likely tx not yet confirmed): %v", err))
+			return
+		}
+		spvBlockHeight = spv.BlockHeight
+		spvMerkleProofHex = spv.MerkleProofHex
+		spvTxIndex = spv.TxIndex
+	}
 	payload := MapInstantSendPayload{
 		Body: MapInstantSendBody{
-			RawTxHex:     rawTxHex,
-			Instruction:  sess.Instruction,
-			Epoch:        req.Epoch,
-			Attestations: atts,
-			ChainId:      req.ChainId,
+			RawTxHex:       rawTxHex,
+			Instruction:    sess.Instruction,
+			Epoch:          req.Epoch,
+			Attestations:   atts,
+			ChainId:        req.ChainId,
+			BlockHeight:    spvBlockHeight,
+			MerkleProofHex: spvMerkleProofHex,
+			TxIndex:        spvTxIndex,
 		},
 		Agg: MapInstantSendAgg{
 			AggSigHex: aggSigHex,

--- a/cmd/is-service/orchestrator_test.go
+++ b/cmd/is-service/orchestrator_test.go
@@ -238,7 +238,13 @@ func TestOrchestrator_ReconcileTimeoutIncrementsCounter(t *testing.T) {
 	assert.Equal(t, int64(1), counters.ReconcileTimeouts,
 		"ReconcileTimeouts must increment when status stays UNKNOWN")
 	sess, _ := store.Get("sid-reconcile-timeout")
-	assert.Equal(t, StateForwardFailed, sess.State)
+	// Audit M8: reconcile-timeout while last status was non-FAILED is
+	// SLOW_PATH_PENDING (recoverable), not FORWARD_FAILED. The tx may
+	// still confirm and the contract's slow-path mined-block proof
+	// will credit; frontend should show "still being mined" rather
+	// than "deposit lost."
+	assert.Equal(t, StateSlowPathPending, sess.State,
+		"reconcile-timeout with non-FAILED last status must be SLOW_PATH_PENDING per audit M8")
 }
 
 // Round-6 audit R6-TEST-05: pin the R5-ADV-01 roster-divergence

--- a/cmd/is-service/session.go
+++ b/cmd/is-service/session.go
@@ -26,15 +26,13 @@ const (
 	StateL2Submitted        SessionState = "L2_SUBMITTED"
 	StateOnChain            SessionState = "ON_CHAIN"
 	StateAttestationTimeout SessionState = "ATTESTATION_TIMEOUT"
-	// StateSlowPathPending is reserved for the spec's mined-block-
-	// proof fallback (§5.2). The slow-path flow is NOT wired into the
-	// orchestrator yet — Drive never transitions into this state.
-	// TODO(slow-path-workstream): implement the fallback that walks a
-	// session from AttestationTimeout into SlowPathPending and then to
-	// OnChain or ForwardFailed via the slow-path mined-block proof.
-	// Round-5 audit R5-TEST-01 noted the dead branch; left in place
-	// because it's a stable wire-protocol value the contract already
-	// accepts.
+	// StateSlowPathPending: the L2 submission landed in the mempool +
+	// reconciliation timed out without a terminal status. The tx may
+	// still confirm and credit via the contract's slow-path mined-block
+	// proof. Audit M8: orchestrator.pending() routes here (vs
+	// ForwardFailed) so the frontend can show "still being mined" and a
+	// recovery scanner can re-poll. Session.L2TxId + Session.ForwardError
+	// carry the human-readable hint.
 	StateSlowPathPending SessionState = "SLOW_PATH_PENDING"
 	StateForwardFailed   SessionState = "FORWARD_FAILED"
 	StateExpired         SessionState = "EXPIRED"

--- a/cmd/is-service/submitter.go
+++ b/cmd/is-service/submitter.go
@@ -54,12 +54,21 @@ func IsL2TerminalSuccess(status string) bool {
 // type in dash-mapping-contract/contract/mapping/forwarder_integration.go).
 // Field names + JSON tags MUST stay byte-for-byte aligned. Drift here is
 // the audit's `payload-schema-mismatch-is-vs-contract` finding.
+//
+// Audit C2 + H1 + FD3-1: the BlockHeight/MerkleProofHex/TxIndex triplet
+// is now REQUIRED — the contract performs SPV verify before crediting,
+// uses the proven txid:vout as the canonical idempotency marker, and
+// registers the UTXO + bumps Supply on success. Without these fields
+// the contract rejects with "fast-path SPV verify failed".
 type MapInstantSendBody struct {
-	RawTxHex     string                      `json:"raw_tx_hex"`
-	Instruction  string                      `json:"instruction"`
-	Epoch        uint64                      `json:"epoch"`
-	Attestations []MapInstantSendAttestation `json:"attestations"`
-	ChainId      string                      `json:"chain_id"`
+	RawTxHex       string                      `json:"raw_tx_hex"`
+	Instruction    string                      `json:"instruction"`
+	Epoch          uint64                      `json:"epoch"`
+	Attestations   []MapInstantSendAttestation `json:"attestations"`
+	ChainId        string                      `json:"chain_id"`
+	BlockHeight    uint32                      `json:"block_height"`
+	MerkleProofHex string                      `json:"merkle_proof_hex"`
+	TxIndex        uint32                      `json:"tx_index"`
 }
 
 // MapInstantSendAttestation mirrors the contract's ValidatorAttestation.

--- a/cmd/mapping-bot/chain/mempool_space.go
+++ b/cmd/mapping-bot/chain/mempool_space.go
@@ -174,12 +174,22 @@ func (m *MempoolSpaceClient) GetTxDetails(txid string) (TxConfirmationDetails, e
 	if err := json.NewDecoder(txidsResp.Body).Decode(&txids); err != nil {
 		return TxConfirmationDetails{}, fmt.Errorf("error decoding block txids: %w", err)
 	}
+	// Audit FD9-3 (LOW 3.2): the previous default-to-0 silently used
+	// the coinbase position when the tx wasn't found in the block —
+	// the resulting Merkle proof was wrong → confirmSpend failed
+	// on-chain → manual retry required. Return a proper not-found
+	// error so the caller can retry or surface it loudly.
 	txIndex := uint32(0)
+	found := false
 	for i, id := range txids {
 		if id == txid {
 			txIndex = uint32(i)
+			found = true
 			break
 		}
+	}
+	if !found {
+		return TxConfirmationDetails{}, fmt.Errorf("tx %s reported as confirmed at height %d but missing from block %s txid list — refusing to fall back to txIndex=0 (would produce an invalid Merkle proof)", txid, status.BlockHeight, status.BlockHash)
 	}
 
 	return TxConfirmationDetails{

--- a/cmd/mapping-bot/main.go
+++ b/cmd/mapping-bot/main.go
@@ -6,7 +6,9 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
 	"sync"
+	"syscall"
 	"time"
 
 	"vsc-node/cmd/mapping-bot/chain"
@@ -123,8 +125,30 @@ func main() {
 	defer cancel()
 	go mapBotHttpServer(httpCtx, db.Addresses, bot)
 
+	// Audit FD9-2 (LOW 3.5): trap SIGINT/SIGTERM so a deploy-time
+	// restart finishes the in-flight PostTx → MarkSent window cleanly
+	// instead of stranding a vault UTXO (same fund-stranding class as
+	// FD9-1's discarded MarkSent return). The shutdown channel
+	// short-circuits the main loop's next iteration; the deferred
+	// db.Close + cancel() above run on return.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	shutdownCh := make(chan struct{})
+	go func() {
+		sig := <-sigCh
+		bot.L.Info("mapping-bot received shutdown signal — draining in-flight work", "signal", sig.String())
+		close(shutdownCh)
+	}()
+
 	var wg sync.WaitGroup
 	for {
+		select {
+		case <-shutdownCh:
+			bot.L.Info("mapping-bot exiting main loop after shutdown signal")
+			wg.Wait()
+			return
+		default:
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 
 		// Periodic cleanup (every 24h)
@@ -137,6 +161,16 @@ func main() {
 			_, err = db.State.DeleteOldSentTransactions(ctx, 7*24*time.Hour)
 			if err != nil {
 				bot.L.Error("error deleting old sent transactions", "err", err)
+			}
+			// Audit FD9-4 (LOW 2.5): also drain stuck-Pending rows.
+			// Without this, a Pending tx whose vault spend never landed
+			// (e.g. FD9-1's MarkTransactionSent failure, or a node
+			// restart during the broadcast window per FD9-2) loops
+			// forever through re-broadcast attempts + grows the DB.
+			// 7d is the same horizon DeleteOldSentTransactions uses.
+			_, err = db.State.DeleteOldPendingTransactions(ctx, 7*24*time.Hour)
+			if err != nil {
+				bot.L.Error("error deleting old pending transactions", "err", err)
 			}
 			lastClear = time.Now()
 		}

--- a/cmd/mapping-bot/mapper/unmapping.go
+++ b/cmd/mapping-bot/mapper/unmapping.go
@@ -71,7 +71,18 @@ func (b *Bot) HandleUnmap() {
 				continue
 			}
 			height, _ := b.LastBlock()
-			b.stateDB().MarkTransactionSent(ctx, tx.TxId, height)
+			// Audit FD9-1 (MED 5.5): the previous code discarded the
+			// MarkTransactionSent return value. If the DB write fails
+			// AFTER the vault spend is already broadcast, the record
+			// stayed `Pending` → confirmSpend never fired + the bot
+			// re-broadcast the tx forever → vault UTXO stranded.
+			// Surface the error loudly so the operator knows manual
+			// promotion is required (the on-chain tx is fine; only
+			// the local bookkeeping is stuck).
+			if err := b.stateDB().MarkTransactionSent(ctx, tx.TxId, height); err != nil {
+				b.L.Error("MarkTransactionSent failed AFTER vault broadcast — UTXO will be stranded until DB record is promoted to Sent manually",
+					"err", err, "txId", tx.TxId, "height", height)
+			}
 		}
 	}
 }
@@ -266,6 +277,26 @@ func (b *Bot) CheckSignagures(
 	return fullySignedTxs, nil
 }
 
+// attachSignatures builds the final spend transaction by placing each
+// input's TSS signature into a legacy P2SH scriptSig (BIP16 spend).
+//
+// Audit FD4-C1 (CVSS 9.1 LAUNCH-BLOCKING): the previous implementation
+// placed the signature in tx.TxIn[i].Witness and encoded with
+// wire.WitnessEncoding, matching BTC's segwit P2WSH spend. But Dash
+// deposit addresses are plain legacy P2SH (dash-mapping-contract/
+// contract/mapping/utils.go:32-37 — "Dash never activated SegWit so
+// we MUST use P2SH"). btcd's txscript.Engine rejected every withdrawal
+// as "signature script for witness nested p2sh is not canonical".
+// Compound failure with HandleUnmap burning the balance + deleting
+// UTXOs BEFORE the bot produced the (rejected) tx → permanent loss
+// on every withdrawal.
+//
+// Fix: build a legacy scriptSig of `<sig+sighash> <branchSelector>
+// <redeemScript>` via txscript.NewScriptBuilder, assign to
+// tx.TxIn[i].SignatureScript, and encode WITHOUT witness data.
+// inputData.WitnessScript carries the legacy redeem script after
+// contract-side FD4-C1 fix (msgp wire tag `ws` preserved for
+// backward-compat; semantic redefined).
 func attachSignatures(signedData *database.Transaction) (*TxRawIdPair, error) {
 	var tx wire.MsgTx
 	tx.Deserialize(bytes.NewReader(signedData.RawTx))
@@ -280,19 +311,34 @@ func attachSignatures(signedData *database.Transaction) (*TxRawIdPair, error) {
 		if inputData.IsBackup {
 			branchSelector = []byte{} // backup key path (OP_ELSE)
 		}
-		witness := wire.TxWitness{
-			signature[:],
-			branchSelector,
-			inputData.WitnessScript,
-		}
 
-		tx.TxIn[inputData.Index].Witness = witness
+		// Legacy P2SH scriptSig: pushdata <sig+sighash>, <branchSelector>,
+		// <redeemScript>. The redeemScript trailing-push is what BIP16
+		// signals to the verifier to take the HASH160 of and compare
+		// against the scriptPubKey's redeem-hash slot.
+		builder := txscript.NewScriptBuilder()
+		builder.AddData(signature)
+		if len(branchSelector) == 0 {
+			builder.AddOp(txscript.OP_0)
+		} else {
+			builder.AddData(branchSelector)
+		}
+		builder.AddData(inputData.WitnessScript)
+		scriptSig, err := builder.Script()
+		if err != nil {
+			return nil, err
+		}
+		tx.TxIn[inputData.Index].SignatureScript = scriptSig
+		// Explicitly clear any witness data — defense-in-depth against
+		// a future caller that pre-populates Witness for some other
+		// reason.
+		tx.TxIn[inputData.Index].Witness = nil
 	}
 
 	var buf bytes.Buffer
-	// serialize is almost the same but with a different protocol version. Not sure if that
-	// actually changes the result
-	if err := tx.BtcEncode(&buf, wire.ProtocolVersion, wire.WitnessEncoding); err != nil {
+	// Audit FD4-C1: serialize WITHOUT witness encoding for legacy P2SH.
+	// Serialize() uses the legacy (BIP141-free) wire format.
+	if err := tx.Serialize(&buf); err != nil {
 		return nil, err
 	}
 

--- a/lib/dids/bls.go
+++ b/lib/dids/bls.go
@@ -804,15 +804,26 @@ func (b *BlsCircuit) Verify() (bool, []BlsDID, error) {
 		return false, nil, fmt.Errorf("no public keys to verify")
 	}
 
-	// aggregate the pub keys
-	// agg all the pub keys at once
-	pubKey, _ := bls.AggregatePubkeys(includedPubKeys)
-	// aggWorks := aggPub.Aggregate(includedPubKeys, true)
-	// aggPubKey := aggPub.ToAffine()
+	// Aggregate the pub keys.
+	//
+	// Audit H4 (CVSS 7.5 — DEVNET-PROVEN panic): the previous
+	// `pubKey, _ := bls.AggregatePubkeys(...)` discarded the error
+	// path. The underlying protolambda/bls12-381-util library
+	// returns `(nil, "cannot add zero pubkey")` when any member's
+	// pubkey is the G1 identity point (a structurally-valid 48-byte
+	// compressed point that deserializes OK but represents the
+	// neutral element). The discarded nil then nil-derefs inside
+	// bls.Verify's pairing engine via a recovered panic in
+	// BlsCircuit.Verify's outer call site — a single on-chain
+	// validator-set entry with the identity pubkey halts consensus
+	// on every node. Sibling sdk.go:890 already checks the error
+	// (SAFE). Restore the matching check here.
+	pubKey, err := bls.AggregatePubkeys(includedPubKeys)
+	if err != nil {
+		return false, nil, fmt.Errorf("AggregatePubkeys failed: %w", err)
+	}
 
 	// verify the aggregated sig
 	verified := bls.Verify(pubKey, b.msg.Bytes(), b.aggSigs)
-	// verified := b.aggSigs.FastAggregateVerify(true, includedPubKeys, b.msg.Bytes(), nil)
-
 	return verified, includedDIDs, nil
 }

--- a/modules/incentive-pendulum/wasm/applier.go
+++ b/modules/incentive-pendulum/wasm/applier.go
@@ -385,10 +385,30 @@ func exacerbatesFromSnapshot(sBps int64, hbdIn bool) bool {
 	}
 }
 
-// splitFractionsBps returns (f_node, f_node_protocol) as basis points. fNode
+// splitFractionsBps returns (f_node, f_node_protocol) as basis points.
+//
+// Audit PEND-1 (HIGH 7.5 — CODE-PROVEN): the previous denominator mixed
+// HIVE-denominated T with HBD³ terms (T·V² + P·E·(cE−V)), producing
+// LP under-payment of +718 bps at devnet's price 0.0625 and +2916 bps
+// at 0.30 (test t = 1 makes the bug invisible; any HIVE price ≠ 1
+// exposed it). The audit's corrected form is HBD-denominated:
+//
+//	denom = E·((3/2)V² + P(cE − V))
+//	stake_node = (3/2)·V²·E
+//	f_node = stake_node / denom = (3/2)V² / ((3/2)V² + P(cE−V))
+//	       = 3V² / (3V² + 2P(cE − V))      (multiply through by 2)
+//
+// T and E cancel out — only V, E (in cE), and P remain. T is kept on
+// the function signature for caller compat but no longer participates
+// in the calc.
+//
+// fNode
 // applies to the CLP pot; fNodeProtocol applies to the protocol+surplus pot
 // with §9 redirect cliffs at the safe-band edges (pendulum.RedirectLo/HiBps).
 func splitFractionsBps(T, V, E, P *big.Int, sBps int64) (int64, int64) {
+	_ = T // audit PEND-1: T no longer participates (cancels out under HBD-denominated stake)
+	_ = E // audit PEND-1: E also cancels (the corrected form is unit-homogeneous in V and P)
+
 	scale := big.NewInt(pendulum.BpsScale)
 
 	cE := pendulum.CliffTimesE(E)
@@ -397,19 +417,24 @@ func splitFractionsBps(T, V, E, P *big.Int, sBps int64) (int64, int64) {
 		return pendulum.BpsScale, pendulum.BpsScale
 	}
 
-	// denom = T·V² + P·E·(c·E − V)
-	tvSquared := new(big.Int).Mul(V, V)
-	tvSquared.Mul(tvSquared, T)
+	// Audit PEND-1: HBD-denominated stake formula.
+	//   numer = 3·V²
+	//   denom = 3·V² + 2·P·(cE − V)
+	//   f_node = numer · scale / denom (in bps)
+	three := big.NewInt(3)
+	two := big.NewInt(2)
+	vSquared := new(big.Int).Mul(V, V)
+	numer := new(big.Int).Mul(three, vSquared) // 3·V²
 	cEMinusV := new(big.Int).Sub(cE, V)
-	peTerm := new(big.Int).Mul(P, E)
-	peTerm.Mul(peTerm, cEMinusV)
-	denom := new(big.Int).Add(tvSquared, peTerm)
+	pTerm := new(big.Int).Mul(two, P)
+	pTerm.Mul(pTerm, cEMinusV) // 2·P·(cE − V)
+	denom := new(big.Int).Add(numer, pTerm)
 	if denom.Sign() == 0 {
 		return pendulum.BpsScale, pendulum.BpsScale
 	}
 
-	// f_node = T·V² / denom in bps.
-	fNodeBig := intmath.MulDivFloor(tvSquared, scale, denom)
+	// f_node = 3V² / (3V² + 2P(cE − V)) in bps.
+	fNodeBig := intmath.MulDivFloor(numer, scale, denom)
 	if !fNodeBig.IsInt64() {
 		return pendulum.BpsScale, pendulum.BpsScale
 	}

--- a/modules/islock-attestation/dashd_poller.go
+++ b/modules/islock-attestation/dashd_poller.go
@@ -272,7 +272,10 @@ func (c *dashdRPCClient) call(ctx context.Context, method string, params []any, 
 		return err
 	}
 	defer resp.Body.Close()
-	raw, _ := io.ReadAll(resp.Body)
+	// Audit L3 (LOW): bound the dashd RPC response to prevent
+	// unbounded-ReadAll slow-loris / OOM. 32 MiB covers any legitimate
+	// dashd response.
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
 	var r rpcResponse
 	if err := json.Unmarshal(raw, &r); err != nil {
 		return fmt.Errorf("rpc response not JSON: %w (raw=%s)", err, string(raw))

--- a/modules/islock-attestation/p2p.go
+++ b/modules/islock-attestation/p2p.go
@@ -420,9 +420,24 @@ func (r *requestRateLimiter) allow(peerID string) bool {
 		b.count++
 		return true
 	}
+	// Audit M19 (5.0): the previous code only ever ADDED entries to
+	// the state map; old peers with windows long elapsed were never
+	// reclaimed. At 10k tracked peers the limiter fails closed for
+	// EVERY new peer — a DoS surface. Reap expired entries before
+	// hitting the cap. This is cheap (linear scan of <=10k entries
+	// every allow() call ONLY when cap is hit) so it doesn't burn
+	// hot-path cycles in steady-state.
 	if len(r.state) >= r.maxPeers {
-		// Memory cap — refuse to track new peer, fail-closed for them.
-		return false
+		threshold := now.Add(-r.window)
+		for id, b := range r.state {
+			if b.windowAt.Before(threshold) {
+				delete(r.state, id)
+			}
+		}
+		if len(r.state) >= r.maxPeers {
+			// Still at cap after reaping — refuse to track new peer.
+			return false
+		}
 	}
 	r.state[peerID] = &requestBucket{count: 1, windowAt: now}
 	return true

--- a/modules/ledger-system/ledger_system.go
+++ b/modules/ledger-system/ledger_system.go
@@ -1038,15 +1038,18 @@ func (ls *ledgerSystem) Deposit(deposit Deposit) string {
 	} else if strings.HasPrefix(decodedParams.To, "contract:") {
 		// Pass through. Contract accounts (e.g. "contract:vsc1B...") are
 		// valid ledger owners — the same string the contract execution
-		// context's SendBalance / HiveTransfer uses as From/To. Letting
-		// `to=contract:<id>` deposits land directly avoids the previous
-		// fallback-to-sender behaviour, which silently rerouted the
-		// HBD back to the depositor and made it impossible to fund a
-		// contract's L2 native ledger via the standard L1 → vsc.gateway
-		// memo path. Used by the IS-login op=call devnet test scaffold
-		// to pre-fund the mapping contract for mapInstantSendV2's
-		// rcReimbursementHBD HiveTransfer; also a legitimate operator
-		// path for one-shot operational top-ups.
+		// context's SendBalance / HiveTransfer uses as From/To.
+		//
+		// Audit L6 (LOW): the previous pass-through accepted ANY suffix
+		// after "contract:", including malformed contract ids that
+		// would silently strand the HBD (no contract exists to receive
+		// it; no fallback fires). Validate the suffix against the
+		// canonical vsc1... contract-id shape and fall back to the
+		// depositor on mismatch so funds aren't lost.
+		contractID := strings.TrimPrefix(decodedParams.To, "contract:")
+		if !isValidContractID(contractID) {
+			decodedParams.To = deposit.From
+		}
 	} else {
 		//Default to the original sender to prevent fund loss
 		// addr, _ := NormalizeAddress(deposit.From, "hive")

--- a/modules/ledger-system/utils.go
+++ b/modules/ledger-system/utils.go
@@ -11,6 +11,39 @@ var assetTypes = slices.Concat(transferableAssetTypes, []string{"hive_consensus"
 const ETH_REGEX = "^0x[a-fA-F0-9]{40}$"
 const HIVE_REGEX = `^[a-z][0-9a-z\-]*[0-9a-z](\.[a-z][0-9a-z\-]*[0-9a-z])*$`
 
+// VSC_CONTRACT_REGEX matches the base58 contract-id shape (vsc1...).
+// Used by audit L6's `to=contract:<id>` deposit-memo validation.
+const VSC_CONTRACT_REGEX = `^vsc1[1-9A-HJ-NP-Za-km-z]{32,40}$`
+
+// isValidContractID returns true if `id` matches the vsc1...
+// contract-id shape. Used to validate `to=contract:<id>` deposit
+// memos before passing them through to the ledger — a malformed
+// id would otherwise silently strand HBD with no contract to
+// receive it.
+func isValidContractID(id string) bool {
+	if len(id) < 36 || len(id) > 44 {
+		return false
+	}
+	if id[:4] != "vsc1" {
+		return false
+	}
+	// Base58 alphabet check (Bitcoin's: no 0, O, I, l).
+	for i := 4; i < len(id); i++ {
+		c := id[i]
+		switch {
+		case c >= '1' && c <= '9':
+		case c >= 'A' && c <= 'H':
+		case c >= 'J' && c <= 'N':
+		case c >= 'P' && c <= 'Z':
+		case c >= 'a' && c <= 'k':
+		case c >= 'm' && c <= 'z':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 const HBD_INSTANT_FEE = int64(1) // 1% or 100 bps
 const HBD_INSTANT_MIN = int64(1) // 0.001 HBD
 const HBD_FEE_RECEIVER = "vsc.dao"

--- a/modules/wasm/sdk/sdk.go
+++ b/modules/wasm/sdk/sdk.go
@@ -828,9 +828,16 @@ var SdkNamespaces = map[string]map[string]sdkFunc{
 			if ok {
 				outResult = "true"
 			}
+			// Audit M23 (MED 5.0): the previous flat 5×CYCLE_GAS_PER_RC
+			// charge under-priced large-message verifies — hash-to-curve
+			// is linear in len(msg). Charge a small per-byte component
+			// on top of the base. Anchor: 5 base + 1/16 per byte (a
+			// 1KB msg burns ~5+64 = 69 cycles equivalent, still cheap
+			// but proportional to work done).
+			gas := params.CYCLE_GAS_PER_RC * uint(5+(len(msg)+15)/16)
 			return result.Ok(SdkResultStruct{
 				Result: outResult,
-				Gas:    params.CYCLE_GAS_PER_RC * 5,
+				Gas:    gas,
 			})
 		},
 		// bls_verify_aggregate verifies an aggregated BLS signature against
@@ -901,10 +908,18 @@ var SdkNamespaces = map[string]map[string]sdkFunc{
 			// Per-pubkey hash + curve add cost is roughly half a keccak each;
 			// the pairing dominates total cost regardless of N up to small
 			// quorum sizes (~17 for testnet, similar for mainnet).
+			//
+			// Audit M23 (MED 5.0): add a per-byte component on top of
+			// the pairing + per-pubkey cost. The hash-to-curve step
+			// inside the verify is linear in len(msg); without the
+			// per-byte term a contract that passes a 1MB message
+			// pays the same as a 32-byte one. Same 1/16 per byte
+			// anchor as bls_verify.
 			perPubkeyGas := uint(params.CYCLE_GAS_PER_RC / 2)
+			perMsgByteGas := uint(params.CYCLE_GAS_PER_RC / 16)
 			return result.Ok(SdkResultStruct{
 				Result: outResult,
-				Gas:    params.CYCLE_GAS_PER_RC*10 + perPubkeyGas*uint(len(pubkeys)),
+				Gas:    params.CYCLE_GAS_PER_RC*10 + perPubkeyGas*uint(len(pubkeys)) + perMsgByteGas*uint(len(msg)),
 			})
 		},
 	},


### PR DESCRIPTION
## Summary

Closes the go-vsc-node side of the 2026-06-18 dash audit. IS-service
hardening + pendulum HBD-denom stake fix + ledger-system memo
validation + the SPV proof fetcher that complements the contract-side
C2/H1/FD3-1 changes.

## What changed

- **C2 IS-service companion** — `DashdRPCClient.BuildSpvProof` chains
  `getrawtransaction → getblock → Merkle proof walk`. Orchestrator
  gains `spvProofFetcher` abstraction (production = dashd client;
  tests = canned fake). Bundle shape mirrors the contract's new params.
- **M8 (MED 6.0)** — `o.pending()` routes reconcile-timeout sessions to
  `StateSlowPathPending` (was `ForwardFailed`). The L2 tx may still
  confirm; frontend can show "still mining" rather than "deposit lost."
  Test updated.
- **PEND-1 (HIGH 7.5)** — `applier.go:splitFractionsBps` now uses the
  HBD-denominated stake formula `f_node = 3V² / (3V² + 2P(cE−V))`. The
  previous form mixed HIVE and HBD³ units; LPs were under-paid +718 bps
  at devnet price 0.0625 and +2916 bps at 0.30. Existing tests passed
  pre-fix only because their fixtures use price = 1.
- **L6 (LOW)** — `to=contract:<id>` deposit memo validated against
  `vsc1<base58>{32-40}` shape in `modules/ledger-system/utils.go`;
  mismatch falls back to depositor.
- **L3 (LOW)** — `io.ReadAll → io.LimitReader` at 4 sites (dashd_watcher,
  dashd_poller, Vault transit ×2). Caps 16/32 MiB.
- **IS-service hardening (M4, M14B, M15, M16, M18, M19, M20, M23)** —
  mainnet-refuse without pinned signer pubkey; sid 16-char min entropy
  + 128-char max; `-l2PrivKeyFile` + `-dashdRPCPasswordFile`;
  RC-payload-size component; op=auth rate-limit; gossip reaper at cap;
  verify-then-dedup; BLS gas scales with `len(msg)`.
- **Mapping-bot cluster (FD9-1 to FD9-4)** — `MarkTransactionSent`
  error check; SIGINT/SIGTERM graceful shutdown; `mempool_space`
  not-found returns error; `DeleteOldPendingTransactions` wired
  alongside `DeleteOldSentTransactions`.

## Cross-repo dependencies

- **PAIRED WITH** `vsc-eco/utxo-mapping#<PR id>` — this PR's IS-service
  produces bundles with `BlockHeight + MerkleProofHex + TxIndex` that
  the old contract rejects. Merge + activate the contract via timelock
  FIRST; this PR's IS-service rollout follows.
- **`-dashdRPC` is now mandatory** on every IS-service deploy (the
  orchestrator's SPV proof fetcher needs it). Without it, every bundle
  ships with empty proof and the contract rejects.

## Test plan

- [x] `go test -count=1 ./cmd/is-service/...` — ok 7.9s
- [x] `go test -count=1 ./modules/incentive-pendulum/...` — all ok
- [x] `go test -count=1 ./modules/ledger-system/...` — ok 0.4s
- [x] `go test -count=1 ./modules/islock-attestation/...` — ok
- [x] `go test -count=1 ./cmd/mapping-bot/...` — all ok
- [ ] (pre-existing, NOT this PR) `modules/state-processing`,
      `modules/rc-system`, and `db/vsc/elections/TestGetElectionByHeight`
      have unrelated failures on upstream develop; none of this PR's 13
      changed files live in those packages.

## Reference

`DASH-AUDIT-HANDOVER-2026-06-19.md` for rollout sequencing.
