### PR TITLE
Mediums batch 2

### DIFF
--- a/cmd/vsc-node/main.go
+++ b/cmd/vsc-node/main.go
@@ -240,8 +240,22 @@ func main() {
 
 	sr := streamer.NewStreamReader(hiveBlocks, blockConsumer.ProcessBlock, se.SaveBlockHeight, stBlock)
 
-	flatDb, err := flatfs.CreateOrOpen(path.Join(args.dataDir, "tss-keys"), flatfs.Prefix(1), false)
+	tssKeysDir := path.Join(args.dataDir, "tss-keys")
+	flatDb, err := flatfs.CreateOrOpen(tssKeysDir, flatfs.Prefix(1), false)
 	if err != nil {
+		panic(err)
+	}
+	// M58-O6: the TSS keystore holds the node's threshold-signature share
+	// material (per key id / epoch). go-ds-flatfs creates this directory with
+	// os.MkdirAll(path, 0755) (flatfs.go) and writes shard files at 0666, both
+	// subject only to umask — so a misconfigured umask, an `cp` without -p, or a
+	// `tar --no-same-permissions` extract leaves the directory world-readable,
+	// letting any adjacent local user enumerate the TSS key ids and epochs.
+	// Mirror the owner-only treatment the identity config already gets (GV-H7 /
+	// review2 CRITICAL #5 in modules/config/config.go) by forcing the keystore
+	// directory to 0700 regardless of umask. flatfs created/opened it above, so
+	// the chmod is unconditional and idempotent.
+	if err := os.Chmod(tssKeysDir, 0700); err != nil {
 		panic(err)
 	}
 

--- a/lib/dids/eth.go
+++ b/lib/dids/eth.go
@@ -133,6 +133,17 @@ func (d EthDID) Verify(block blocks.Block, sig string) (bool, error) {
 		return false, fmt.Errorf("failed to decode signature: %v", err)
 	}
 
+	// audit N6-H4: EthDID.Verify is a crypto primitive reached on a
+	// permissionless path (OffchainTransaction.Verify -> VerifySignatures ->
+	// VerifyMany). An attacker-supplied signature shorter than 65 bytes made the
+	// sigBytes[64] access below panic (index out of range). Reject malformed
+	// lengths up front like every other DID verifier in this package
+	// (btc.go:120/129, bls.go:167, gateway_pop.go:89). A valid secp256k1
+	// recoverable signature is always exactly 65 bytes, so no valid sig changes.
+	if len(sigBytes) != 65 {
+		return false, fmt.Errorf("invalid signature length for DID %s: got %d, want 65", d.String(), len(sigBytes))
+	}
+
 	if sigBytes[64] != 0 && sigBytes[64] != 1 {
 		sigBytes[64] -= 27
 	}

--- a/modules/common/consensusversion/version.go
+++ b/modules/common/consensusversion/version.go
@@ -25,32 +25,59 @@ import (
 //   - 0.1.0 — pendulum settlement rollout. The Consensus 0→1 bump is what lets the floor
 //     rise to exclude pre-pendulum (0.0.0) nodes from the committee and TSS once a
 //     vsc.propose_consensus_version activates (see docs/consensus-upgrades.md).
-//   - 0.2.0 — the Consensus 1→2 bump gates TWO independent consensus changes, both
-//     activated together when the election floor reaches 0.2.0:
-//     (a) try/catch inter-contract calls (ICCallOptions.Try): a caught revert returns a
-//     structured outcome + rolls back to a savepoint instead of trapping. Until the
-//     floor reaches 0.2.0 the Try flag is IGNORED and a reverting callee traps as
-//     before. See TryCatchICCVersion.
-//     (b) pendulum LP minimum-floor (B12): the swap-fee split caps the node fraction at
-//     BpsScale − MinFractionBps (including on the under-secured cliff), so liquidity
-//     providers always retain a minimum share of every pot. Gated on this line via
-//     pendulum.LPFloorActivation.
-//     Until 0.2.0 is chain-active both behaviors are inert and splits/call semantics stay
-//     byte-identical to 0.1.0, so old and new binaries interoperate until activation.
+//   - 0.2.0 — try/catch inter-contract calls (ICCallOptions.Try). The Consensus 1→2 bump
+//     gates the new contracts.call semantics (a caught revert returns a structured
+//     outcome + rolls back to a savepoint instead of trapping). Until the floor reaches
+//     0.2.0 the Try flag is IGNORED and a reverting callee traps as before, so old and
+//     new binaries stay byte-identical pre-activation. See TryCatchICCVersion.
+	//   - 0.3.0 — WASM _initialize hard-fail (MED #130 / m57 F-WB-3). Below this floor the
+	//     host discards the result of the contract's `_initialize` export and dispatches the
+	//     action handler anyway; on a TinyGo (Go runtime) contract whose `_initialize` traps,
+	//     the module init-flag stays 0 and the handler silently no-ops (br_if over its body)
+	//     yet the call reports success. The 2→3 bump makes the host ABORT the call with
+	//     WASM_INIT_ERROR when `_initialize` traps, instead of running a half-initialised
+	//     handler. See WasmInitGuardVersion.
 const (
 	currentMajor        uint64 = 0
-	currentConsensus    uint64 = 2
+	currentConsensus    uint64 = 3
 	currentNonConsensus uint64 = 0
 )
 
 // TryCatchICCVersion is the minimum chain-active consensus version at which the
 // try/catch inter-contract-call semantics (ICCallOptions.Try) take effect. Below
 // it a Try call behaves exactly like a legacy call (a reverting callee traps the
-// caller), so activation is fully coordinated by the election version floor. It
-// is part of the v0.2.0 batch, so it is the same line as V0_2_0 (see
-// feature_gates.go) — kept as its own named var so the try/catch gate reads by
-// FEATURE at its call site.
-var TryCatchICCVersion = V0_2_0
+// caller), so activation is fully coordinated by the election version floor.
+var TryCatchICCVersion = Version{Major: 0, Consensus: 2, NonConsensus: 0}
+
+// SdkErrorDeterminismVersion is the minimum chain-active consensus version at
+// which the deterministic system.call panic-detail rendering takes effect. It
+// ships in the v0.2.0 batch (Consensus 1->2), so it is keyed to the same {0,2,0}
+// triple as TryCatchICCVersion, but is kept as its OWN named gate so the two
+// v0.2.0-era features stay independently traceable (matching the per-feature
+// gate convention in ConsensusParams).
+//
+// Below it, system.call renders a recovered panic value with
+// fmt.Errorf("%v", r) (legacy) — which can leak per-node pointer addresses /
+// goroutine ids and so fork the result CID. At/after it, the recovered panic
+// value is rendered deterministically (errors/strings verbatim, any other type
+// as its concrete type name only). Because that string flows into the contract
+// result -> state diff -> CID, the switch is consensus-affecting and MUST be
+// coordinated by the election version floor, exactly like TryCatchICCVersion.
+//
+// (The related sp1_verify_groth16 error-class fix — MED-37 — and the
+// contracts.read presence-disambiguation fix — MED-119 — are NOT gated here:
+// each ships as an additive sibling host function (sp1_verify_groth16_ex /
+// contracts.read_ex) that changes no existing contract's behaviour and so needs
+// no height gate.)
+var SdkErrorDeterminismVersion = Version{Major: 0, Consensus: 2, NonConsensus: 0}
+
+// WasmInitGuardVersion is the minimum chain-active consensus version at which the
+// WASM host aborts a contract call whose `_initialize` export trapped (MED #130 /
+// m57 F-WB-3). Below it the host preserves the legacy behaviour — the `_initialize`
+// result is discarded and the action handler runs even with an uninitialised module
+// (a silent no-op on TinyGo contracts) — so old and new binaries stay byte-identical
+// pre-activation. Activation is coordinated solely by the election version floor.
+var WasmInitGuardVersion = Version{Major: 0, Consensus: 3, NonConsensus: 0}
 
 // ParseComponent parses a numeric version-component string, defaulting to 0 when
 // empty/invalid. Retained for the announcement payload helper; the running version itself
@@ -79,8 +106,8 @@ func RunningVersion() Version {
 
 // Version is the canonical on-chain / wire representation.
 type Version struct {
-	Major        uint64 `json:"major"         bson:"version_major,omitempty"`
-	Consensus    uint64 `json:"consensus"     bson:"version_consensus,omitempty"`
+	Major         uint64 `json:"major" bson:"version_major,omitempty"`
+	Consensus     uint64 `json:"consensus" bson:"version_consensus,omitempty"`
 	NonConsensus uint64 `json:"non_consensus" bson:"version_non_consensus,omitempty"`
 }
 
@@ -149,3 +176,4 @@ func MaxComponentwise(a, b Version) Version {
 	}
 	return out
 }
+

--- a/modules/common/consensusversion/version_test.go
+++ b/modules/common/consensusversion/version_test.go
@@ -44,7 +44,7 @@ func TestMaxComponentwise(t *testing.T) {
 // pinned current triple. Update this pin in the SAME commit that bumps the constants in
 // version.go.
 func TestRunningVersionIsSourcePinned(t *testing.T) {
-	want := Version{Major: 0, Consensus: 2, NonConsensus: 0}
+	want := Version{Major: 0, Consensus: 3, NonConsensus: 0}
 	if got := RunningVersion(); got != want {
 		t.Fatalf("running version = %+v, want %+v (source constants in version.go)", got, want)
 	}

--- a/modules/contract/execution-context/execution-context.go
+++ b/modules/contract/execution-context/execution-context.go
@@ -57,6 +57,21 @@ type contractExecutionContext struct {
 	// across binaries. Set once per tx by the state engine and propagated into
 	// nested calls.
 	tryCatchActive bool
+
+	// sdkErrorDeterminismActive gates the v0.2.0 deterministic SDK
+	// error-surfacing behaviour (>= SdkErrorDeterminismVersion). False => SDK
+	// host functions render errors exactly as the pre-fix code did (byte-
+	// identical legacy output). Set once per tx by the state engine from the
+	// chain-active consensus version and propagated into nested calls, so it is
+	// height-addressable and identical across nodes — mirrors tryCatchActive.
+	sdkErrorDeterminismActive bool
+
+	// initGuardActive gates the WASM host's `_initialize` hard-fail (MED #130 /
+	// m57 F-WB-3) on the chain-active consensus version (>= WasmInitGuardVersion).
+	// False => a trapping `_initialize` is ignored and the (uninitialised) handler
+	// runs as before, keeping pre-activation behaviour identical across binaries.
+	// Set once per tx by the state engine and propagated into nested calls.
+	initGuardActive bool
 }
 
 type ContractExecutionContext = *contractExecutionContext
@@ -161,6 +176,29 @@ func WithPendulumApplier(p wasm_context.PendulumApplier) Option {
 // coordinated version floor.
 func WithTryCatch(active bool) Option {
 	return func(ctx *contractExecutionContext) { ctx.tryCatchActive = active }
+}
+
+// WithSdkErrorDeterminism enables the v0.2.0 deterministic SDK error-surfacing
+// behaviour. The state engine sets this from the chain-active consensus version
+// (>= consensusversion.SdkErrorDeterminismVersion) so it only activates at a
+// coordinated version floor; when false the SDK host functions emit byte-
+// identical legacy output.
+func WithSdkErrorDeterminism(active bool) Option {
+	return func(ctx *contractExecutionContext) { ctx.sdkErrorDeterminismActive = active }
+}
+
+// SdkErrorDeterminismActive implements wasm_context.ExecContextValue. It exposes
+// the per-call, height-addressable gate to the SDK host functions.
+func (ctx *contractExecutionContext) SdkErrorDeterminismActive() bool {
+	return ctx.sdkErrorDeterminismActive
+}
+
+// WithInitGuard enables the WASM host's `_initialize` hard-fail (MED #130). The
+// state engine sets this from the chain-active consensus version so the abort-on-
+// failed-init semantics only activate at a coordinated version floor. It is
+// propagated into nested contracts.call contexts unchanged.
+func WithInitGuard(active bool) Option {
+	return func(ctx *contractExecutionContext) { ctx.initGuardActive = active }
 }
 
 func (ctx *contractExecutionContext) IOGas() int {
@@ -574,6 +612,32 @@ func (ctx *contractExecutionContext) ContractStateGet(contractId string, key str
 	return result.Ok(resStr)
 }
 
+// ContractStateGetEx is the presence-disambiguating sibling of ContractStateGet
+// (MED-119). ContractStateGet collapses both "key absent" and "key present with
+// an empty value" to result.Ok("") — a cross-contract reader (e.g. the ZK
+// verifier blocklist read of another contract's "b-{height}" key) cannot tell a
+// stale/missing entry from an intentional empty one. This sibling returns the
+// same value string PLUS an `exists` flag derived from the same nil-vs-non-nil
+// distinction the state store already computes deterministically from the
+// merkle-backed databin (StateStore.Get returns nil only when the key is truly
+// absent; an empty stored value comes back as a non-nil empty slice). The
+// existence bit is therefore height-deterministic and identical across nodes.
+//
+// Gas is charged byte-for-byte identically to ContractStateGet (same doIO calls
+// in the same order) so the only observable difference for a contract that opts
+// in via contracts.read_ex is the extra `exists` field — and existing contracts,
+// which import only contracts.read, are completely unaffected.
+func (ctx *contractExecutionContext) ContractStateGetEx(contractId string, key string) (result.Result[string], bool) {
+	ctx.doIO(len(key))
+	res := ctx.callSession.GetStateStore(contractId).Get(key)
+	if res == nil {
+		return result.Ok(""), false
+	}
+	resStr := string(res)
+	ctx.doIO(len(resStr))
+	return result.Ok(resStr), true
+}
+
 // tryOutcome encodes the structured result a try/catch inter-contract call hands
 // back to the caller (instead of trapping). The caller's SDK decodes the "ok"
 // field to branch. gas is what the callee actually consumed — charged either way,
@@ -653,15 +717,29 @@ func (ctx *contractExecutionContext) ContractCall(
 				// the GraphQL simulate path), this propagates nil — same
 				// behaviour as before, just now consistent across the call depth.
 				WithPendulumApplier(ctx.pendulumApplier),
-				WithTryCatch(ctx.tryCatchActive))
+				WithTryCatch(ctx.tryCatchActive),
+				// Propagate the v0.2.0 SDK error-determinism gate into the nested
+				// context so a contract reached via contracts.call evaluates it
+				// identically to the entrypoint (height-addressable, same on all
+				// nodes) — mirrors the tryCatchActive propagation above.
+				WithSdkErrorDeterminism(ctx.sdkErrorDeterminismActive),
+				WithInitGuard(ctx.initGuardActive))
 
 			callPayload := payload
 			json.Unmarshal([]byte(payloadJson), &callPayload)
 
 			wasmCtx := context.WithValue(
-				context.WithValue(context.Background(), wasm_context.WasmExecCtxKey, ctxValue),
-				wasm_context.WasmExecCodeCtxKey,
-				hex.EncodeToString(ct.Code),
+				context.WithValue(
+					context.WithValue(context.Background(), wasm_context.WasmExecCtxKey, ctxValue),
+					wasm_context.WasmExecCodeCtxKey,
+					hex.EncodeToString(ct.Code),
+				),
+				// MED #130 (m57 F-WB-3): propagate the chain-active `_initialize`
+				// hard-fail gate into the nested call so a callee with a trapping
+				// `_initialize` aborts (post-activation) instead of silently
+				// no-opping, matching the top-level entry semantics.
+				wasm_context.WasmInitGuardCtxKey,
+				ctx.initGuardActive,
 			)
 			// try/catch (ICCallOptions.Try): snapshot state + ledger just before
 			// the callee runs, so a revert can be unwound without disturbing the

--- a/modules/gateway/multisig.go
+++ b/modules/gateway/multisig.go
@@ -21,7 +21,6 @@ import (
 	"vsc-node/lib/vsclog"
 	a "vsc-node/modules/aggregate"
 	"vsc-node/modules/common"
-	"vsc-node/modules/common/consensusversion"
 	systemconfig "vsc-node/modules/common/system-config"
 	"vsc-node/modules/db/vsc/elections"
 	ledgerDb "vsc-node/modules/db/vsc/ledger"
@@ -69,10 +68,34 @@ type MultiSig struct {
 	// "fatal error: concurrent map writes".
 	msgMu sync.Mutex
 
-	bh uint64
+	// bh is the latest L1 block height seen by BlockTick. It is read by the
+	// pubsub dispatch goroutine (p2p.go HandleMessage) and by waitCheckBh while
+	// BlockTick concurrently writes it, so every access MUST go through the
+	// loadBh/storeBh helpers below — an unsynchronized read/write here is a data
+	// race (audit MED M38-MED-4 / #112). bhMu guards it.
+	//
+	// The field is left a plain uint64 (rather than an atomic.Uint64) on purpose:
+	// the existing tests construct MultiSig with struct literals (e.g.
+	// review2_bh_underflow_test.go `&MultiSig{bh: 5}`), which an atomic type would
+	// break, and a zero-value sync.Mutex is valid so the literal still compiles.
+	bhMu sync.Mutex
+	bh   uint64
 
-	electionPeerIDs   atomic.Pointer[map[string]bool]
-	lastElectionEpoch uint64
+	electionPeerIDs atomic.Pointer[map[string]bool]
+	// MED-55 removed the `election.Epoch != lastElectionEpoch` rebuild guard
+	// (the allow-set is now rebuilt every ACTION_INTERVAL), so the
+	// lastElectionEpoch tracking field it fed has no remaining reader and was
+	// dropped (fix-round-2 R2-6a).
+}
+
+// storeBh records the latest block height seen by BlockTick (MED #112).
+func (ms *MultiSig) storeBh(bh uint64) { ms.bhMu.Lock(); ms.bh = bh; ms.bhMu.Unlock() }
+
+// loadBh returns the latest block height seen by BlockTick (MED #112).
+func (ms *MultiSig) loadBh() uint64 {
+	ms.bhMu.Lock()
+	defer ms.bhMu.Unlock()
+	return ms.bh
 }
 
 func (ms *MultiSig) Init() error {
@@ -164,6 +187,64 @@ func enforceMainnetIntervals(onMainnet bool) {
 	}
 }
 
+// assertIntervalDivisibility panics if the active rotation/action/sync intervals
+// violate the strict ordering and divisibility the MED-56 co-fire deferral
+// relies on (fix-round-2 R2-6c, tightened in fix-round-3 C-RV).
+//
+// The BlockTick scheduler requires STRICT ordering — not merely divisibility:
+//
+//   ACTION_INTERVAL < ROTATION_INTERVAL < SYNC_INTERVAL
+//
+// with ROTATION_INTERVAL % ACTION_INTERVAL == 0 and
+//      SYNC_INTERVAL % ROTATION_INTERVAL == 0.
+//
+// Why strict ordering matters (C-RV):
+//
+//   If ACTION_INTERVAL == ROTATION_INTERVAL the deferred-actions path
+//   (bh%ACTION_INTERVAL == 0 && !isRotationBlock) is NEVER true — every
+//   action tick is also a rotation tick — so actions are permanently starved
+//   and the MED-56 co-fire race is re-introduced (the rotation ships with
+//   stale signatures from the old key-auth set). The divisibility check
+//   alone does not catch this: 20%20==0 passes divisibility but breaks the
+//   deferral invariant.
+//
+//   If ROTATION_INTERVAL >= SYNC_INTERVAL (equal or inverted) the fr_sync
+//   re-targeting (bh%SYNC_INTERVAL == ACTION_INTERVAL) either lands on the
+//   same block class as the rotation or the divisibility check below becomes
+//   meaningless, reintroducing the sync co-fire leg.
+//
+// Mainnet already enforces the canonical values via enforceMainnetIntervals.
+// A devnet that sets equal intervals would SILENTLY starve actions; fail loud
+// at construction instead. ACTION_INTERVAL > 0 is guaranteed: the defaults are
+// non-zero and init() only applies env overrides when n > 0.
+func assertIntervalDivisibility() {
+	if ACTION_INTERVAL == 0 || ROTATION_INTERVAL == 0 || SYNC_INTERVAL == 0 {
+		panic(fmt.Sprintf("gateway: zero interval (rotation=%d action=%d sync=%d)",
+			ROTATION_INTERVAL, ACTION_INTERVAL, SYNC_INTERVAL))
+	}
+	// Strict ordering: ACTION_INTERVAL < ROTATION_INTERVAL < SYNC_INTERVAL.
+	// Equal intervals re-introduce the MED-56 co-fire or action starvation.
+	if ACTION_INTERVAL >= ROTATION_INTERVAL {
+		panic(fmt.Sprintf("gateway: ACTION_INTERVAL (%d) must be strictly less than ROTATION_INTERVAL (%d) — equal values starve actions (MED-56 co-fire deferral)",
+			ACTION_INTERVAL, ROTATION_INTERVAL))
+	}
+	if ROTATION_INTERVAL >= SYNC_INTERVAL {
+		panic(fmt.Sprintf("gateway: ROTATION_INTERVAL (%d) must be strictly less than SYNC_INTERVAL (%d) — equal values re-introduce sync co-fire (MED-56 co-fire deferral)",
+			ROTATION_INTERVAL, SYNC_INTERVAL))
+	}
+	// Divisibility: both strict-ordering checks above implicitly guarantee the
+	// non-zero denominators, but we also verify the modular relationship the
+	// BlockTick bh%INTERVAL==ACTION_INTERVAL re-targeting relies on.
+	if ROTATION_INTERVAL%ACTION_INTERVAL != 0 {
+		panic(fmt.Sprintf("gateway: ROTATION_INTERVAL (%d) must be a multiple of ACTION_INTERVAL (%d) — see MED-56 co-fire deferral",
+			ROTATION_INTERVAL, ACTION_INTERVAL))
+	}
+	if SYNC_INTERVAL%ROTATION_INTERVAL != 0 {
+		panic(fmt.Sprintf("gateway: SYNC_INTERVAL (%d) must be a multiple of ROTATION_INTERVAL (%d) — see MED-56 co-fire deferral",
+			SYNC_INTERVAL, ROTATION_INTERVAL))
+	}
+}
+
 // Devnet-only env-var overrides so e2e tests can drive rotation/action
 // ticks on the order of seconds instead of an hour. Honoured only when
 // set to a positive value; production binaries leave the defaults alone.
@@ -187,7 +268,7 @@ func init() {
 }
 
 func (ms *MultiSig) BlockTick(bh uint64, headHeight *uint64) {
-	ms.bh = bh
+	ms.storeBh(bh)
 	if headHeight == nil {
 		return
 	}
@@ -198,9 +279,20 @@ func (ms *MultiSig) BlockTick(bh uint64, headHeight *uint64) {
 		return
 	}
 
+	// MED #55 (M26-K5-M1): rebuild the gossip ingress allow-set on every
+	// ACTION_INTERVAL tick, not only when the on-chain election epoch changes.
+	// electionPeerIDs is keyed by libp2p PeerId. A witness that rotates its
+	// libp2p identity mid-epoch updates its witnessDb PeerId without advancing
+	// the epoch, so the old `election.Epoch != ms.lastElectionEpoch` guard left
+	// every other node's allow-set holding that witness's STALE PeerId until the
+	// next epoch (~1 h on mainnet) — self-excluding the rotated witness from
+	// sign_request validation. Rebuilding each ACTION_INTERVAL (~1 min) picks up
+	// the new PeerId within one interval of the witnessDb resync. This map is a
+	// per-node ingress filter only (read solely in p2p.go ValidateMessage); it
+	// feeds no commitment/CID, so the per-node DB-read cost is the only effect.
 	if ms.electionPeerIDs.Load() == nil || bh%ACTION_INTERVAL == 0 {
 		election, err := ms.electionDb.GetElectionByHeight(bh)
-		if err == nil && election.Epoch != ms.lastElectionEpoch {
+		if err == nil {
 			peerIDs := make(map[string]bool, len(election.Members))
 			for _, member := range election.Members {
 				w, _ := ms.witnessDb.GetWitnessAtHeight(member.Account, &bh)
@@ -208,8 +300,21 @@ func (ms *MultiSig) BlockTick(bh uint64, headHeight *uint64) {
 					peerIDs[w.PeerId] = true
 				}
 			}
-			ms.electionPeerIDs.Store(&peerIDs)
-			ms.lastElectionEpoch = election.Epoch
+			// fix-round-2 R2-6b: only swap in the freshly-built allow-set when it
+			// resolved at least one PeerId. A transient witnessDb sync gap (the
+			// GetWitnessAtHeight reads above all returning nil for one tick) would
+			// otherwise Store an EMPTY map, which p2p.go ValidateMessage treats as
+			// "no one is allowed" — self-DoSing this node's sign_request ingress
+			// until the next non-empty rebuild. Keeping the previous non-nil map on
+			// an empty rebuild is strictly safer: the stale set is a superset/peer
+			// of the live committee far more often than it is a blank, and the
+			// rebuild retries every ACTION_INTERVAL. (election membership is
+			// on-chain/deterministic, but this map is a per-node ingress filter
+			// only — it feeds no commitment/CID — so retaining the prior set is not
+			// consensus-affecting.)
+			if len(peerIDs) > 0 {
+				ms.electionPeerIDs.Store(&peerIDs)
+			}
 		}
 	}
 
@@ -230,16 +335,63 @@ func (ms *MultiSig) BlockTick(bh uint64, headHeight *uint64) {
 			return
 		}
 
-		if bh%ROTATION_INTERVAL == 0 {
-			log.Debug("running key rotation", "bh", bh)
-			go ms.TickKeyRotation(bh)
-		}
-		if bh%ACTION_INTERVAL == 0 {
-			log.Debug("running actions", "bh", bh)
-			go ms.TickActions(bh)
-		}
-		if bh%SYNC_INTERVAL == 0 {
-			go ms.TickSyncFr(bh)
+		// MED M26-K6-M3 (#56): ROTATION_INTERVAL is a multiple of ACTION_INTERVAL
+		// (1200 % 20 == 0) and SYNC_INTERVAL is a multiple of ROTATION_INTERVAL
+		// (7200 % 1200 == 0), so on a rotation block the actions/sync spend can
+		// co-fire with the rotation. If the rotation's account_update (which
+		// changes the gateway owner/active key_auths set) lands on L1 BEFORE the
+		// actions/sync tx — whose signatures were collected against the OLD auth
+		// set — that tx fails "missing required authority": for actions the
+		// carried withdrawal is debited on L2 but never settled on L1 (stuck
+		// funds); for fr_sync the internal HBD rebalance silently fails.
+		//
+		// The fix runs the rotation ALONE on its block and DEFERS the co-firing
+		// spends to the next non-rotation tick — it does NOT drop them:
+		//   - actions defer to the next ACTION tick. executeActions is pure and
+		//     re-reads GetPendingActions (status stays "pending"), so the batch is
+		//     re-selected one tick later against the now-stable post-rotation auth.
+		//   - fr_sync re-targets the action tick exactly ACTION_INTERVAL after the
+		//     sync block (bh%SYNC_INTERVAL == ACTION_INTERVAL), which is never a
+		//     rotation block (SYNC%ROT==0 so SYNC+ACTION % ROT == ACTION != 0).
+		//     syncBalance still requires bh%ACTION_INTERVAL==0 and its own
+		//     freshness guard (balRecord.BlockHeight > bh-SYNC_INTERVAL) keeps the
+		//     cadence at exactly SYNC_INTERVAL, so running it ACTION_INTERVAL late
+		//     is harmless and never double-syncs.
+		//
+		// This is leader-only scheduling OFF the deterministic L2 consensus path
+		// (the state engine ingests the resulting L1 vsc.actions / vsc.fr_sync
+		// header by CONTENT, not by predicting which block the leader ran it on),
+		// but per the repo convention every gateway behaviour change still gates
+		// on the coordinated v0.2.0 height — the SAME gate decentralizeOwner uses
+		// (GatewayDecentralizationActive == Version0_2_0Active) — so the LEGACY
+		// schedule below stays byte-identical until activation and no node runs a
+		// mixed schedule within one activation regime.
+		if ms.sconf.ConsensusParams().Version0_2_0Active(bh) {
+			isRotationBlock := bh%ROTATION_INTERVAL == 0
+			if isRotationBlock {
+				log.Debug("running key rotation", "bh", bh)
+				go ms.TickKeyRotation(bh)
+			}
+			if bh%ACTION_INTERVAL == 0 && !isRotationBlock {
+				log.Debug("running actions", "bh", bh)
+				go ms.TickActions(bh)
+			}
+			if bh%SYNC_INTERVAL == ACTION_INTERVAL {
+				go ms.TickSyncFr(bh)
+			}
+		} else {
+			// LEGACY deterministic schedule — byte-identical to base 937ae771.
+			if bh%ROTATION_INTERVAL == 0 {
+				log.Debug("running key rotation", "bh", bh)
+				go ms.TickKeyRotation(bh)
+			}
+			if bh%ACTION_INTERVAL == 0 {
+				log.Debug("running actions", "bh", bh)
+				go ms.TickActions(bh)
+			}
+			if bh%SYNC_INTERVAL == 0 {
+				go ms.TickSyncFr(bh)
+			}
 		}
 	}
 }
@@ -279,7 +431,14 @@ func (ms *MultiSig) TickKeyRotation(bh uint64) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// MED M29-F3 (#105): the rotation sig-collection window was 5s while
+	// actions/sync use 30s. 5s is too tight to collect a 2/3 stake supermajority
+	// from up to MAX_GATEWAY_KEYS cross-continent witnesses; a missed rotation
+	// leaves the stale key set in place for a full ROTATION_INTERVAL (~1h). Match
+	// the 30s the other two paths use. This is local liveness only (it bounds how
+	// long THIS leader waits before broadcasting); it never changes the signed tx
+	// bytes or any on-chain commitment, so it is off the consensus path.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	signatures, weight, err := ms.waitForSigs(ctx, signPkg.Tx, signPkg.TxId)
 	ms.deleteMsgChan(signPkg.TxId)
@@ -519,15 +678,13 @@ func (ms *MultiSig) keyRotation(bh uint64) (signingPackage, error) {
 	// weight == threshold and posting carries vsc.dao + vsc.network.
 	//
 	// *** HIGHEST-RISK once active ***: with no vsc.dao backstop, a committee that
-	// wedges below threshold has no on-chain recovery. Do NOT raise the consensus
-	// floor to 0.2.0 on mainnet until CP-1 (floor-advance readiness, gateway/TSS
-	// handover ordering, the floor guard) is devnet-proven under heavy churn.
+	// wedges below threshold has no on-chain recovery. Do NOT pin Version0_2_0Height
+	// on mainnet until CP-1 (floor-advance readiness, gateway/TSS handover ordering,
+	// the floor guard) is devnet-proven under heavy churn.
 	//
-	// Determinism (Constraint 3): decentralizeOwner is a pure function of the
-	// chain-active consensus version at bh (ResultVersion of the election at bh,
-	// already loaded above) + the compile-time line, so every cosigner builds the
-	// identical account_update.
-	decentralizeOwner := consensusversion.GatewayDecentralizationActive(elections.ResultVersion(electionResult))
+	// Determinism (Constraint 3): decentralizeOwner is a pure function of bh + the
+	// compile-time param, so every cosigner builds the identical account_update.
+	decentralizeOwner := ms.sconf.ConsensusParams().GatewayDecentralizationActive(bh)
 
 	var eb [2]interface{}
 	eb[0] = "vsc.network"
@@ -984,6 +1141,11 @@ func (ms *MultiSig) waitForSigs(
 	type collectResult struct {
 		sigs   []string
 		weight uint64
+		// signers is the set of committee pubkeys whose signature was counted.
+		// Carried back so the timeout path can name the MISSING committee members
+		// (MED M29-F4 / #81 per-signer telemetry) without re-running pubkey
+		// recovery — the collector goroutine already recovered them.
+		signers map[string]struct{}
 	}
 	// Buffered so the collector can always hand back its result and exit, even
 	// if the parent already returned via ctx timeout — no goroutine leak.
@@ -1003,7 +1165,7 @@ func (ms *MultiSig) waitForSigs(
 			select {
 			case <-ctx.Done():
 				// Timed out / cancelled: hand back what we have and exit.
-				resCh <- collectResult{sigs, signedWeight}
+				resCh <- collectResult{sigs, signedWeight, signedByPubKey}
 				return
 			case msg := <-ch:
 				if msg == nil {
@@ -1025,6 +1187,16 @@ func (ms *MultiSig) waitForSigs(
 								signedByPubKey[pubKey] = struct{}{}
 								sigs = append(sigs, sigRes.Sig)
 								signedWeight = signedWeight + uint64(weights[idx])
+								// MED M29-F4 (#81): emit per-signer telemetry so a
+								// defender can detect slow-burn signer compromise (a
+								// key that stops signing, or one signing for an
+								// account it shouldn't). Aggregate-only logging hid
+								// which committee keys actually participated. Logging
+								// only; off consensus path.
+								log.Verbose("waitForSigs: counted signer",
+									"txId", hivetxId, "pubKey", pubKey,
+									"weight", weights[idx], "cumWeight", signedWeight,
+									"threshold", threshold)
 							}
 						}
 					}
@@ -1032,7 +1204,7 @@ func (ms *MultiSig) waitForSigs(
 			}
 		}
 
-		resCh <- collectResult{sigs, signedWeight}
+		resCh <- collectResult{sigs, signedWeight, signedByPubKey}
 	}()
 
 	// sigs/signedWeight are owned exclusively by the collector goroutine and
@@ -1041,10 +1213,24 @@ func (ms *MultiSig) waitForSigs(
 	select {
 	case <-ctx.Done():
 		res := <-resCh
-		log.Verbose("waitForSigs: collect timeout", "weight", res.weight)
+		// MED M29-F4 (#81): on a failed collection, name the committee keys that
+		// did NOT sign so a defender can see WHICH signers went dark (slow-burn
+		// compromise / partial outage) rather than only the aggregate shortfall.
+		missing := make([]string, 0, len(publicList))
+		for _, pk := range publicList {
+			if _, signed := res.signers[pk]; !signed {
+				missing = append(missing, pk)
+			}
+		}
+		log.Warn("waitForSigs: collect timeout below threshold",
+			"txId", hivetxId, "weight", res.weight, "threshold", threshold,
+			"signed", len(res.signers), "committee", len(publicList),
+			"missingSigners", missing)
 		return res.sigs, res.weight, nil
 	case res := <-resCh:
-		log.Verbose("waitForSigs: collected needed sigs", "weight", res.weight)
+		log.Verbose("waitForSigs: collected needed sigs",
+			"txId", hivetxId, "weight", res.weight, "threshold", threshold,
+			"signed", len(res.signers))
 		return res.sigs, res.weight, nil
 	}
 }
@@ -1054,27 +1240,34 @@ func (ms *MultiSig) waitCheckBh(INTERVAL uint64, blockHeight uint64) error {
 		return errors.New("invalid interval")
 	}
 
-	if blockHeight > ms.bh {
+	// MED M38-MED-4 (#112): read ms.bh through loadBh (BlockTick writes it
+	// concurrently — the previous bare field reads were a data race) and replace
+	// the tight 20×1s time.Sleep busy-wait with a select/ticker that can exit
+	// promptly on the deadline. Local liveness only; off the consensus path.
+	curBh := ms.loadBh()
+	if blockHeight > curBh {
 		//if too far into future!
-		if blockHeight-10 > ms.bh {
+		if blockHeight-10 > curBh {
 			return nil
 		}
 
-		var clear bool
-		for i := 0; i < 20; i++ {
-			if ms.bh == blockHeight {
-				clear = true
-				break
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		deadline := time.After(20 * time.Second)
+		for {
+			if ms.loadBh() == blockHeight {
+				return nil
 			}
-			time.Sleep(time.Second)
-		}
-		if !clear {
-			return errors.New("timeout waiting for block height")
+			select {
+			case <-deadline:
+				return errors.New("timeout waiting for block height")
+			case <-ticker.C:
+			}
 		}
 		// review2 LOW #113: ms.bh-10 underflows to ~1.8e19 when the node
 		// is below block 10, rejecting every early block as "too far into
 		// past". blockHeight+10 < ms.bh is the same check without underflow.
-	} else if blockHeight+10 < ms.bh {
+	} else if blockHeight+10 < curBh {
 		return errors.New("too far into past")
 	}
 
@@ -1124,6 +1317,11 @@ func New(
 	// C11-c: a mainnet node must use the canonical consensus intervals,
 	// regardless of any VSC_GATEWAY_*_INTERVAL env value.
 	enforceMainnetIntervals(sconf.OnMainnet())
+	// fix-round-2 R2-6c: after env overrides + mainnet enforcement, fail loud if
+	// the active intervals violate the divisibility the MED-56 co-fire deferral
+	// depends on (a misconfigured devnet would otherwise silently reintroduce the
+	// rotation/spend race). Mainnet is already safe via enforceMainnetIntervals.
+	assertIntervalDivisibility()
 	return &MultiSig{
 		witnessDb:     witnessDb,
 		electionDb:    electionDb,

--- a/modules/gateway/p2p.go
+++ b/modules/gateway/p2p.go
@@ -33,23 +33,59 @@ type p2pSpec struct {
 	ms *MultiSig
 }
 
-// ValidateMessage rejects sign_request messages from peers not in the current
-// election. Prevents unauthenticated peers from triggering expensive signing
-// work on every witness (finding S7).
+// ValidateMessage is the gossipsub topic validator (registered in
+// modules/p2p/pubsub.go RegisterTopicValidator). Returning false means the
+// message is NEITHER relayed onward through the mesh NOR dispatched to
+// HandleMessage on this node, so this is the ingress chokepoint for the
+// /gateway/v1 topic. Only the two protocol message types are admitted:
+//
+//   - sign_request  — gated by current-election peer.ID. The leader publishes
+//     it; a peer not in electionPeerIDs cannot trigger expensive signing work
+//     on every witness (finding S7). The allow-set is now rebuilt every
+//     ACTION_INTERVAL (multisig.go BlockTick) so a leader whose libp2p identity
+//     rotated mid-epoch is admitted within ~1 min, not the next epoch (MED #55).
+//
+//   - sign_response — admitted unconditionally so gossip can relay a cosigner's
+//     response toward the leader through intermediate (non-leader) nodes. It is
+//     deliberately NOT peer.ID-gated: gating it by peer.ID would drop the
+//     response of any witness whose libp2p identity rotated ahead of the
+//     witness-DB resync (MED #55 / M26-K5-M1), self-excluding that witness from
+//     the multisig. The security boundary for a sign_response is downstream and
+//     identity-rotation-independent: waitForSigs (multisig.go) recovers the
+//     secp256k1 signer pubkey from the signature over the real tx hash, requires
+//     it to be in the committee publicList, and dedups per pubkey — so a forged
+//     or outsider response is rejected there, and the collector channel is a
+//     16-deep non-blocking buffer that drops on overflow (bounds the flood,
+//     MED #3 / #6). A sign_response flood cannot be dropped at THIS validator
+//     without either re-introducing MED #55 (peer.ID gate) or breaking mesh
+//     relay (a leader-only TxId gate), so it is bounded here, not closed here.
+//
+// Any other (unknown or zero-value Type:"") message is rejected outright. The
+// previous code returned true for everything that was not a sign_request, which
+// let a malformed/zero-value message (Type=="", see MED #110) and arbitrary
+// junk types propagate through the mesh.
 func (s p2pSpec) ValidateMessage(ctx context.Context, from peer.ID, msg *pubsub.Message, parsedMsg p2pMessage) bool {
-	if parsedMsg.Type == "sign_request" {
+	switch parsedMsg.Type {
+	case "sign_request":
 		allowed := s.ms.electionPeerIDs.Load()
 		if allowed == nil {
 			return false
 		}
 		return (*allowed)[from.String()]
+	case "sign_response":
+		// Relay-safe, identity-rotation-safe. Authenticated downstream by
+		// recovered secp256k1 pubkey in waitForSigs, not by peer.ID.
+		return true
+	default:
+		return false
 	}
-	return true
 }
 
 func (s p2pSpec) HandleMessage(ctx context.Context, from peer.ID, msg p2pMessage, send libp2p.SendFunc[p2pMessage]) error {
 	if msg.Type == "sign_request" {
-		if s.ms.bh == 0 {
+		// MED M38-MED-4 (#112): ms.bh is written by BlockTick concurrently, so
+		// read it through loadBh — a bare field read here raced.
+		if s.ms.loadBh() == 0 {
 			return nil
 		}
 		if msg.Op == "key_rotation" {
@@ -227,10 +263,16 @@ func (p2pSpec) HandleRawMessage(ctx context.Context, rawMsg *pubsub.Message, sen
 	return nil
 }
 
+// ParseMessage decodes the wire bytes. The json.Unmarshal error is now
+// propagated (MED #110 / M38-MED-1): the topic validator in
+// modules/p2p/pubsub.go treats a ParseMessage error as an invalid message and
+// drops it (no relay, no dispatch), and the dispatch goroutine likewise returns
+// on the error. Swallowing it turned malformed input into a zero-value
+// p2pMessage{Type:""} that previously sailed through ValidateMessage.
 func (p2pSpec) ParseMessage(data []byte) (p2pMessage, error) {
 	res := p2pMessage{}
-	json.Unmarshal(data, &res)
-	return res, nil
+	err := json.Unmarshal(data, &res)
+	return res, err
 }
 
 func (p2pSpec) SerializeMessage(msg p2pMessage) []byte {

--- a/modules/gateway/utils.go
+++ b/modules/gateway/utils.go
@@ -103,8 +103,33 @@ func GatewayKeyFromBlsSeed(blsSeed string) (*hivego.KeyPair, error) {
 	if err != nil {
 		return nil, err
 	}
-	salt := []byte("gateway_key")
-	gatewayKey := sha256.Sum256(append(blsPrivSeed, salt...))
+	// MED M26-K1-M2 (#54): scrub the transient secret material from the heap
+	// before returning. getSigningKp re-derives on every rotation tick, so these
+	// buffers (the raw BLS private seed and the derived gateway private key)
+	// otherwise pile up on the heap and can survive into a core dump / swap page /
+	// heap snapshot taken during a renew/retire window. This is the gateway-side
+	// companion to the TSS-module zeroize and is pure defense-in-depth: it never
+	// changes the returned key bytes.
+	//
+	// Capturing the appended buffer is required because append() may allocate a
+	// NEW backing array (cap exceeded) that ALSO holds a copy of blsPrivSeed;
+	// wiping only blsPrivSeed would leave that second copy live. KeyPairFromBytes
+	// copies the input into a fresh big.Int (secp256k1.PrivKeyFromBytes →
+	// big.Int.SetBytes), so the returned KeyPair does not alias gatewayKey — the
+	// wipe below is byte-safe and behaviour-neutral.
+	seedAndSalt := append(blsPrivSeed, []byte("gateway_key")...)
+	gatewayKey := sha256.Sum256(seedAndSalt)
+	defer func() {
+		for i := range blsPrivSeed {
+			blsPrivSeed[i] = 0
+		}
+		for i := range seedAndSalt {
+			seedAndSalt[i] = 0
+		}
+		for i := range gatewayKey {
+			gatewayKey[i] = 0
+		}
+	}()
 
 	kp := hivego.KeyPairFromBytes(gatewayKey[:])
 	return kp, nil

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -19,6 +19,7 @@ import (
 	"vsc-node/lib/datalayer"
 	"vsc-node/modules/announcements"
 	"vsc-node/modules/common"
+	"vsc-node/modules/common/consensusversion"
 	"vsc-node/modules/common/params"
 	contract_execution_context "vsc-node/modules/contract/execution-context"
 	contract_session "vsc-node/modules/contract/session"
@@ -859,6 +860,10 @@ func (r *queryResolver) SimulateContractCalls(ctx context.Context, input Simulat
 
 		var pendulumOracle map[string]interface{}
 		var ctxOpts []contract_execution_context.Option
+		// MED #130 (m57 F-WB-3): mirror the on-chain `_initialize` hard-fail gate on
+		// the simulate path so a simulated call sees the same success/failure as
+		// execution at this height. Defaults to legacy (off) when no StateEngine.
+		var initGuardActive bool
 		if r.StateEngine != nil {
 			pendulumOracle = r.StateEngine.PendulumOracleEnv()
 			// Wire the pendulum swap-fee applier so simulated swaps on
@@ -870,6 +875,30 @@ func (r *queryResolver) SimulateContractCalls(ctx context.Context, input Simulat
 			if applier := r.StateEngine.PendulumApplier(); applier != nil {
 				ctxOpts = append(ctxOpts, contract_execution_context.WithPendulumApplier(applier))
 			}
+			initGuardActive = r.StateEngine.ActiveConsensusVersion(blockHeight).
+				MeetsConsensusMin(consensusversion.WasmInitGuardVersion)
+			ctxOpts = append(ctxOpts, contract_execution_context.WithInitGuard(initGuardActive))
+			// fix-round-2 R2-5: also thread the deterministic SDK error-surfacing
+			// gate so a simulated call renders errors the SAME way execution does
+			// at this height. The on-chain path (state-processing/transactions.go)
+			// sets BOTH WithInitGuard and WithSdkErrorDeterminism; simulate only set
+			// the former, so above SdkErrorDeterminismVersion a simulate could show
+			// a different error string/outcome than the real execution. Same
+			// height-addressable consensus gate, mirroring transactions.go exactly.
+			ctxOpts = append(ctxOpts, contract_execution_context.WithSdkErrorDeterminism(
+				r.StateEngine.ActiveConsensusVersion(blockHeight).
+					MeetsConsensusMin(consensusversion.SdkErrorDeterminismVersion),
+			))
+			// fix-round-3 C-RV: add the missing WithTryCatch gate (the fourth
+			// option the on-chain path sets — transactions.go:164-166). Without
+			// this, a simulated ICC that uses Try semantics shows a different
+			// outcome than real execution above TryCatchICCVersion: simulate
+			// ignores Try (legacy fail-open), on-chain respects it. Same
+			// height-addressable consensus gate, mirroring transactions.go exactly.
+			ctxOpts = append(ctxOpts, contract_execution_context.WithTryCatch(
+				r.StateEngine.ActiveConsensusVersion(blockHeight).
+					MeetsConsensusMin(consensusversion.TryCatchICCVersion),
+			))
 		}
 		ctxValue := contract_execution_context.New(
 			contract_execution_context.Environment{
@@ -899,9 +928,15 @@ func (r *queryResolver) SimulateContractCalls(ctx context.Context, input Simulat
 		}
 
 		wasmCtx := context.WithValue(
-			context.WithValue(context.Background(), wasm_context.WasmExecCtxKey, ctxValue),
-			wasm_context.WasmExecCodeCtxKey,
-			hex.EncodeToString(code),
+			context.WithValue(
+				context.WithValue(context.Background(), wasm_context.WasmExecCtxKey, ctxValue),
+				wasm_context.WasmExecCodeCtxKey,
+				hex.EncodeToString(code),
+			),
+			// MED #130 (m57 F-WB-3): hand the host the same gate decided above so the
+			// simulate path's success/failure matches on-chain execution at this height.
+			wasm_context.WasmInitGuardCtxKey,
+			initGuardActive,
 		)
 
 		w := wasm_runtime_ipc.New()

--- a/modules/oracle/chain/bitcoin.go
+++ b/modules/oracle/chain/bitcoin.go
@@ -305,9 +305,35 @@ func requestBlockFromPeer(btcdClient *rpcclient.Client, blockHash *chainhash.Has
 	return err
 }
 
+// prunedRecoveryBudget bounds the TOTAL wall-clock time fetchPrunedBlocks may
+// spend polling for pruned blocks across ALL peers. MED #111 (m38 M38-MED-3):
+// the previous nested loop (3 peers x 10 iterations x 1s) could block the oracle
+// witness goroutine for up to 90s in the hot path, piling up behind the
+// ChainOracle tick. This single shared budget is the genuine upper bound on how
+// long recovery can stall — the total never exceeds it regardless of how many
+// peers we cycle through. The block data returned to the caller is unchanged;
+// only the worst-case stall shrinks (90s -> 20s).
+const prunedRecoveryBudget = 20 * time.Second
+
+// prunedRecoveryPollInterval is how often we re-poll btcd for the requested
+// blocks after issuing getblockfrompeer.
+const prunedRecoveryPollInterval = 1 * time.Second
+
+// prunedRecoveryPerPeerPolls is the number of poll intervals to give a single
+// peer before moving on to the next one. This preserves recovery success for
+// slow / large-block deliveries (each peer gets a fair patience window, not a
+// single 1s poll) while the shared prunedRecoveryBudget still caps the total.
+// 7 polls x 1s = up to 7s per peer; 3 peers would want 21s but the 20s budget
+// is the hard ceiling, so a genuinely slow peer set gives up at the budget.
+const prunedRecoveryPerPeerPolls = 7
+
 // fetchPrunedBlocks requests multiple pruned blocks from peers in batch, then
-// polls until all arrive. Tries up to 3 archive (NODE_NETWORK) peers, falling
-// back if one times out. The provided context controls cancellation on shutdown.
+// polls until all arrive. Tries up to 3 archive (NODE_NETWORK) peers, giving each
+// a bounded patience window before falling back to the next. The provided context
+// controls cancellation on shutdown; a hard prunedRecoveryBudget bounds the total
+// time spent so a slow/uncooperative peer set can't stall the oracle hot path
+// (MED #111). The set of blocks returned to the caller is unchanged — only the
+// upper bound on how long recovery may block is reduced.
 func fetchPrunedBlocks(ctx context.Context, btcdClient *rpcclient.Client, blockHashes []*chainhash.Hash) error {
 	if len(blockHashes) == 0 {
 		return nil
@@ -328,6 +354,11 @@ func fetchPrunedBlocks(ctx context.Context, btcdClient *rpcclient.Client, blockH
 		maxPeers = 3
 	}
 
+	// Bound the entire recovery (across all peers) to a single time budget,
+	// derived from ctx so shutdown still cancels promptly.
+	budgetCtx, cancel := context.WithTimeout(ctx, prunedRecoveryBudget)
+	defer cancel()
+
 	for p := 0; p < maxPeers; p++ {
 		// Request all remaining blocks from this peer.
 		for _, hash := range blockHashes {
@@ -336,12 +367,24 @@ func fetchPrunedBlocks(ctx context.Context, btcdClient *rpcclient.Client, blockH
 			}
 		}
 
-		// Poll until all blocks arrive (up to 10s per peer attempt).
-		for i := 0; i < 10; i++ {
+		// Poll this peer up to prunedRecoveryPerPeerPolls times, but never past
+		// the shared budget. The budget (not the per-peer count) is the true
+		// upper bound: the total stall across all peers can never exceed
+		// prunedRecoveryBudget, while each peer still gets a fair patience
+		// window so a slow-but-honest peer is not abandoned after a single poll.
+		for i := 0; i < prunedRecoveryPerPeerPolls; i++ {
 			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(1 * time.Second):
+			case <-budgetCtx.Done():
+				// Budget or parent context expired. Surface a real shutdown
+				// (parent ctx) distinctly; otherwise the shared budget is
+				// exhausted and we give up entirely.
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				btcLogger.Warn("giving up on pruned block recovery (budget exhausted)",
+					"remaining", len(blockHashes), "peersAttempted", p+1, "budget", prunedRecoveryBudget)
+				return fmt.Errorf("%d blocks still unavailable after %s recovery budget", len(blockHashes), prunedRecoveryBudget)
+			case <-time.After(prunedRecoveryPollInterval):
 			}
 			remaining := make([]*chainhash.Hash, 0)
 			for _, hash := range blockHashes {
@@ -359,6 +402,8 @@ func fetchPrunedBlocks(ctx context.Context, btcdClient *rpcclient.Client, blockH
 			}
 			blockHashes = remaining
 		}
+		// This peer did not deliver all remaining blocks within its patience
+		// window; fall back to the next peer (re-issuing the request above).
 	}
 	btcLogger.Warn("giving up on pruned block recovery", "remaining", len(blockHashes), "peersAttempted", maxPeers)
 	return fmt.Errorf("%d blocks still unavailable after trying %d peers", len(blockHashes), maxPeers)

--- a/modules/oracle/chain/chain_relay.go
+++ b/modules/oracle/chain/chain_relay.go
@@ -149,6 +149,17 @@ type ChainOracle struct {
 	txCrafter         *transactionpool.TransactionCrafter
 	txPool            *transactionpool.TransactionPool
 	nonceDb           nonces.Nonces
+	// dedupStore optionally persists the producer-side dedup tracker
+	// (lastSubmittedEnd / lastSubmittedAt) across process restarts. MED #109
+	// (m36/m38 CHAOS-S-CLOCK-1 / M38-MED-2): with only the in-memory maps below,
+	// a restart wipes the 2-minute dedup window, so a node that becomes producer
+	// before its previous addBlocks tx lands on-chain re-submits the same range
+	// (RC + mempool waste). When a backend is wired, loadDedup repopulates the
+	// in-memory maps on the first tick after restart, closing the window.
+	//
+	// nil = persistence disabled: behavior is byte-identical to the pre-fix
+	// in-memory-only tracker. See SetDedupStore for the coordinated wiring TODO.
+	dedupStore relayDedupStore
 	// lastSubmittedEnd tracks the end height of the last submitted block range
 	// per chain symbol. Any new submission whose start height <= this value
 	// is skipped until the contract state catches up, preventing overlapping
@@ -188,6 +199,93 @@ func (c *ChainOracle) clearWitnessed(key string) {
 	c.recentlyWitnessedMu.Lock()
 	delete(c.recentlyWitnessed, key)
 	c.recentlyWitnessedMu.Unlock()
+}
+
+// relayDedupStore is the persistence backend for the producer-side relay dedup
+// tracker (MED #109). It is a tiny key/value contract — one record per chain
+// symbol — deliberately decoupled from the rest of the oracle so a MongoDB
+// (or any) implementation can be wired through the constructor without further
+// changes inside modules/oracle/chain.
+//
+// Implementations MUST be safe for concurrent use; ChainOracle only ever calls
+// them from the single block-tick goroutine today, but the contract keeps the
+// door open for the witness path.
+type relayDedupStore interface {
+	// GetDedup returns the last submitted end height and submission time for a
+	// symbol. found=false means no record exists yet (fresh / never submitted).
+	GetDedup(symbol string) (endHeight uint64, at time.Time, found bool, err error)
+	// SetDedup upserts the dedup record for a symbol.
+	SetDedup(symbol string, endHeight uint64, at time.Time) error
+	// DeleteDedup removes the dedup record for a symbol (contract caught up or
+	// the dedup window expired).
+	DeleteDedup(symbol string) error
+}
+
+// SetDedupStore wires a persistent dedup backend after construction.
+//
+// TODO(coordination, MED #109): construct a MongoDB-backed relayDedupStore in
+// modules/oracle/oracle.go (oracle.New) — it already holds the *vsc.VscDb needed
+// to create a collection, exactly like nonces.New(d) — and call
+// chainOracle.SetDedupStore(store) there. That single coordinated edit (outside
+// this package's scope) activates cross-restart dedup. Until then the store is
+// nil and the tracker degrades to the previous in-memory-only behavior with NO
+// change in deterministic relay output: the dedup tracker is producer-local and
+// off-consensus (witnesses never read it), so persisting it changes only how
+// often a freshly-restarted producer redundantly re-broadcasts an already-
+// pending range — never any signed payload, CID, or on-chain result.
+func (c *ChainOracle) SetDedupStore(store relayDedupStore) {
+	c.dedupStore = store
+}
+
+// loadDedup returns the dedup tracker for a symbol, preferring the persistent
+// store (so a restart sees the pre-restart window) and falling back to the
+// in-memory maps when no backend is wired or the store read fails. It also
+// repopulates the in-memory cache from persistence so subsequent reads this
+// session are cheap.
+func (c *ChainOracle) loadDedup(symbol string) (endHeight uint64, at time.Time, found bool) {
+	if c.dedupStore != nil {
+		end, t, ok, err := c.dedupStore.GetDedup(symbol)
+		if err == nil {
+			if ok {
+				c.lastSubmittedEnd[symbol] = end
+				c.lastSubmittedAt[symbol] = t
+			}
+			return end, t, ok
+		}
+		// Persistence read failed — fall through to the in-memory cache so
+		// dedup still works for the current process lifetime.
+		c.logger.Debug("dedup store read failed, using in-memory tracker",
+			"symbol", symbol, "err", err)
+	}
+	end, ok := c.lastSubmittedEnd[symbol]
+	return end, c.lastSubmittedAt[symbol], ok
+}
+
+// storeDedup records a submission in both the in-memory cache and the
+// persistent store (if wired). A persistence write failure is logged but not
+// fatal — the in-memory tracker still dedups for this process lifetime.
+func (c *ChainOracle) storeDedup(symbol string, endHeight uint64, at time.Time) {
+	c.lastSubmittedEnd[symbol] = endHeight
+	c.lastSubmittedAt[symbol] = at
+	if c.dedupStore != nil {
+		if err := c.dedupStore.SetDedup(symbol, endHeight, at); err != nil {
+			c.logger.Warn("failed to persist relay dedup tracker",
+				"symbol", symbol, "endHeight", endHeight, "err", err)
+		}
+	}
+}
+
+// clearDedup drops the dedup tracker for a symbol from both the in-memory cache
+// and the persistent store (if wired).
+func (c *ChainOracle) clearDedup(symbol string) {
+	delete(c.lastSubmittedEnd, symbol)
+	delete(c.lastSubmittedAt, symbol)
+	if c.dedupStore != nil {
+		if err := c.dedupStore.DeleteDedup(symbol); err != nil {
+			c.logger.Debug("failed to delete persisted relay dedup tracker",
+				"symbol", symbol, "err", err)
+		}
+	}
 }
 
 func New(

--- a/modules/oracle/chain/chain_witness.go
+++ b/modules/oracle/chain/chain_witness.go
@@ -22,8 +22,8 @@ func witnessChainData(c *ChainOracle, msg *chainOracleMessage) (*chainRelayRespo
 		return witnessReplaceBlock(c, msg.SessionID, &request)
 	}
 
-	// Parse the session ID to get symbol, start, end blocks
-	chainSymbol, _, startBlock, endBlock, err := parseChainSessionID(msg.SessionID)
+	// Parse the session ID to get symbol, hive height, start, end blocks
+	chainSymbol, hiveBlockHeight, startBlock, endBlock, err := parseChainSessionID(msg.SessionID)
 	if err != nil {
 		return nil, fmt.Errorf("invalid session id: %w", err)
 	}
@@ -66,6 +66,18 @@ func witnessChainData(c *ChainOracle, msg *chainOracleMessage) (*chainRelayRespo
 
 	if len(blocks) == 0 {
 		return nil, fmt.Errorf("no blocks returned for %s %d-%d", chainSymbol, startBlock, endBlock)
+	}
+
+	// MED #114 (m39 F-INJ-A12): independently verify the Ethereum header
+	// parent-hash chain before signing — the witness must not endorse a batch
+	// whose headers don't actually chain. Gated on the SAME deterministic Hive
+	// block height the producer uses (Version0_2_0Active), so producer and
+	// witness make the identical decision and pre-activation behavior is
+	// byte-identical. No-op for non-ETH chains and never rejects canonical data.
+	if c.sconf.ConsensusParams().Version0_2_0Active(hiveBlockHeight) {
+		if err := verifyEthHeaderChain(blocks, ""); err != nil {
+			return nil, fmt.Errorf("refusing to witness %s %d-%d: %w", chainSymbol, startBlock, endBlock, err)
+		}
 	}
 
 	// Build the exact same transaction payload the producer built

--- a/modules/oracle/chain/ethereum.go
+++ b/modules/oracle/chain/ethereum.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
+	"strings"
 	"time"
 	systemconfig "vsc-node/modules/common/system-config"
 
@@ -245,6 +246,69 @@ func (e *ethereumRelayer) ChainData(_ context.Context, startHeight uint64, count
 	}
 
 	return blocks, nil
+}
+
+// verifyEthHeaderChain asserts that a fetched batch of Ethereum headers forms an
+// unbroken parent-hash chain: every block's ParentHash equals the prior block's
+// Hash, and (when prevHash is non-empty) the first block links to the contract's
+// stored tip. This is the defence-in-depth check the audit (m39 F-INJ-A12 / MED
+// #114) found missing on the BLS-oracle relay path — the ZK path already verifies
+// the parent-hash chain (sp1-helios operator), but the oracle relay trusted the
+// RPC's "finalized" tag without confirming the headers actually chain.
+//
+// On a canonical finalized chain this check ALWAYS passes (consecutive finalized
+// headers chain by definition), so it returns nil and changes no relay bytes; it
+// only rejects an RPC that serves a broken / spliced header sequence. Callers MUST
+// gate invocation on the v0.2.0 consensus activation height so that, before
+// activation, both producer and witness skip the check and remain byte-identical
+// with pre-upgrade nodes (the gate is keyed to the deterministic Hive block height
+// shared by producer and witness, so all nodes make the same decision).
+//
+// prevHash is the L1 hash (0x-prefixed, lowercase) of the block immediately
+// before blocks[0]; pass "" to skip the link-to-tip check (e.g. when the prior
+// tip is not available to the caller). Non-ETH blocks are ignored (returns nil)
+// since only ETH carries an explicit parent-hash field here.
+func verifyEthHeaderChain(blocks []chainBlock, prevHash string) error {
+	var prev *ethChainData
+	for i, b := range blocks {
+		eth, ok := b.(*ethChainData)
+		if !ok {
+			// Not an Ethereum batch — nothing to chain-check here.
+			return nil
+		}
+		// C-F5 (fix-round-3): guard against a typed-nil header. A typed nil
+		// satisfies the *ethChainData type assertion (ok==true) but dereferencing
+		// eth.ParentHash or eth.Hash would panic. This can occur if a caller
+		// inserts a nil *ethChainData into the chainBlock slice — defensive guard.
+		if eth == nil {
+			return fmt.Errorf("eth header chain: nil header at index %d", i)
+		}
+		if i == 0 {
+			if prevHash != "" && !strings.EqualFold(eth.ParentHash, prevHash) {
+				return fmt.Errorf(
+					"eth header chain break at height %d: parent_hash %s does not link to prior tip %s",
+					eth.Height, eth.ParentHash, prevHash,
+				)
+			}
+		} else {
+			// prev is guaranteed non-nil here: it was set to a non-nil eth in the
+			// prior iteration (any nil eth is caught above and returns early).
+			if !strings.EqualFold(eth.ParentHash, prev.Hash) {
+				return fmt.Errorf(
+					"eth header chain break at height %d: parent_hash %s != prior block hash %s",
+					eth.Height, eth.ParentHash, prev.Hash,
+				)
+			}
+			if eth.Height != prev.Height+1 {
+				return fmt.Errorf(
+					"eth header chain gap: block %d follows %d (non-contiguous heights)",
+					eth.Height, prev.Height,
+				)
+			}
+		}
+		prev = eth
+	}
+	return nil
 }
 
 // BlockHeight implements chainBlock.

--- a/modules/oracle/chain/handle_block_tick.go
+++ b/modules/oracle/chain/handle_block_tick.go
@@ -116,23 +116,23 @@ func (o *ChainOracle) processChainRelay(
 	// submissions when the mempool hasn't cleared.
 	// Expires after 2 minutes to avoid deadlocks if the tx failed on-chain.
 	if !chainStatus.replaceBlock {
-		if lastEnd, ok := o.lastSubmittedEnd[chainStatus.symbol]; ok && startHeight <= lastEnd {
-			submittedAt := o.lastSubmittedAt[chainStatus.symbol]
+		// MED #109: read the dedup tracker through loadDedup so a persistent
+		// backend (when wired) survives restarts. With no backend this is the
+		// previous in-memory-only read — byte-identical behavior.
+		if lastEnd, submittedAt, ok := o.loadDedup(chainStatus.symbol); ok && startHeight <= lastEnd {
 			expired := time.Since(submittedAt) > 2*time.Minute
 
 			contractHeight, err := o.getContractBlockHeight(chainStatus.contractId)
 			if err == nil && contractHeight >= lastEnd {
 				// Contract caught up — clear the tracker
-				delete(o.lastSubmittedEnd, chainStatus.symbol)
-				delete(o.lastSubmittedAt, chainStatus.symbol)
+				o.clearDedup(chainStatus.symbol)
 			} else if expired {
 				// Timeout — previous tx likely failed, allow retry
 				o.logger.Info("dedup tracker expired, allowing retry",
 					"symbol", chainStatus.symbol,
 					"lastSubmittedEnd", lastEnd,
 				)
-				delete(o.lastSubmittedEnd, chainStatus.symbol)
-				delete(o.lastSubmittedAt, chainStatus.symbol)
+				o.clearDedup(chainStatus.symbol)
 			} else {
 				o.logger.Debug("skipping overlapping range (previous tx still pending)",
 					"symbol", chainStatus.symbol,
@@ -176,6 +176,23 @@ func (o *ChainOracle) processChainRelay(
 	// Build the transaction payload
 	var payloadJson []byte
 	if !chainStatus.replaceBlock {
+		// MED #114 (m39 F-INJ-A12): on the v0.2.0 consensus path, reject an
+		// Ethereum batch whose headers do not form an unbroken parent-hash
+		// chain before signing/relaying it. Gated on the deterministic Hive
+		// block height (Version0_2_0Active) so producer and witness make the
+		// identical decision and pre-activation behavior stays byte-identical.
+		// On canonical finalized headers this never rejects, so the relay
+		// payload is unchanged once active. verifyEthHeaderChain is a no-op for
+		// non-ETH chains.
+		if o.sconf.ConsensusParams().Version0_2_0Active(signal.BlockHeight) {
+			if err := verifyEthHeaderChain(chainStatus.chainData, ""); err != nil {
+				o.logger.Error("rejecting chain relay: header chain verification failed",
+					"symbol", chainStatus.symbol, "err", err,
+				)
+				return
+			}
+		}
+
 		txPayload, err := makeTransactionPayload(chainStatus.chainData)
 		if err != nil {
 			o.logger.Error("failed to make transaction payload",
@@ -529,8 +546,9 @@ func (o *ChainOracle) processChainRelay(
 
 	// Track the end height to prevent overlapping submissions
 	if !chainStatus.replaceBlock {
-		o.lastSubmittedEnd[chainStatus.symbol] = endHeight
-		o.lastSubmittedAt[chainStatus.symbol] = time.Now()
+		// MED #109: persist through storeDedup so the dedup window survives a
+		// restart when a backend is wired (no-op persistence when nil).
+		o.storeDedup(chainStatus.symbol, endHeight, time.Now())
 	}
 }
 

--- a/modules/oracle/chain/message_handler.go
+++ b/modules/oracle/chain/message_handler.go
@@ -63,11 +63,21 @@ func (c *ChainOracle) Handle(peerID peer.ID, p2pMsg p2p.Msg) (p2p.Msg, error) {
 	case signatureResponse:
 		// Producer: route signature to the waiting channel
 		if err := receiveSignature(c, &msg); err != nil {
-			// Not an error — may not have an active session for this
-			c.logger.Debug("failed to receive signature",
-				"sessionID", msg.SessionID,
-				"err", err,
-			)
+			// MED #113 (m38 M38-HIGH-4): a full channel means we are
+			// DROPPING a valid witness signature under load — surface it at
+			// Warn so "not enough signatures" failures are diagnosable rather
+			// than silent. errInvalidSession is benign (no active session for
+			// this response) and stays at Debug.
+			if errors.Is(err, errChannelFull) {
+				c.logger.Warn("dropped witness signature: signature channel full",
+					"sessionID", msg.SessionID,
+				)
+			} else {
+				c.logger.Debug("failed to receive signature",
+					"sessionID", msg.SessionID,
+					"err", err,
+				)
+			}
 		}
 
 	default:

--- a/modules/state-processing/system_txs.go
+++ b/modules/state-processing/system_txs.go
@@ -9,7 +9,6 @@ import (
 	"vsc-node/lib/dids"
 	"vsc-node/modules/common"
 	"vsc-node/modules/common/common_types"
-	"vsc-node/modules/common/consensusversion"
 	systemconfig "vsc-node/modules/common/system-config"
 	"vsc-node/modules/db/vsc/contracts"
 	"vsc-node/modules/db/vsc/elections"
@@ -178,7 +177,12 @@ const CONTRACT_DATA_AVAILABLITY_PROOF_REQUIRED_HEIGHT = 84162592
 
 // ProcessTx implements VSCTransaction.
 func (tx *TxCreateContract) ExecuteTx(se *StateEngine) TxResult {
-	if wasm_runtime.NewFromString(tx.Runtime.String()).IsErr() {
+	// MED #136: gate the declared runtime on the chain-active consensus version.
+	// Both inputs are on-chain/height-addressable, so every node accepts/rejects
+	// this tx identically (no fork). The two genesis runtimes have a {0,0,0} min
+	// version, so this is byte-identical to the legacy NewFromString check until
+	// a future runtime is introduced behind a higher consensus floor.
+	if !wasm_runtime.IsSupportedAt(tx.Runtime.String(), se.ActiveConsensusVersion(tx.Self.BlockHeight)) {
 		return TxResult{
 			Success: false,
 			Ret:     "runtime name is invalid",
@@ -371,7 +375,7 @@ func (tx *TxUpdateContract) ExecuteTx(se *StateEngine, hasFee bool) UpdateContra
 		// Queue the whole update behind the network timelock. Until this height
 		// the previously-active version (existing) keeps running; ContractById
 		// ignores this row while activation_height > the query height.
-		ActivationHeight: se.contractUpdateActivationHeight(tx.Self.BlockHeight, se.ActiveConsensusVersion(tx.Self.BlockHeight)),
+		ActivationHeight: se.contractUpdateActivationHeight(tx.Self.BlockHeight),
 	}
 	if tx.Owner != "" {
 		// update owner
@@ -383,7 +387,12 @@ func (tx *TxUpdateContract) ExecuteTx(se *StateEngine, hasFee bool) UpdateContra
 	}
 	if hasFee && tx.Code != "" && tx.Code != existing.Code {
 		// update contract code
-		if wasm_runtime.NewFromString(tx.Runtime.String()).IsErr() {
+		// MED #136: gate the declared runtime on the chain-active consensus
+		// version (see TxCreateContract.ExecuteTx). Byte-identical to the legacy
+		// NewFromString check for the two genesis runtimes; a future runtime is
+		// only accepted once the on-chain consensus floor reaches its min
+		// version, so old and new binaries never diverge on the same update tx.
+		if !wasm_runtime.IsSupportedAt(tx.Runtime.String(), se.ActiveConsensusVersion(tx.Self.BlockHeight)) {
 			return UpdateContractResult{
 				Success: false,
 				Err:     "runtime name is invalid",
@@ -427,21 +436,18 @@ func (tx *TxUpdateContract) ExecuteTx(se *StateEngine, hasFee bool) UpdateContra
 
 // contractUpdateActivationHeight returns the height at which an update submitted
 // at submitHeight becomes the active code. It is submitHeight (immediate) when
-// the network has no timelock, or — on mainnet — while the chain-active consensus
-// version has not reached 0.2.0, so a full reindex reproduces historical state
-// byte-for-byte. Otherwise it is submitHeight + the network's (non-overridable)
-// timelock. `active` is the chain-active consensus version at submitHeight,
-// resolved by the caller (se.ActiveConsensusVersion) and passed in so this policy
-// stays a pure function of (network, submitHeight, version).
-func (se *StateEngine) contractUpdateActivationHeight(submitHeight uint64, active consensusversion.Version) uint64 {
+// the network has no timelock, or — on mainnet — while the rollout gate is unset
+// or unreached, so a full reindex reproduces historical state byte-for-byte.
+// Otherwise it is submitHeight + the network's (non-overridable) timelock.
+func (se *StateEngine) contractUpdateActivationHeight(submitHeight uint64) uint64 {
 	blocks := se.sconf.ContractUpdateTimelockBlocks()
 	if blocks == 0 {
 		return submitHeight
 	}
 	if se.sconf.OnMainnet() {
-		// Pre-v0.2.0 (floor below 0.2.0): updates stay immediate so a full reindex
+		// Pre-v0.2.0 (or unpinned gate): updates stay immediate so a full reindex
 		// reproduces historical state byte-for-byte.
-		if !consensusversion.ContractUpdateTimelockActive(active) {
+		if !se.sconf.ConsensusParams().ContractUpdateTimelockActive(submitHeight) {
 			return submitHeight
 		}
 	}

--- a/modules/state-processing/transactions.go
+++ b/modules/state-processing/transactions.go
@@ -16,6 +16,7 @@ import (
 	"vsc-node/modules/common/params"
 	contract_execution_context "vsc-node/modules/contract/execution-context"
 	contract_session "vsc-node/modules/contract/session"
+	wasm_runtime     "vsc-node/modules/wasm/runtime"
 	wasm_runtime_ipc "vsc-node/modules/wasm/runtime_ipc"
 
 	"vsc-node/modules/db/vsc/contracts"
@@ -134,6 +135,13 @@ func (t TxVscCallContract) ExecuteTx(
 	// ensure entrypoint contract is appended to outputs regardless of state access or logs
 	callSession.GetContractSession(t.ContractId)
 
+	// MED #130 (m57 F-WB-3): decide the WASM `_initialize` hard-fail gate once from
+	// the chain-active consensus version (deterministic, height-addressable). Used
+	// for both the execution context (so nested contracts.call inherit it) and the
+	// host wasmCtx below, so a contract whose `_initialize` traps aborts the call
+	// instead of running a silently-uninitialised handler — only at/after the floor.
+	initGuardActive := se.ActiveConsensusVersion(t.Self.BlockHeight).MeetsConsensusMin(consensusversion.WasmInitGuardVersion)
+
 	ctxValue := contract_execution_context.New(contract_execution_context.Environment{
 		ContractId:           t.ContractId,
 		ContractOwner:        info.Owner,
@@ -157,6 +165,14 @@ func (t TxVscCallContract) ExecuteTx(
 		contract_execution_context.WithTryCatch(
 			se.ActiveConsensusVersion(t.Self.BlockHeight).MeetsConsensusMin(consensusversion.TryCatchICCVersion),
 		),
+		// Gate deterministic SDK error-surfacing on the chain-active consensus
+		// version (deterministic, height-addressable) so the new error rendering
+		// activates only at a coordinated version floor — same pattern as
+		// WithTryCatch above.
+		contract_execution_context.WithSdkErrorDeterminism(
+			se.ActiveConsensusVersion(t.Self.BlockHeight).MeetsConsensusMin(consensusversion.SdkErrorDeterminismVersion),
+		),
+		contract_execution_context.WithInitGuard(initGuardActive),
 	)
 
 	validUtf8 := utf8.Valid(t.Payload)
@@ -172,10 +188,35 @@ func (t TxVscCallContract) ExecuteTx(
 	json.Unmarshal([]byte(t.Payload), &payload)
 
 	wasmCtx := context.WithValue(
-		context.WithValue(context.Background(), wasm_context.WasmExecCtxKey, ctxValue),
-		wasm_context.WasmExecCodeCtxKey,
-		hex.EncodeToString(code),
+		context.WithValue(
+			context.WithValue(context.Background(), wasm_context.WasmExecCtxKey, ctxValue),
+			wasm_context.WasmExecCodeCtxKey,
+			hex.EncodeToString(code),
+		),
+		// MED #130 (m57 F-WB-3): hand the host the same chain-active gate decided
+		// above (deterministic, height-addressable) so the abort-on-failed-init
+		// semantics activate only at a coordinated version floor — byte-identical
+		// to the legacy silent-no-op below it.
+		wasm_context.WasmInitGuardCtxKey,
+		initGuardActive,
 	)
+
+	// CD-1 (LOW, round-4): IsSupportedAt is already enforced at create/update
+	// time (system_txs.go:185,395), so a legitimately-registered contract always
+	// carries a supported runtime.  However, a document inserted DIRECTLY into
+	// MongoDB (bypassing tx validation) with an invalid runtime string would reach
+	// wasm_runtime.Execute's default branch at wasm.go:618 and panic — halting
+	// every node that processes the call, non-deterministically (whichever block
+	// this tx appears in).
+	//
+	// Adding a consensus-gated IsSupportedAt check here makes the CALL path
+	// self-contained: an invalid runtime produces a DETERMINISTIC tx-level
+	// failure (identical on all nodes, rc charged, no halt) rather than relying
+	// on the create/update gate as the sole defence.  Both inputs are on-chain /
+	// height-addressable so all nodes at the same height return the same bool.
+	if !wasm_runtime.IsSupportedAt(info.Runtime.String(), se.ActiveConsensusVersion(t.Self.BlockHeight)) {
+		return errorToTxResult(fmt.Errorf("contract has unsupported runtime %q", info.Runtime.String()), 100)
+	}
 
 	res := w.Execute(wasmCtx, gas*params.CYCLE_GAS_PER_RC, t.Action, payload, info.Runtime)
 

--- a/modules/wasm/context/context.go
+++ b/modules/wasm/context/context.go
@@ -11,6 +11,17 @@ type contextKey string
 const WasmExecCtxKey = contextKey("exec")
 const WasmExecCodeCtxKey = contextKey("exec-code")
 
+// WasmInitGuardCtxKey carries a bool into Wasm.Execute that activates the
+// `_initialize` hard-fail guard (MED #130 / m57 F-WB-3). The value is the
+// chain-active gate decided by the caller (state engine / inter-contract call)
+// from ActiveConsensusVersion(blockHeight).MeetsConsensusMin(
+// consensusversion.WasmInitGuardVersion). When true, a trapping `_initialize`
+// aborts the call with WASM_INIT_ERROR instead of dispatching a handler over an
+// uninitialised module. When the key is absent or false (read-only paths that do
+// not set it, and every block below the version floor) the host keeps the legacy
+// behaviour, so pre-activation execution is byte-identical across binaries.
+const WasmInitGuardCtxKey = contextKey("init-guard")
+
 type IOSession interface {
 	End() uint
 }
@@ -94,6 +105,24 @@ type PendulumApplier interface {
 type ExecContextValue interface {
 	ContractCall(contractId string, method string, payload string, options string) wasm_types.WasmResult
 	ContractStateGet(contractId string, key string) result.Result[string]
+	// ContractStateGetEx is the presence-disambiguating sibling of
+	// ContractStateGet (MED-119). It returns the same value string plus an
+	// `exists` bool that is true iff the key is actually present in the target
+	// contract's state (an empty stored value => value="" with exists=true; a
+	// missing key => value="" with exists=false). The existence bit is derived
+	// from the state store's deterministic nil-vs-non-nil result, so every node
+	// computes it identically at a given height. Used by the additive
+	// contracts.read_ex host function; existing contracts (which call only
+	// contracts.read) are unaffected.
+	ContractStateGetEx(contractId string, key string) (result.Result[string], bool)
+	// SdkErrorDeterminismActive reports whether the v0.2.0 deterministic
+	// SDK error-surfacing behaviour is in force for the block this call runs
+	// against. It is set once per tx by the state engine from the chain-active
+	// consensus version (>= consensusversion.SdkErrorDeterminismVersion) and
+	// propagated into nested inter-contract calls, so every node evaluates it
+	// identically at a given height. SDK host functions gate their consensus-
+	// affecting error rendering on this; false => byte-identical legacy output.
+	SdkErrorDeterminismActive() bool
 	DeleteEphemState(key string) result.Result[struct{}]
 	DeleteState(key string) result.Result[struct{}]
 	EnvVar(key string) result.Result[string]

--- a/modules/wasm/runtime/runtime.go
+++ b/modules/wasm/runtime/runtime.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"vsc-node/modules/common/consensusversion"
+
 	"github.com/JustinKnueppel/go-result"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -20,6 +22,54 @@ var (
 	AssemblyScript = runtime{"assembly-script"}
 	Go             = runtime{"go"}
 )
+
+// runtimeMinVersion is the minimum chain-active consensus version at which a
+// runtime may be declared on a contract (create_contract / update_contract).
+//
+// MED #136 (m59 F9 — Contract.Runtime enum has no versioning): the runtime
+// string is a consensus input — every node must accept or reject the SAME
+// create/update tx identically, or the chain forks. Previously a node simply
+// accepted any runtime its binary happened to recognize. The moment a future
+// binary adds a third runtime, an owner could declare it: new binaries would
+// register the contract (TxResult.Success=true) while old binaries reject it
+// (NewFromString(...).IsErr() -> Success=false) on the very same tx -> state
+// fork / network split.
+//
+// Binding each runtime to a minimum consensus version closes that: acceptance
+// becomes a pure function of two on-chain, height-addressable inputs — the
+// declared runtime string and the chain-active consensus version
+// (StateEngine.ActiveConsensusVersion). Every node at a given height resolves
+// the identical answer, so old and new binaries never diverge on the same tx.
+//
+// The two genesis runtimes map to {0,0,0}, so IsSupportedAt is byte-identical
+// to the legacy NewFromString check at every height (the floor is always >=
+// {0,0,0}). A future runtime MUST be added here with the consensus version
+// that introduces it, and that version bumped in consensusversion/version.go,
+// in the same commit that wires its execution — mirroring TryCatchICCVersion.
+var runtimeMinVersion = map[string]consensusversion.Version{
+	AssemblyScript.string: {Major: 0, Consensus: 0, NonConsensus: 0},
+	Go.string:             {Major: 0, Consensus: 0, NonConsensus: 0},
+}
+
+// IsSupportedAt reports whether the runtime string s may be declared on a
+// contract given the chain-active consensus version `active`. It is the
+// consensus-gated replacement for NewFromString(s).IsOk() at the create/update
+// boundary: a runtime is supported iff this binary recognizes it AND the
+// chain-active consensus floor has reached the runtime's minimum version.
+//
+// Determinism: both `s` (from the tx) and `active` (from the on-chain election
+// via ActiveConsensusVersion) are pure functions of on-chain data, so all nodes
+// at the same height return the same bool. For the two genesis runtimes the
+// min version is {0,0,0} so this returns exactly NewFromString(s).IsOk() — the
+// legacy result — at every height. Unknown strings are rejected (same as
+// NewFromString), with no panic.
+func IsSupportedAt(s string, active consensusversion.Version) bool {
+	min, known := runtimeMinVersion[s]
+	if !known {
+		return false
+	}
+	return active.MeetsConsensusMin(min)
+}
 
 type RuntimeAction[Result any] struct {
 	AssemblyScript func() Result
@@ -64,7 +114,23 @@ func Execute[Result any](r runtime, action RuntimeAction[Result]) Result {
 		}
 		return action.Go()
 	default:
-		panic(fmt.Errorf("BUG: unsupported runtime: %s", r))
+		// MED #136 (fix-round-3 C-R24): IsSupportedAt gates every create/update
+		// transaction, so this branch is PROVABLY UNREACHABLE for any runtime
+		// that passed validation. The generic signature cannot construct a typed
+		// result.Err here (Result is constrained to `any`, not result.Result[T]),
+		// so we panic instead — which is strictly correct for an impossible state:
+		//
+		//   - DETERMINISTIC: the unsupported runtime string is on-chain data; all
+		//     nodes at the same height would see the same value and take the same
+		//     branch, so there is no fork risk.
+		//   - NOT a silent success: a zero-value result.Result[T] has err==nil,
+		//     i.e. IsOk()==true, which would mask a wiring regression. Panic is
+		//     louder and forces investigation.
+		//   - UNREACHABLE assertion, NOT a halt risk: the IsSupportedAt gate at
+		//     the create/update boundary is the first line of defence; this panic
+		//     is the backstop that makes a future registry-wiring regression
+		//     immediately visible rather than silently corrupting outputs.
+		panic("unsupported runtime: " + r.string)
 	}
 }
 

--- a/modules/wasm/runtime_ipc/wasm.go
+++ b/modules/wasm/runtime_ipc/wasm.go
@@ -606,11 +606,32 @@ func (w *Wasm) Execute(
 		}
 	}
 
-	wasm_runtime.Execute(runtime, wasm_runtime.RuntimeAction[result.Result[[]any]]{
+	// MED #130 (m57 F-WB-3): the host runs the contract's `_initialize` export
+	// exactly once per fresh VM here. Previously its result was discarded and the
+	// action handler was dispatched unconditionally. On a TinyGo (Go runtime)
+	// contract whose `_initialize` traps (out-of-gas via the cost limit, abort, or
+	// a panic in a global constructor), the module init-flag stays 0; the handler
+	// then short-circuits its own body (br_if 0) and returns a benign value, so the
+	// call reports SUCCESS while doing nothing — a silent no-op the caller paid RC
+	// for. Capture the result and, once the chain-active version floor is reached,
+	// abort the call instead of running a half-initialised handler.
+	initResultRes := wasm_runtime.Execute(runtime, wasm_runtime.RuntimeAction[result.Result[[]any]]{
 		Go: func() result.Result[[]any] {
 			return resultWrap(vm.ExecuteRegistered("contract", "_initialize"))
 		},
 	})
+	// AssemblyScript supplies no Go action above, so wasm_runtime.Execute returns
+	// the zero-value result.Result (IsOk, err==nil) for AS contracts — the guard
+	// only ever trips for the Go runtime, where `_initialize` actually ran.
+	initGuardActive, _ := ctx.Value(wasm_context.WasmInitGuardCtxKey).(bool)
+	if initGuardActive && initResultRes.IsErr() {
+		errStr := fmt.Errorf("contract _initialize failed: %w", initResultRes.UnwrapErr()).Error()
+		return wasm_types.WasmResultStruct{
+			Error:     &errStr,
+			ErrorCode: contracts.WASM_INIT_ERROR,
+			Gas:       vm.GetStatistics().GetTotalCost() + importGm.GetGasUsed(),
+		}
+	}
 
 	argsAlloc := allocString(runtime, vm, nil, args)
 

--- a/modules/wasm/sdk/sdk.go
+++ b/modules/wasm/sdk/sdk.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"regexp"
 	"strconv"
 	"strings"
@@ -51,6 +52,39 @@ var onMainnet bool
 // before any contract execution, passing sysConfig.OnMainnet().
 func Init(mainnet bool) {
 	onMainnet = mainnet
+}
+
+// sdkErrorDeterminismActive reports whether the v0.2.0 deterministic SDK
+// error-surfacing gate is in force for the call carried by ctx. It reads the
+// per-call, height-addressable flag the state engine set on the execution
+// context (>= consensusversion.SdkErrorDeterminismVersion). The lookup uses a
+// comma-ok type assertion so it can NEVER panic — important because it is read
+// from inside a panic-recovery path; if the context lacks a valid exec value
+// (e.g. an early panic, or a read-path with no exec ctx) it returns false,
+// yielding the byte-identical legacy behaviour.
+func sdkErrorDeterminismActive(ctx context.Context) bool {
+	eCtx, ok := ctx.Value(wasm_context.WasmExecCtxKey).(wasm_context.ExecContextValue)
+	if !ok || eCtx == nil {
+		return false
+	}
+	return eCtx.SdkErrorDeterminismActive()
+}
+
+// deterministicPanicDetail renders a recovered panic value into a stable,
+// node-independent string. Go errors and plain strings are reproduced verbatim;
+// any other type collapses to its concrete type name only, dropping the "%v"
+// value rendering that can leak pointer addresses / goroutine ids and fork
+// consensus. Used only on the gated (post-activation) path; the legacy path
+// keeps fmt.Errorf("%v", r).
+func deterministicPanicDetail(r any) string {
+	switch v := r.(type) {
+	case error:
+		return v.Error()
+	case string:
+		return v
+	default:
+		return fmt.Sprintf("%T", v)
+	}
 }
 
 func init() {
@@ -231,11 +265,25 @@ var SdkNamespaces = map[string]map[string]sdkFunc{
 						return func() (ret SdkResult) {
 							defer func() {
 								if r := recover(); r != nil {
+									// MED-92 (F-M34-02): gate the panic-detail
+									// rendering on the v0.2.0 consensus version.
+									// Legacy (gate off) keeps the exact pre-fix
+									// "%v" string so the live consensus path is
+									// byte-identical; the gated path strips
+									// non-deterministic content (pointer
+									// addresses / goroutine ids) that would
+									// otherwise fork the result CID per node.
+									var detail error
+									if sdkErrorDeterminismActive(ctx) {
+										detail = fmt.Errorf("%s", deterministicPanicDetail(r))
+									} else {
+										detail = fmt.Errorf("%v", r)
+									}
 									ret = result.Err[SdkResultStruct](
 										errors.Join(
 											fmt.Errorf(contracts.SDK_ERROR),
 											fmt.Errorf("SYSTEM_CALL_PANIC"),
-											fmt.Errorf("%v", r),
+											detail,
 										),
 									)
 								}
@@ -472,6 +520,47 @@ var SdkNamespaces = map[string]map[string]sdkFunc{
 				func(r string) SdkResultStruct { return SdkResultStruct{Result: r, Gas: session.End()} },
 			)
 		},
+		// read_ex — MED-119 (m39 F-INJ-G2) fix. The original contracts.read
+		// collapses "key missing" and "key present but empty value" to the same
+		// empty string, so a cross-contract reader (e.g. the ZK verifier
+		// blocklist reading another contract's "b-{height}" key) cannot tell a
+		// stale / never-written entry from an intentional empty one. This
+		// sibling preserves contracts.read BYTE-FOR-BYTE (all deployed contracts
+		// and their CIDs are unaffected) and is purely ADDITIVE: it introduces a
+		// NEW import name, so it cannot change the behaviour of any contract that
+		// does not import it — exactly like the tss_v2 versioned namespace and
+		// sp1_verify_groth16_ex above. Because it is additive (never reached by
+		// old contracts) it needs no height gate: a contract gets this behaviour
+		// from the first block it is deployed against, deterministically on every
+		// node.
+		//
+		// It returns a JSON object {"exists":bool,"value":string}. The `exists`
+		// bit comes from ContractStateGetEx, which surfaces the state store's
+		// deterministic nil-vs-non-nil result (nil => key truly absent; an empty
+		// stored value => non-nil empty slice => exists=true). That distinction
+		// is computed from the merkle-backed databin and is therefore identical
+		// across nodes at any given height. Gas is charged identically to
+		// contracts.read (same IOSession + doIO sequence in ContractStateGetEx).
+		"read_ex": func(ctx context.Context, arg1 any, arg2 any) SdkResult {
+			eCtx := ctx.Value(wasm_context.WasmExecCtxKey).(wasm_context.ExecContextValue)
+			contractId, ok := arg1.(string)
+			if !ok {
+				return ErrInvalidArgument
+			}
+			key, ok := arg2.(string)
+			if !ok {
+				return ErrInvalidArgument
+			}
+			session := eCtx.IOSession()
+			valRes, exists := eCtx.ContractStateGetEx(contractId, key)
+			return result.Map(
+				valRes,
+				func(r string) SdkResultStruct {
+					payload, _ := json.Marshal(map[string]any{"exists": exists, "value": r})
+					return SdkResultStruct{Result: string(payload), Gas: session.End()}
+				},
+			)
+		},
 		"call": func(ctx context.Context, arg1 any, arg2 any, arg3 any, arg4 any) SdkResult {
 			eCtx := ctx.Value(wasm_context.WasmExecCtxKey).(wasm_context.ExecContextValue)
 			contractId, ok := arg1.(string)
@@ -660,6 +749,97 @@ var SdkNamespaces = map[string]map[string]sdkFunc{
 			addr := ethCrypto.Keccak256(pubkey[1:])[12:]
 			return result.Ok(SdkResultStruct{Result: hexEncode(addr), Gas: params.CYCLE_GAS_PER_RC})
 		},
+		// ecrecover_strict — CRIT #11 / DS-F1 site 4 REJECT path. Identical
+		// parse to "ecrecover" (arg1=hashHex 32B, arg2=sigHex 65B r||s||v),
+		// but REJECTS non-canonical (high-S) signatures: if S > N/2 it returns
+		// SDK_ERROR instead of recovering. Backs the contract's
+		// crypto.ecrecover_strict import (EcrecoverStrict) used at SYSTEM
+		// signature sites (confirmSpend vault-bind, drop-proof) where a
+		// malleable sig must NEVER be accepted.
+		"ecrecover_strict": func(ctx context.Context, arg1 any, arg2 any) SdkResult {
+			hashHex, ok := arg1.(string)
+			if !ok {
+				return ErrInvalidArgument
+			}
+			sigHex, ok := arg2.(string)
+			if !ok {
+				return ErrInvalidArgument
+			}
+			hash, err := hexDecode(hashHex)
+			if err != nil || len(hash) != 32 {
+				return result.Err[SdkResultStruct](
+					errors.Join(fmt.Errorf(contracts.SDK_ERROR), fmt.Errorf("hash must be 32 bytes hex")),
+				)
+			}
+			sig, err := hexDecode(sigHex)
+			if err != nil || len(sig) != 65 {
+				return result.Err[SdkResultStruct](
+					errors.Join(fmt.Errorf(contracts.SDK_ERROR), fmt.Errorf("sig must be 65 bytes hex (r+s+v)")),
+				)
+			}
+			// S is sig[32:64] (r||s||v layout). Reject the high-S malleability
+			// twin: any S > N/2 is non-canonical.
+			s := new(big.Int).SetBytes(sig[32:64])
+			if s.Cmp(secp256k1HalfOrderN) > 0 {
+				return result.Err[SdkResultStruct](
+					errors.Join(fmt.Errorf(contracts.SDK_ERROR), fmt.Errorf("high-S signature rejected")),
+				)
+			}
+			pubkey, err := ethCrypto.Ecrecover(hash, sig)
+			if err != nil {
+				return result.Err[SdkResultStruct](
+					errors.Join(fmt.Errorf(contracts.SDK_ERROR), fmt.Errorf("ecrecover failed: %w", err)),
+				)
+			}
+			addr := ethCrypto.Keccak256(pubkey[1:])[12:]
+			return result.Ok(SdkResultStruct{Result: hexEncode(addr), Gas: params.CYCLE_GAS_PER_RC})
+		},
+		// ecrecover_canonical — CRIT #11 / DS-F1 site 4 NORMALIZE path.
+		// Identical parse to "ecrecover", but ACCEPTS both low- and high-S by
+		// canonicalizing a high-S sig before recovery: S = N - S and flip the
+		// recovery id (v ^= 1). Backs the contract's crypto.ecrecover_canonical
+		// import (EcrecoverCanonical) used at USER signature sites (ETH deposit
+		// verify) where legacy wallets may legitimately emit high-S.
+		"ecrecover_canonical": func(ctx context.Context, arg1 any, arg2 any) SdkResult {
+			hashHex, ok := arg1.(string)
+			if !ok {
+				return ErrInvalidArgument
+			}
+			sigHex, ok := arg2.(string)
+			if !ok {
+				return ErrInvalidArgument
+			}
+			hash, err := hexDecode(hashHex)
+			if err != nil || len(hash) != 32 {
+				return result.Err[SdkResultStruct](
+					errors.Join(fmt.Errorf(contracts.SDK_ERROR), fmt.Errorf("hash must be 32 bytes hex")),
+				)
+			}
+			sig, err := hexDecode(sigHex)
+			if err != nil || len(sig) != 65 {
+				return result.Err[SdkResultStruct](
+					errors.Join(fmt.Errorf(contracts.SDK_ERROR), fmt.Errorf("sig must be 65 bytes hex (r+s+v)")),
+				)
+			}
+			// Normalize a high-S sig to its canonical low-S twin: S' = N - S,
+			// and flip the recovery id so recovery still yields the same key.
+			s := new(big.Int).SetBytes(sig[32:64])
+			if s.Cmp(secp256k1HalfOrderN) > 0 {
+				normS := new(big.Int).Sub(secp256k1OrderN, s)
+				normBytes := make([]byte, 32)
+				normS.FillBytes(normBytes)
+				copy(sig[32:64], normBytes)
+				sig[64] ^= 1
+			}
+			pubkey, err := ethCrypto.Ecrecover(hash, sig)
+			if err != nil {
+				return result.Err[SdkResultStruct](
+					errors.Join(fmt.Errorf(contracts.SDK_ERROR), fmt.Errorf("ecrecover failed: %w", err)),
+				)
+			}
+			addr := ethCrypto.Keccak256(pubkey[1:])[12:]
+			return result.Ok(SdkResultStruct{Result: hexEncode(addr), Gas: params.CYCLE_GAS_PER_RC})
+		},
 		"rlp_decode": func(ctx context.Context, arg1 any) SdkResult {
 			hexData, ok := arg1.(string)
 			if !ok {
@@ -738,6 +918,92 @@ var SdkNamespaces = map[string]map[string]sdkFunc{
 			}
 			return result.Ok(SdkResultStruct{Result: "true", Gas: params.CYCLE_GAS_PER_RC * 10})
 		},
+		// sp1_verify_groth16_ex — MED-37 (A3/F3) fix. The original
+		// sp1_verify_groth16 collapses every verifier error to "false", so an
+		// honest contract cannot distinguish a malformed-input rejection from a
+		// genuine pairing-check failure (it also masks the CPU-amplification
+		// surface tracked separately as a CRIT). This sibling preserves the
+		// existing function BYTE-FOR-BYTE (so all deployed contracts and their
+		// CIDs are completely unaffected) and is purely ADDITIVE: it introduces
+		// a NEW import name, so it cannot change the behaviour of any contract
+		// that does not import it — exactly like the tss_v2 versioned namespace.
+		// Because it is additive (never reached by old contracts) it needs no
+		// height gate: a contract gets this behaviour from the first block it is
+		// deployed against, deterministically on every node.
+		//
+		// It returns a JSON object {"ok":bool,"error":string}. On success
+		// ok=true, error="". On failure ok=false and error carries the
+		// deterministic verifier detail — Sp1VerifyGroth16's errors all wrap a
+		// fixed sentinel with input-derived (lengths) / fixed-string content
+		// (no pointer addresses / goroutine ids), so the string is identical
+		// across nodes and consensus-safe. The detail is carried in the Result
+		// string (a SUCCESSFUL host call), NOT in WasmResultStruct.Error, because
+		// a non-nil Error makes the runtime treat the host call as a TRAP
+		// (runtime_ipc/wasm.go:419-428) rather than a normal return.
+		"sp1_verify_groth16_ex": func(ctx context.Context, arg1 any, arg2 any, arg3 any, arg4 any, arg5 any) SdkResult {
+			proofHex, ok := arg1.(string)
+			if !ok {
+				return ErrInvalidArgument
+			}
+			publicInputsHex, ok := arg2.(string)
+			if !ok {
+				return ErrInvalidArgument
+			}
+			sp1VkeyHashHex, ok := arg3.(string)
+			if !ok {
+				return ErrInvalidArgument
+			}
+			groth16VkHex, ok := arg4.(string)
+			if !ok {
+				return ErrInvalidArgument
+			}
+			vkRootHex, ok := arg5.(string)
+			if !ok {
+				return ErrInvalidArgument
+			}
+			proof, err := hexDecode(proofHex)
+			if err != nil {
+				return result.Err[SdkResultStruct](
+					errors.Join(fmt.Errorf(contracts.SDK_ERROR), fmt.Errorf("invalid proof hex")),
+				)
+			}
+			publicInputs, err := hexDecode(publicInputsHex)
+			if err != nil {
+				return result.Err[SdkResultStruct](
+					errors.Join(fmt.Errorf(contracts.SDK_ERROR), fmt.Errorf("invalid public inputs hex")),
+				)
+			}
+			vkeyHash, err := hexDecode(sp1VkeyHashHex)
+			if err != nil {
+				return result.Err[SdkResultStruct](
+					errors.Join(fmt.Errorf(contracts.SDK_ERROR), fmt.Errorf("invalid vkey hash hex")),
+				)
+			}
+			groth16Vk, err := hexDecode(groth16VkHex)
+			if err != nil {
+				return result.Err[SdkResultStruct](
+					errors.Join(fmt.Errorf(contracts.SDK_ERROR), fmt.Errorf("invalid groth16 vk hex")),
+				)
+			}
+			vkRoot, err := hexDecode(vkRootHex)
+			if err != nil {
+				return result.Err[SdkResultStruct](
+					errors.Join(fmt.Errorf(contracts.SDK_ERROR), fmt.Errorf("invalid vk root hex")),
+				)
+			}
+			verifyErr := Sp1VerifyGroth16(proof, publicInputs, vkeyHash, groth16Vk, vkRoot)
+			out := map[string]any{"ok": verifyErr == nil, "error": ""}
+			if verifyErr != nil {
+				out["error"] = verifyErr.Error()
+			}
+			payload, mErr := json.Marshal(out)
+			if mErr != nil {
+				return result.Err[SdkResultStruct](
+					errors.Join(fmt.Errorf(contracts.SDK_ERROR), fmt.Errorf("SERIALIZATION_ERROR"), mErr),
+				)
+			}
+			return result.Ok(SdkResultStruct{Result: string(payload), Gas: params.CYCLE_GAS_PER_RC * 10})
+		},
 	},
 }
 
@@ -756,6 +1022,17 @@ func hexEncode(b []byte) string {
 const (
 	keccak256GasPerByte = params.CYCLE_GAS_PER_RC / 256
 	rlpDecodeGasPerByte = params.CYCLE_GAS_PER_RC / 128
+)
+
+// secp256k1OrderN / secp256k1HalfOrderN are the secp256k1 group order and its
+// half, taken from the SAME curve the rest of the node uses
+// (ethCrypto.S256() wraps decred secp256k1.S256(), identical to the
+// modules/gateway/utils.go halfOrderN source) — NOT a hand-defined value.
+// Used by crypto.ecrecover_strict (REJECT high-S) and crypto.ecrecover_canonical
+// (NORMALIZE high-S → low-S) to detect non-canonical (malleable) S components.
+var (
+	secp256k1OrderN     = ethCrypto.S256().Params().N
+	secp256k1HalfOrderN = new(big.Int).Rsh(secp256k1OrderN, 1)
 )
 
 // rlpMaxDecodeDepth bounds recursion to prevent stack exhaustion. Ethereum

--- a/tests/devnet/evm_anvil.go
+++ b/tests/devnet/evm_anvil.go
@@ -1,0 +1,316 @@
+//go:build evm_devnet
+
+// Anvil L1 harness for the EVM-bridge waves (W1/W2/W3). A fresh anvil at the
+// contract's chainId is the L1: deposits (ETH -> vault) and withdrawals
+// (vault -> recipient) land in real anvil blocks whose REAL roots
+// (transactionsRoot/receiptsRoot) are then planted into the mock verifier via
+// devSetHeader, so the contract's tx-trie / receipt-trie proofs verify against
+// genuine Ethereum-encoded tries. No Sepolia fork needed — fresh anvil blocks
+// carry real canonical roots.
+package devnet
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"bytes"
+	"encoding/hex"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	rawdb "github.com/ethereum/go-ethereum/core/rawdb"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	ethCrypto "github.com/ethereum/go-ethereum/crypto"
+	ethclient "github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rlp"
+	ethrpc "github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/ethereum/go-ethereum/triedb"
+)
+
+// proofList collects ordered MPT proof nodes (implements ethdb.KeyValueWriter).
+type proofList [][]byte
+
+func (p *proofList) Put(key, value []byte) error { *p = append(*p, value); return nil }
+func (p *proofList) Delete(key []byte) error      { return nil }
+
+// Anvil is a running anvil process + clients.
+type Anvil struct {
+	cmd     *exec.Cmd
+	URL     string
+	ChainID *big.Int
+	cli     *ethclient.Client
+	rpc     *ethrpc.Client
+}
+
+// StartAnvil launches a fresh anvil bound to chainID on the given port.
+func StartAnvil(t *testing.T, ctx context.Context, chainID uint64, port string) *Anvil {
+	bin := "anvil"
+	if _, err := exec.LookPath("anvil"); err != nil {
+		bin = os.ExpandEnv("$HOME/.foundry/bin/anvil")
+	}
+	cmd := exec.CommandContext(ctx, bin,
+		"--port", port,
+		"--chain-id", fmt.Sprintf("%d", chainID),
+		"--block-time", "1", // auto-mine every 1s so finalized advances
+		"--silent",
+	)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("anvil start: %v", err)
+	}
+	url := "http://127.0.0.1:" + port
+	a := &Anvil{cmd: cmd, URL: url, ChainID: new(big.Int).SetUint64(chainID)}
+	// Wait for RPC up.
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		rc, err := ethrpc.DialContext(ctx, url)
+		if err == nil {
+			a.rpc = rc
+			a.cli = ethclient.NewClient(rc)
+			if _, e := a.cli.ChainID(ctx); e == nil {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("anvil RPC never came up at %s", url)
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	return a
+}
+
+func (a *Anvil) Stop() {
+	if a.cmd != nil && a.cmd.Process != nil {
+		_ = a.cmd.Process.Kill()
+	}
+}
+
+// SetBalance funds an address with wei via anvil_setBalance.
+func (a *Anvil) SetBalance(ctx context.Context, addr ethcommon.Address, wei *big.Int) error {
+	return a.rpc.CallContext(ctx, nil, "anvil_setBalance", addr.Hex(), "0x"+wei.Text(16))
+}
+
+// Mine advances n blocks (anvil_mine).
+func (a *Anvil) Mine(ctx context.Context, n int) error {
+	return a.rpc.CallContext(ctx, nil, "anvil_mine", fmt.Sprintf("0x%x", n))
+}
+
+// SendETH signs+sends an EIP-1559 ETH transfer from key to `to`, returns the tx
+// hash and the block number it mined in.
+func (a *Anvil) SendETH(ctx context.Context, key *ecdsa.PrivateKey, to ethcommon.Address, valueWei *big.Int) (ethcommon.Hash, uint64, error) {
+	from := cryptoPubkeyAddr(key)
+	nonce, err := a.cli.PendingNonceAt(ctx, from)
+	if err != nil {
+		return ethcommon.Hash{}, 0, fmt.Errorf("nonce: %w", err)
+	}
+	tip := big.NewInt(1_000_000_000)  // 1 gwei
+	feeCap := big.NewInt(20_000_000_000) // 20 gwei
+	tx := ethtypes.NewTx(&ethtypes.DynamicFeeTx{
+		ChainID:   a.ChainID,
+		Nonce:     nonce,
+		GasTipCap: tip,
+		GasFeeCap: feeCap,
+		Gas:       21000,
+		To:        &to,
+		Value:     valueWei,
+	})
+	signed, err := ethtypes.SignTx(tx, ethtypes.LatestSignerForChainID(a.ChainID), key)
+	if err != nil {
+		return ethcommon.Hash{}, 0, fmt.Errorf("sign: %w", err)
+	}
+	if err := a.cli.SendTransaction(ctx, signed); err != nil {
+		return ethcommon.Hash{}, 0, fmt.Errorf("send: %w", err)
+	}
+	rcpt, err := a.waitReceipt(ctx, signed.Hash(), 30*time.Second)
+	if err != nil {
+		return ethcommon.Hash{}, 0, err
+	}
+	return signed.Hash(), rcpt.BlockNumber.Uint64(), nil
+}
+
+// SendRawTx broadcasts a raw signed tx (e.g. the bot's vault withdrawal),
+// returns the tx hash + mined block.
+func (a *Anvil) SendRawTx(ctx context.Context, raw []byte) (ethcommon.Hash, uint64, error) {
+	tx := new(ethtypes.Transaction)
+	if err := tx.UnmarshalBinary(raw); err != nil {
+		return ethcommon.Hash{}, 0, fmt.Errorf("decode raw tx: %w", err)
+	}
+	if err := a.cli.SendTransaction(ctx, tx); err != nil {
+		return ethcommon.Hash{}, 0, fmt.Errorf("send raw: %w", err)
+	}
+	rcpt, err := a.waitReceipt(ctx, tx.Hash(), 30*time.Second)
+	if err != nil {
+		return ethcommon.Hash{}, 0, err
+	}
+	return tx.Hash(), rcpt.BlockNumber.Uint64(), nil
+}
+
+func (a *Anvil) waitReceipt(ctx context.Context, h ethcommon.Hash, timeout time.Duration) (*ethtypes.Receipt, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		r, err := a.cli.TransactionReceipt(ctx, h)
+		if err == nil && r != nil {
+			return r, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("receipt for %s not found within %s", h.Hex(), timeout)
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+}
+
+// AnvilHeader holds the fields the mock verifier plants (137-byte review6 layout).
+type AnvilHeader struct {
+	Number       uint64
+	StateRoot    string // 0x-less 64-hex
+	TxRoot       string
+	ReceiptsRoot string
+	BaseFee      uint64
+	GasLimit     uint64
+	Timestamp    uint64
+}
+
+// Header reads block `num`'s real header fields for planting.
+func (a *Anvil) Header(ctx context.Context, num uint64) (*AnvilHeader, error) {
+	blk, err := a.cli.BlockByNumber(ctx, new(big.Int).SetUint64(num))
+	if err != nil {
+		return nil, fmt.Errorf("block %d: %w", num, err)
+	}
+	h := blk.Header()
+	bf := uint64(0)
+	if h.BaseFee != nil {
+		bf = h.BaseFee.Uint64()
+	}
+	return &AnvilHeader{
+		Number:       h.Number.Uint64(),
+		StateRoot:    h.Root.Hex()[2:],
+		TxRoot:       h.TxHash.Hex()[2:],
+		ReceiptsRoot: h.ReceiptHash.Hex()[2:],
+		BaseFee:      bf,
+		GasLimit:     h.GasLimit,
+		Timestamp:    h.Time,
+	}, nil
+}
+
+// Finalized returns the current finalized block number (the bot scans only up to it).
+func (a *Anvil) Finalized(ctx context.Context) (uint64, error) {
+	var head struct {
+		Number string `json:"number"`
+	}
+	if err := a.rpc.CallContext(ctx, &head, "eth_getBlockByNumber", "finalized", false); err != nil {
+		return 0, err
+	}
+	n := new(big.Int)
+	n.SetString(head.Number[2:], 16)
+	return n.Uint64(), nil
+}
+
+func cryptoPubkeyAddr(key *ecdsa.PrivateKey) ethcommon.Address {
+	return ethCrypto.PubkeyToAddress(key.PublicKey)
+}
+
+// TxTrieProof builds the tx-trie proof for txIndex in block `num`: returns the
+// raw typed-tx hex + the concatenated-RLP proof-node hex that the contract's
+// splitProofNodes/mpt.VerifyProof expects. It reconstructs the canonical tx
+// trie and asserts its root == the block's real transactionsRoot BEFORE
+// returning, so a format error is caught locally (not on devnet).
+func (a *Anvil) TxTrieProof(ctx context.Context, num, txIndex uint64) (rawHex, proofHex string, err error) {
+	blk, err := a.cli.BlockByNumber(ctx, new(big.Int).SetUint64(num))
+	if err != nil {
+		return "", "", fmt.Errorf("block %d: %w", num, err)
+	}
+	tr := trie.NewEmpty(triedb.NewDatabase(rawdb.NewMemoryDatabase(), nil))
+	txs := blk.Transactions()
+	if txIndex >= uint64(len(txs)) {
+		return "", "", fmt.Errorf("txIndex %d out of range (%d txs)", txIndex, len(txs))
+	}
+	for i, tx := range txs {
+		key, _ := rlp.EncodeToBytes(uint(i))
+		val, mErr := tx.MarshalBinary()
+		if mErr != nil {
+			return "", "", fmt.Errorf("marshal tx %d: %w", i, mErr)
+		}
+		tr.MustUpdate(key, val)
+	}
+	if tr.Hash() != blk.TxHash() {
+		return "", "", fmt.Errorf("reconstructed tx-trie root %s != block txRoot %s", tr.Hash().Hex(), blk.TxHash().Hex())
+	}
+	var proof proofList
+	tkey, _ := rlp.EncodeToBytes(uint(txIndex))
+	if err := tr.Prove(tkey, &proof); err != nil {
+		return "", "", fmt.Errorf("prove: %w", err)
+	}
+	var buf []byte
+	for _, n := range proof {
+		buf = append(buf, n...)
+	}
+	raw, _ := txs[txIndex].MarshalBinary()
+	return hex.EncodeToString(raw), hex.EncodeToString(buf), nil
+}
+
+// ReceiptTrieProof builds the receipt-trie proof for txIndex in block `num`:
+// returns the consensus-encoded receipt hex + concatenated-RLP proof-node hex.
+// Reconstructs the canonical receipt trie (the same EncodeIndex bytes DeriveSha
+// uses) and asserts root == the block's real receiptsRoot before returning.
+// For a plain ETH transfer the receipt has empty logs + all-zero bloom — the
+// CC-1 case (non-stripping receipt encoding must still match the root).
+func (a *Anvil) ReceiptTrieProof(ctx context.Context, num, txIndex uint64) (receiptHex, proofHex string, err error) {
+	blk, err := a.cli.BlockByNumber(ctx, new(big.Int).SetUint64(num))
+	if err != nil {
+		return "", "", fmt.Errorf("block %d: %w", num, err)
+	}
+	txs := blk.Transactions()
+	if txIndex >= uint64(len(txs)) {
+		return "", "", fmt.Errorf("txIndex %d out of range (%d txs)", txIndex, len(txs))
+	}
+	receipts := make(ethtypes.Receipts, len(txs))
+	for i, tx := range txs {
+		r, rErr := a.cli.TransactionReceipt(ctx, tx.Hash())
+		if rErr != nil {
+			return "", "", fmt.Errorf("receipt %d: %w", i, rErr)
+		}
+		receipts[i] = r
+	}
+	encode := func(i int) []byte {
+		var buf bytes.Buffer
+		receipts.EncodeIndex(i, &buf)
+		return buf.Bytes()
+	}
+	tr := trie.NewEmpty(triedb.NewDatabase(rawdb.NewMemoryDatabase(), nil))
+	for i := range receipts {
+		key, _ := rlp.EncodeToBytes(uint(i))
+		tr.MustUpdate(key, encode(i))
+	}
+	if tr.Hash() != blk.ReceiptHash() {
+		return "", "", fmt.Errorf("reconstructed receipt-trie root %s != block receiptsRoot %s", tr.Hash().Hex(), blk.ReceiptHash().Hex())
+	}
+	var proof proofList
+	tkey, _ := rlp.EncodeToBytes(uint(txIndex))
+	if err := tr.Prove(tkey, &proof); err != nil {
+		return "", "", fmt.Errorf("prove: %w", err)
+	}
+	var buf []byte
+	for _, n := range proof {
+		buf = append(buf, n...)
+	}
+	return hex.EncodeToString(encode(int(txIndex))), hex.EncodeToString(buf), nil
+}
+
+// FindTxIndex returns the index of txHash within its block.
+func (a *Anvil) FindTxIndex(ctx context.Context, num uint64, txHash ethcommon.Hash) (uint64, error) {
+	blk, err := a.cli.BlockByNumber(ctx, new(big.Int).SetUint64(num))
+	if err != nil {
+		return 0, err
+	}
+	for i, tx := range blk.Transactions() {
+		if tx.Hash() == txHash {
+			return uint64(i), nil
+		}
+	}
+	return 0, fmt.Errorf("tx %s not in block %d", txHash.Hex(), num)
+}

--- a/tests/devnet/evm_bot.go
+++ b/tests/devnet/evm_bot.go
@@ -1,0 +1,116 @@
+//go:build evm_devnet
+
+// evm-mapping-bot runner for the L1-bridge waves. Launches the real bot binary
+// (bot-pr154) against (anvil L1, devnet GQL, the deployed contract) so its
+// REAL deposit-relay (buildMapPayload/MPT) and withdrawal-close-out
+// (buildConfirmSpendPayload/encodeReceiptRLP = the H-F1/H-F2/CC-1 code) run
+// end-to-end. The binary is built once to /tmp/evm-mapping-bot.
+package devnet
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const evmBotBin = "/tmp/evm-mapping-bot"
+
+// BotConfig is the env for one bot process.
+type BotConfig struct {
+	EthRPC      string // anvil URL
+	VaultAddr   string // 0x..20-byte
+	ContractID  string
+	GraphQLURL  string // a devnet node GQL endpoint
+	EthPrivHex  string // 64-hex L2 relayer key (its DID must be RC-funded)
+	Checkpoint  string // checkpoint file path
+}
+
+// Bot is a running bot process with captured logs.
+type Bot struct {
+	cmd  *exec.Cmd
+	mu   sync.Mutex
+	logs []string
+}
+
+// StartBot launches the bot; it streams logs into the Bot for assertions.
+func StartBot(t *testing.T, ctx context.Context, cfg BotConfig) *Bot {
+	if _, err := os.Stat(evmBotBin); err != nil {
+		t.Fatalf("bot binary missing at %s (build: go build -o %s ./cmd/evm-mapping-bot): %v", evmBotBin, evmBotBin, err)
+	}
+	if cfg.Checkpoint == "" {
+		cfg.Checkpoint = fmt.Sprintf("/tmp/evm-bot-cp-%d.json", time.Now().UnixNano())
+	}
+	cmd := exec.CommandContext(ctx, evmBotBin)
+	cmd.Env = append(os.Environ(),
+		"ETH_RPC="+cfg.EthRPC,
+		"VAULT_ADDRESS="+cfg.VaultAddr,
+		"CONTRACT_ID="+cfg.ContractID,
+		"GRAPHQL_URLS="+cfg.GraphQLURL,
+		"BOT_ETH_PRIVKEY="+cfg.EthPrivHex,
+		"NET_ID=vsc-devnet",
+		"NETWORK=testnet",
+		"RC_LIMIT=5000000",
+		"CHECKPOINT_FILE="+cfg.Checkpoint,
+	)
+	stdout, _ := cmd.StdoutPipe()
+	stderr, _ := cmd.StderrPipe()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("bot start: %v", err)
+	}
+	b := &Bot{cmd: cmd}
+	scan := func(r *bufio.Scanner) {
+		for r.Scan() {
+			line := r.Text()
+			b.mu.Lock()
+			b.logs = append(b.logs, line)
+			b.mu.Unlock()
+		}
+	}
+	go scan(bufio.NewScanner(stdout))
+	go scan(bufio.NewScanner(stderr))
+	return b
+}
+
+func (b *Bot) Stop() {
+	if b.cmd != nil && b.cmd.Process != nil {
+		_ = b.cmd.Process.Kill()
+	}
+}
+
+// Logs returns a snapshot of captured log lines.
+func (b *Bot) Logs() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]string, len(b.logs))
+	copy(out, b.logs)
+	return out
+}
+
+// WaitForLog polls until a log line contains `substr` or timeout.
+func (b *Bot) WaitForLog(ctx context.Context, substr string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		b.mu.Lock()
+		for _, l := range b.logs {
+			if strings.Contains(l, substr) {
+				b.mu.Unlock()
+				return true
+			}
+		}
+		b.mu.Unlock()
+		if time.Now().After(deadline) {
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(time.Second):
+		}
+	}
+}

--- a/tests/devnet/evm_bridge_both_devnet_test.go
+++ b/tests/devnet/evm_bridge_both_devnet_test.go
@@ -1,0 +1,100 @@
+//go:build evm_devnet
+
+// BOT-H FINDING PROOF — proves the contract<->bot scan-height mismatch at
+// runtime (test-only; no bot/contract source change). The evm-mapping-bot caps
+// its L1 deposit scan at contractHeight = state key "h" read FROM THE
+// ACCOUNT-MAPPING CONTRACT (cmd/evm-mapping-bot/main.go:2646), but contract
+// refactor M23-F5 (#31) moved "h" to the ZK verifier contract — the
+// account-mapping contract no longer stores "h" in its own state
+// (blocklist/blocks.go GetLastHeight reads it via the verifier). The bot has no
+// verifier id, so contractHeight is ALWAYS 0 -> scanUpTo = min(finalized,0) = 0
+// -> the bot maps ZERO deposits on mainnet. Local builds pass (both compile);
+// only running them together reveals it.
+//
+// This test plants a header (which sets "h" in the mock VERIFIER) and asserts:
+//   1. account-mapping["h"]  is EMPTY  (the bot's read target — nothing there)
+//   2. verifier["h"]         == planted height (where "h" actually lives)
+//   3. account-mapping["zkverifier"] == verifier id (the fix path is viable:
+//      the bot can read the verifier id from am state, then read "h" from it)
+//
+// Run: go test -tags evm_devnet -run TestEVMBridge_BotHFinding ./tests/devnet/ -timeout 40m -v
+package devnet
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestEVMBridge_BotHFinding_ContractMismatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("devnet")
+	}
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Minute)
+	t.Cleanup(cancel)
+
+	e := setupEvmBridgeDevnet(t, ctx)
+
+	// Plant a header at a known height — this calls the mock VERIFIER's
+	// devSetHeader, which sets KeyLastHeight "h" in the VERIFIER's state.
+	const plantedHeight = 1234567
+	hdr := &AnvilHeader{
+		Number:       plantedHeight,
+		StateRoot:    "11111111111111111111111111111111111111111111111111111111111111aa",
+		TxRoot:       "22222222222222222222222222222222222222222222222222222222222222bb",
+		ReceiptsRoot: "33333333333333333333333333333333333333333333333333333333333333cc",
+		BaseFee:      1000000000,
+		GasLimit:     30000000,
+		Timestamp:    1700000000,
+	}
+	if err := e.plantHeader(hdr, 1); err != nil {
+		t.Fatalf("plantHeader: %v", err)
+	}
+	t.Logf("planted header height=%d into the mock verifier (%s)", plantedHeight, e.mockID)
+
+	// (1) The account-mapping contract's OWN state has NO "h" — this is exactly
+	// what fetchContractLastHeight(cfg.ContractID) reads, so the bot gets 0.
+	amState, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{"h"})
+	amH := ""
+	if amState != nil && amState["h"] != nil {
+		amH = fmt.Sprintf("%v", amState["h"])
+	}
+	if amH != "" && amH != "0" && amH != "<nil>" {
+		t.Fatalf("UNEXPECTED: account-mapping contract DOES have 'h'=%q — the finding may be stale (M23-F5 reverted?). Re-verify.", amH)
+	}
+	t.Logf("PROVEN (1): account-mapping['h'] = %q (EMPTY) — the bot reads THIS and gets contractHeight=0", amH)
+
+	// (2) The verifier's "h" carries the real height.
+	var verifierH string
+	if err := pollUntil(ctx, 60*time.Second, func() bool {
+		m, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.mockID, []string{"h"})
+		if m == nil || m["h"] == nil {
+			return false
+		}
+		verifierH = fmt.Sprintf("%v", m["h"])
+		return verifierH == fmt.Sprintf("%d", plantedHeight)
+	}); err != nil {
+		t.Fatalf("verifier['h'] never reached planted height %d (got %q)", plantedHeight, verifierH)
+	}
+	t.Logf("PROVEN (2): verifier['h'] = %q — 'h' lives in the VERIFIER, not account-mapping", verifierH)
+
+	// (3) The account-mapping contract DOES expose the verifier id under
+	// "zkverifier" (VerifierContractIdKey) — so the fix is viable WITHOUT new
+	// bot config: the bot can read am['zkverifier'], then read 'h' from it.
+	zkState, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{"zkverifier"})
+	zkv := ""
+	if zkState != nil && zkState["zkverifier"] != nil {
+		zkv = fmt.Sprintf("%v", zkState["zkverifier"])
+	}
+	if zkv != e.mockID {
+		t.Fatalf("account-mapping['zkverifier'] = %q, expected verifier id %q — fix path needs re-check", zkv, e.mockID)
+	}
+	t.Logf("PROVEN (3): account-mapping['zkverifier'] = %q (== verifier id) — fix: bot reads this, then 'h' from the verifier", zkv)
+
+	t.Logf("BOT-H FINDING PROVEN: account-mapping['h'] EMPTY while verifier['h']=%d. "+
+		"The bot's fetchContractLastHeight(cfg.ContractID) reads account-mapping['h']=0 -> scanUpTo=min(finalized,0)=0 -> "+
+		"maps ZERO deposits. Fix (no new config): bot reads account-mapping['zkverifier']=%s, then reads 'h' from that verifier.",
+		plantedHeight, e.mockID)
+}

--- a/tests/devnet/evm_bridge_botres_devnet_test.go
+++ b/tests/devnet/evm_bridge_botres_devnet_test.go
@@ -1,0 +1,311 @@
+//go:build evm_devnet
+
+// BotResilience — proves the evm-mapping-bot's checkpoint / lock / fail-closed
+// resilience fixes at RUNTIME against a real devnet + anvil L1. No deposits are
+// required: the bot only needs to START, scan anvil (vault set, no transfers),
+// and persist its checkpoint. We then exercise:
+//
+//   - MED-43  fail-closed on a corrupt checkpoint  (loadCheckpoint → os.Exit(1))
+//   - MED-91  exclusive flock so a 2nd instance fails fast (acquireCheckpointLock)
+//   - MED-120 0600 perms on the checkpoint file      (cp.save WriteFile 0600)
+//   - C-ER1   per-worker scanBlockSafe recover        (structurally covered)
+//   - restart-resume: a fresh start loads the persisted last_scanned_block.
+//
+// The bot binary is /tmp/evm-mapping-bot (built once by the lead). It is driven
+// here as a raw process via the StartBot runner (evm_bot.go), keying assertions
+// on the bot's REAL slog messages (read from cmd/evm-mapping-bot/main.go).
+//
+// Run: go test -tags evm_devnet -run TestEVMBridge_BotResilience ./tests/devnet/ -timeout 40m -v
+package devnet
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	ethCrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestEVMBridge_BotResilience(t *testing.T) {
+	if testing.Short() {
+		t.Skip("devnet")
+	}
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Minute)
+	t.Cleanup(cancel)
+
+	e := setupEvmBridgeDevnet(t, ctx)
+
+	anvil := StartAnvil(t, ctx, 1, nextAnvilPort()) // contract chainId() defaults to 1
+	t.Cleanup(anvil.Stop)
+
+	// Mine an anvil chain to scan + wait for it to finalize so the bot's
+	// getFinalizedBlock() returns a height > 0 and the scan loop runs.
+	if err := anvil.Mine(ctx, 12); err != nil {
+		t.Fatalf("mine anvil: %v", err)
+	}
+	if err := pollUntil(ctx, 60*time.Second, func() bool {
+		f, e2 := anvil.Finalized(ctx)
+		return e2 == nil && f >= 1
+	}); err != nil {
+		t.Fatalf("anvil never produced a finalized block to scan")
+	}
+
+	// Vault: the bot requires a valid 20-byte non-zero VAULT_ADDRESS (MED-44),
+	// but no deposits are sent to it (scan-only). setVault is a short-timelock
+	// admin action; the address itself just needs to be a real eth address.
+	vaultKey, _ := ethCrypto.GenerateKey()
+	vaultAddr := ethCrypto.PubkeyToAddress(vaultKey.PublicKey)
+	if err := e.setVault(vaultAddr.Hex()); err != nil {
+		t.Fatalf("setVault: %v", err)
+	}
+
+	// BOT-H FIX PROOF: the bot caps its L1 scan at the contract's ingested header
+	// height (contractHeight). Post-M23-F5 that height lives in the ZK verifier,
+	// and the fixed fetchContractLastHeight reads am['zkverifier'] then the
+	// verifier's 'h'. Plant the real finalized anvil header so the verifier 'h' is
+	// non-zero — otherwise the (fixed) bot reads contractHeight=0 and never scans
+	// (scanUpTo = min(finalized, 0) = 0). Plant BEFORE the bot starts so its first
+	// tick already sees a non-zero ceiling and advances LastScannedBlock.
+	finH, err := anvil.Finalized(ctx)
+	if err != nil || finH < 1 {
+		t.Fatalf("anvil finalized height unavailable for scan ceiling: %v", err)
+	}
+	scanHdr, err := anvil.Header(ctx, finH)
+	if err != nil {
+		t.Fatalf("read anvil header %d: %v", finH, err)
+	}
+	if err := e.plantHeader(scanHdr, 1); err != nil {
+		t.Fatalf("plant scan-ceiling header %d: %v", finH, err)
+	}
+	t.Logf("planted verifier scan-ceiling header height=%d so the fixed bot can scan", finH)
+
+	// Relayer eth key for BOT_ETH_PRIVKEY (the bot loads it for L2 signing; with
+	// no deposits it never submits, so the DID needs no RC funding).
+	relayerKey, _ := ethCrypto.GenerateKey()
+	relayerHex := hex.EncodeToString(ethCrypto.FromECDSA(relayerKey))
+
+	gqlURL := e.d.GQLEndpoint(e.gqlNode)
+	t.Logf("vault=%s gql=%s contract=%s", vaultAddr.Hex(), gqlURL, e.amID)
+
+	// Single checkpoint path reused across restarts (under t.TempDir so it is
+	// cleaned up automatically). The bot writes a sidecar `.lock` and `.tmp`.
+	cpDir := t.TempDir()
+	cpPath := filepath.Join(cpDir, "evm-bot-checkpoint.json")
+	lockPath := cpPath + ".lock"
+
+	mkCfg := func() BotConfig {
+		return BotConfig{
+			EthRPC:     anvil.URL,
+			VaultAddr:  vaultAddr.Hex(),
+			ContractID: e.amID,
+			GraphQLURL: gqlURL,
+			EthPrivHex: relayerHex,
+			Checkpoint: cpPath,
+		}
+	}
+
+	// Bot slog substrings we key on (verbatim from cmd/evm-mapping-bot/main.go):
+	const (
+		logLoadedCheckpoint = "loaded checkpoint"                          // main.go:2043 (every start; carries lastBlock)
+		logStarting         = "evm-mapping-bot starting"                   // main.go:72   (proves the process came up)
+		logCorrupt          = "checkpoint file is corrupt"                 // main.go:241  (MED-43, then os.Exit(1))
+		logLockHeld         = "another bot instance already holds"         // main.go:298  (MED-91, in the returned err)
+	)
+
+	// ── (1) Checkpoint persistence + restart resume ───────────────────────────
+	botA := StartBot(t, ctx, mkCfg())
+	if !botA.WaitForLog(ctx, logStarting, 90*time.Second) {
+		t.Fatalf("bot A never logged %q; logs:\n%s", logStarting, joinLogs(botA))
+	}
+	if !botA.WaitForLog(ctx, logLoadedCheckpoint, 90*time.Second) {
+		t.Fatalf("bot A never logged %q; logs:\n%s", logLoadedCheckpoint, joinLogs(botA))
+	}
+
+	// Wait for the checkpoint FILE to exist with last_scanned_block > 0: the
+	// scan loop advances LastScannedBlock through empty anvil blocks, then
+	// cp.save() writes it (atomic tmp+rename, 0600).
+	if err := pollUntil(ctx, 3*time.Minute, func() bool {
+		cp, err := readCheckpoint(cpPath)
+		return err == nil && cp.LastScannedBlock > 0
+	}); err != nil {
+		t.Fatalf("checkpoint file never persisted last_scanned_block>0 at %s; bot logs:\n%s", cpPath, joinLogs(botA))
+	}
+	cpAfterA, err := readCheckpoint(cpPath)
+	if err != nil {
+		t.Fatalf("read checkpoint after bot A: %v", err)
+	}
+	savedBlock := cpAfterA.LastScannedBlock
+	if savedBlock == 0 {
+		t.Fatalf("expected persisted last_scanned_block>0, got 0")
+	}
+	if cpAfterA.Version != 1 {
+		t.Fatalf("expected checkpoint version 1, got %d", cpAfterA.Version)
+	}
+	t.Logf("ASSERT persist: checkpoint at %s has last_scanned_block=%d version=%d", cpPath, savedBlock, cpAfterA.Version)
+
+	botA.Stop()
+	// The flock is released on process death, but the sidecar .lock FILE remains
+	// on disk; remove it so the restart can re-acquire cleanly (matches the
+	// recon recipe: delete .lock between restarts).
+	_ = os.Remove(lockPath)
+	time.Sleep(2 * time.Second) // let the killed process fully release the fd
+
+	// Restart with the SAME checkpoint → it must LOAD the saved block, not
+	// rescan from 0. "loaded checkpoint" carries lastBlock=<savedBlock>.
+	botA2 := StartBot(t, ctx, mkCfg())
+	if !botA2.WaitForLog(ctx, logLoadedCheckpoint, 90*time.Second) {
+		t.Fatalf("bot A2 never logged %q on restart; logs:\n%s", logLoadedCheckpoint, joinLogs(botA2))
+	}
+	// ASSERT it resumed from the persisted block, not 0. The slog line is
+	// `loaded checkpoint lastBlock=<n>` — assert the resumed value matches.
+	wantResume := fmt.Sprintf("lastBlock=%d", savedBlock)
+	resumed := botA2.WaitForLog(ctx, wantResume, 30*time.Second)
+	if !resumed {
+		// Tolerate the (rare) case where the bot advanced past savedBlock before
+		// dumping logs; re-read the live checkpoint and require it did not regress.
+		cpNow, rerr := readCheckpoint(cpPath)
+		if rerr != nil || cpNow.LastScannedBlock < savedBlock {
+			t.Fatalf("bot A2 did NOT resume from saved block %d (no %q log; checkpoint now=%v err=%v); logs:\n%s",
+				savedBlock, wantResume, cpNow.LastScannedBlock, rerr, joinLogs(botA2))
+		}
+		t.Logf("ASSERT resume: no exact log match but checkpoint did not regress (now=%d >= saved=%d)", cpNow.LastScannedBlock, savedBlock)
+	} else {
+		t.Logf("ASSERT resume: bot A2 loaded checkpoint at saved block %d (did not rescan from 0)", savedBlock)
+	}
+	botA2.Stop()
+	_ = os.Remove(lockPath)
+	time.Sleep(2 * time.Second)
+
+	// ── (3) Corrupt-checkpoint fail-closed (MED-43) ───────────────────────────
+	// Overwrite the checkpoint with partial/invalid JSON. loadCheckpoint must
+	// NOT discard the unmarshal error and re-scan from empty — it logs
+	// "checkpoint file is corrupt …" and os.Exit(1)s. The bot process dies
+	// without ever entering the scan loop.
+	if err := os.WriteFile(cpPath, []byte(`{"last_scanned_block": 12, "sent_wi`), 0600); err != nil {
+		t.Fatalf("write corrupt checkpoint: %v", err)
+	}
+	botCorrupt := StartBot(t, ctx, mkCfg())
+	if !botCorrupt.WaitForLog(ctx, logCorrupt, 60*time.Second) {
+		t.Fatalf("bot did NOT fail-closed on corrupt checkpoint (no %q log) — MED-43 regression; logs:\n%s",
+			logCorrupt, joinLogs(botCorrupt))
+	}
+	// It must NOT have proceeded to load a phantom-empty checkpoint and scan.
+	if botCorrupt.WaitForLog(ctx, logLoadedCheckpoint, 3*time.Second) {
+		t.Fatalf("MED-43 regression: bot logged %q AFTER a corrupt file — it silently re-scanned instead of failing closed; logs:\n%s",
+			logLoadedCheckpoint, joinLogs(botCorrupt))
+	}
+	botCorrupt.Stop()
+	t.Logf("ASSERT corrupt: bot logged %q and did not re-scan (MED-43 fail-closed)", logCorrupt)
+
+	// Restore a clean checkpoint for the lock test, and clear the lock.
+	if err := writeCleanCheckpoint(cpPath, savedBlock); err != nil {
+		t.Fatalf("restore clean checkpoint: %v", err)
+	}
+	_ = os.Remove(lockPath)
+
+	// ── (4) Dual-instance lock (MED-91) ───────────────────────────────────────
+	// Start bot B holding the checkpoint; while it runs, start bot C on the SAME
+	// checkpoint path. C must fail to acquire the flock and exit; B keeps running.
+	botB := StartBot(t, ctx, mkCfg())
+	if !botB.WaitForLog(ctx, logStarting, 90*time.Second) {
+		t.Fatalf("bot B never started; logs:\n%s", joinLogs(botB))
+	}
+	if !botB.WaitForLog(ctx, logLoadedCheckpoint, 90*time.Second) {
+		t.Fatalf("bot B never loaded checkpoint (needed to hold the lock); logs:\n%s", joinLogs(botB))
+	}
+	// B now holds the flock. Launch C on the same path.
+	botC := StartBot(t, ctx, mkCfg())
+	if !botC.WaitForLog(ctx, logLockHeld, 60*time.Second) {
+		t.Fatalf("MED-91 regression: second instance did NOT report %q (lock not exclusive); botC logs:\n%s",
+			logLockHeld, joinLogs(botC))
+	}
+	botC.Stop()
+	// B must still be alive (it never reported a lock error / corruption).
+	for _, l := range botB.Logs() {
+		if strings.Contains(l, logLockHeld) || strings.Contains(l, logCorrupt) {
+			t.Fatalf("MED-91: bot B (the lock holder) unexpectedly reported a fatal: %q", l)
+		}
+	}
+	t.Logf("ASSERT dual-instance: second bot reported %q and exited; holder kept running (MED-91)", logLockHeld)
+	botB.Stop()
+	_ = os.Remove(lockPath)
+
+	// ── (5) 0600 perms on the checkpoint file (MED-120) ───────────────────────
+	// Re-read the file the holder wrote and assert its mode is exactly 0600
+	// (cp.save → os.WriteFile(tmp, …, 0600) then atomic rename).
+	if err := pollUntil(ctx, 60*time.Second, func() bool {
+		fi, err := os.Stat(cpPath)
+		return err == nil && fi.Mode().Perm() == 0o600
+	}); err != nil {
+		fi, serr := os.Stat(cpPath)
+		gotMode := "stat-err"
+		if serr == nil {
+			gotMode = fi.Mode().Perm().String()
+		}
+		t.Fatalf("MED-120 regression: checkpoint perms != 0600 (got %s); err=%v", gotMode, err)
+	}
+	fi, _ := os.Stat(cpPath)
+	t.Logf("ASSERT perms: checkpoint %s mode=%v == 0600 (MED-120)", cpPath, fi.Mode().Perm())
+
+	// ── (C-ER1) per-worker scanBlockSafe recover — structural coverage note ────
+	// Injecting a malformed block into anvil (to trip a scanBlock panic inside a
+	// scanBlocksParallel worker) is infeasible from this harness: anvil only
+	// serves well-formed canonical blocks, and the bot's hostile-RPC parse paths
+	// can't be reached without a fake RPC. scanBlockSafe (main.go:1041-1049)
+	// wraps each per-height scan in its own defer/recover that converts a panic
+	// into a per-block error entry (out[h]={err:…}); the caller stops at the
+	// first error and re-scans the window, so the checkpoint never advances past
+	// a bad block. This is exercised by unit tests on the bot; here we record it
+	// as structurally covered rather than failing the runtime test for it.
+	t.Logf("C-ER1: scanBlockSafe per-worker recover not runtime-injectable from anvil — structurally covered (main.go:1041-1049), not asserted here")
+
+	t.Logf("BotResilience PASS — checkpoint persist/resume (saved block %d resumed), corrupt fail-closed (MED-43), dual-instance lock (MED-91), 0600 perms (MED-120); C-ER1 structurally covered",
+		savedBlock)
+}
+
+// botCheckpoint mirrors the on-disk fields of the bot's Checkpoint we assert on
+// (cmd/evm-mapping-bot/main.go Checkpoint). We only decode what we check.
+type botCheckpoint struct {
+	LastScannedBlock uint64 `json:"last_scanned_block"`
+	Version          int    `json:"version"`
+}
+
+func readCheckpoint(path string) (*botCheckpoint, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cp botCheckpoint
+	if err := json.Unmarshal(data, &cp); err != nil {
+		return nil, err
+	}
+	return &cp, nil
+}
+
+// writeCleanCheckpoint writes a valid, version-1 checkpoint at the given block so
+// the lock test can start from a non-corrupt state. Mirrors the bot's on-disk
+// schema (sent_withdrawals + block_retries maps + version=checkpointVersion=1).
+func writeCleanCheckpoint(path string, lastBlock uint64) error {
+	payload := map[string]any{
+		"last_scanned_block": lastBlock,
+		"sent_withdrawals":   map[string]any{},
+		"block_retries":      map[string]any{},
+		"version":            1,
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+func joinLogs(b *Bot) string {
+	return strings.Join(b.Logs(), "\n")
+}

--- a/tests/devnet/evm_bridge_setup.go
+++ b/tests/devnet/evm_bridge_setup.go
@@ -1,0 +1,333 @@
+//go:build evm_devnet
+
+// Shared L1-bridge devnet setup for W1/W2/W3 — the validated W-MOCK foundation
+// (deploy short-timelock account-mapping + mock verifier, wire setVerifierContract
+// through the short timelock, RC-bootstrap the owner) extracted into a reusable
+// env, plus helpers to plant anvil headers and run owner admin ops.
+package devnet
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethCrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+// --- shared devnet: ONE 5-node devnet for the whole evm_devnet run, shared by
+// all (parallel) waves. Bring-up (~12 min) happens once; each wave deploys its
+// own state-isolated contracts on top. The runner docker-cleans after the
+// process exits (no per-test Stop). ---
+var (
+	sharedDevnetOnce sync.Once
+	sharedDevnet     *Devnet
+	sharedDevnetErr  error
+	sharedDeployMu   sync.Mutex   // DeployContract stops a node (badger lock) — serialize
+	anvilPortSeq     int32 = 38544 // each wave gets a unique anvil port via nextAnvilPort
+	gqlNodeSeq       int32        // round-robins GQL reads across nodes 2-5 (spread parallel load)
+)
+
+func ensureSharedDevnet() (*Devnet, error) {
+	sharedDevnetOnce.Do(func() {
+		ctx := context.Background() // long-lived: outlives individual test timeouts
+		cfg := evmBridgeConfig()
+		d, err := New(cfg)
+		if err != nil {
+			sharedDevnetErr = err
+			return
+		}
+		if err := d.Start(ctx); err != nil {
+			sharedDevnetErr = err
+			return
+		}
+		// Generous RC bootstrap — ALL parallel waves' owner ops (deploys, admin)
+		// draw on magi.test1, so give it a big HBD/RC pool.
+		if _, err := d.Deposit(ctx, 1, "80000.000", "hbd"); err != nil {
+			sharedDevnetErr = fmt.Errorf("RC bootstrap deposit: %w", err)
+			return
+		}
+		if err := pollUntil(ctx, 8*time.Minute, func() bool {
+			bal, e := d.GetAccountBalance(ctx, 2, "hive:magi.test1")
+			return e == nil && bal != nil && bal.Hbd >= 40_000_000
+		}); err != nil {
+			sharedDevnetErr = fmt.Errorf("RC bootstrap never credited magi.test1: %w", err)
+			return
+		}
+		sharedDevnet = d
+	})
+	return sharedDevnet, sharedDevnetErr
+}
+
+// nextAnvilPort returns a unique anvil port so parallel waves don't collide.
+func nextAnvilPort() string { return fmt.Sprintf("%d", atomic.AddInt32(&anvilPortSeq, 1)) }
+
+// deployWithRetry wraps DeployContract to tolerate the transient
+// "failed to request storage proof: context deadline exceeded" that the
+// contract-deployer hits under I/O/CPU pressure on a constrained box (it
+// surfaces as "could not parse contract ID from output"). DeployContract always
+// restarts the stopped node even on failure, so the devnet is left retryable;
+// we wait for it to settle, then retry. Without this, a single transient deploy
+// timeout fails an entire wave whose contract logic is fine.
+func deployWithRetry(ctx context.Context, d *Devnet, opts ContractDeployOpts, attempts int) (string, error) {
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		id, err := d.DeployContract(ctx, opts)
+		if err == nil {
+			return id, nil
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(25 * time.Second): // let the restarted node reconnect
+		}
+	}
+	return "", fmt.Errorf("deploy %q failed after %d attempts: %w", opts.Name, attempts, lastErr)
+}
+
+type evmBridgeEnv struct {
+	t         *testing.T
+	ctx       context.Context
+	d         *Devnet
+	amID      string
+	mockID    string
+	ownerNode int
+	gqlNode   int
+	ownerAcct string
+	propID    uint64 // next proposal id (monotonic)
+}
+
+// evmBridgeConfig builds the standard 5-node fast-config used by the L1 waves.
+func evmBridgeConfig() *Config {
+	cfg := regressionConfig()
+	cfg.Nodes = 5
+	cfg.GenesisNode = 5
+	cfg.SysConfigOverrides.ConsensusParams.ElectionInterval = 20
+	cfg.SysConfigOverrides.ConsensusParams.BondInclusionActivationHeight = 0
+	cfg.GQLBasePort = 38080
+	cfg.P2PBasePort = 31720
+	cfg.MongoPort = 38057
+	cfg.HivePort = 38091
+	cfg.DronePort = 39000
+	cfg.BitcoindRPCPort = 38543
+	cfg.DashdRPCPort = 39898
+	return cfg
+}
+
+// setupEvmBridgeDevnet stands up the full wired foundation and returns the env.
+func setupEvmBridgeDevnet(t *testing.T, ctx context.Context) *evmBridgeEnv {
+	requireDocker(t)
+	d, err := ensureSharedDevnet()
+	if err != nil {
+		t.Fatalf("shared devnet: %v", err)
+	}
+	// Spread GQL reads/deploy-GQL across nodes 2-5 so parallel waves don't all
+	// hammer node 2 (which caused "server closed connection" drops under -parallel 5).
+	gqlNode := 2 + int(atomic.AddInt32(&gqlNodeSeq, 1)-1)%4
+	e := &evmBridgeEnv{t: t, ctx: ctx, d: d, ownerNode: 1, gqlNode: gqlNode, propID: 1}
+	e.ownerAcct = "hive:magi.test1"
+
+	// Deploy this wave's own state-isolated contracts on the shared devnet.
+	// Serialize: DeployContract stops the deployer node (badger lock).
+	sharedDeployMu.Lock()
+	amID, derr := deployWithRetry(ctx, d, ContractDeployOpts{WasmPath: evmBridgeWasmDevnet, Name: "evm-bridge", DeployerNode: e.ownerNode, GQLNode: e.gqlNode}, 3)
+	var mockID string
+	if derr == nil {
+		mockID, derr = deployWithRetry(ctx, d, ContractDeployOpts{WasmPath: mockVerifierWasm, Name: "mock-zk-verifier", DeployerNode: e.ownerNode, GQLNode: e.gqlNode}, 3)
+	}
+	sharedDeployMu.Unlock()
+	if derr != nil {
+		t.Fatalf("deploy: %v", derr)
+	}
+	e.amID = amID
+	e.mockID = mockID
+	t.Logf("contracts: account-mapping=%s mock=%s", amID, mockID)
+
+	if _, err := d.CallContract(ctx, e.ownerNode, amID, "initContract", `{"is_testnet":true}`); err != nil {
+		t.Fatalf("init account-mapping: %v", err)
+	}
+	if _, err := d.CallContract(ctx, e.ownerNode, mockID, "init", `{}`); err != nil {
+		t.Fatalf("init mock: %v", err)
+	}
+
+	// Wire setVerifierContract through the short timelock.
+	if err := e.proposeExecute("setVerifierContract", fmt.Sprintf(`{"contract_id":"%s"}`, mockID)); err != nil {
+		t.Fatalf("wire verifier: %v", err)
+	}
+	if err := pollUntil(ctx, 60*time.Second, func() bool {
+		m, _ := d.GetStateByKeys(ctx, e.gqlNode, amID, []string{"zkverifier"})
+		return m != nil && fmt.Sprintf("%v", m["zkverifier"]) == mockID
+	}); err != nil {
+		t.Fatalf("setVerifierContract did not take effect")
+	}
+	t.Logf("WIRED: account-mapping -> mock verifier")
+	return e
+}
+
+// proposeExecute runs an owner admin action through the short (devnet) timelock:
+// propose -> wait > TimelockLong(5) -> execute. payloadJSON is the action's
+// inner JSON (hex-encoded into payload_hex).
+func (e *evmBridgeEnv) proposeExecute(action, payloadJSON string) error {
+	d := e.d
+	payloadHex := hex.EncodeToString([]byte(payloadJSON))
+	if _, err := d.CallContract(e.ctx, e.ownerNode, e.amID, "propose",
+		fmt.Sprintf(`{"action":"%s","payload_hex":"%s"}`, action, payloadHex)); err != nil {
+		return fmt.Errorf("propose %s: %w", action, err)
+	}
+	id := e.propID
+	e.propID++
+	lb, _, err := d.LocalNodeInfo(e.ctx, e.gqlNode)
+	if err != nil {
+		return err
+	}
+	if err := d.WaitForBlockProcessing(e.ctx, e.gqlNode, lb+12, 6*time.Minute); err != nil {
+		return fmt.Errorf("await timelock: %w", err)
+	}
+	if _, err := d.CallContract(e.ctx, e.ownerNode, e.amID, "execute", fmt.Sprintf(`{"proposal_id":%d}`, id)); err != nil {
+		return fmt.Errorf("execute %s: %w", action, err)
+	}
+	return nil
+}
+
+// setVault sets the bridge vault address (short-timelock admin action).
+func (e *evmBridgeEnv) setVault(addr string) error {
+	if err := e.proposeExecute("setVault", fmt.Sprintf(`"%s"`, addr)); err != nil {
+		return err
+	}
+	return pollUntil(e.ctx, 60*time.Second, func() bool {
+		m, _ := e.d.GetStateByKeys(e.ctx, e.gqlNode, e.amID, []string{"vault"})
+		return m != nil && m["vault"] != nil && fmt.Sprintf("%v", m["vault"]) != ""
+	})
+}
+
+// callOnce broadcasts a vsc.call EXACTLY once (no retry), for non-idempotent
+// actions like `map`/`confirmSpend` where CallContract's 3x broadcast retry can
+// double-process (vsc.call has no L2 nonce dedup). Signs as witness `node`.
+func (e *evmBridgeEnv) callOnce(node int, contractID, action, payload string) (string, error) {
+	callTx := map[string]interface{}{
+		"net_id":      e.d.netId(),
+		"contract_id": contractID,
+		"action":      action,
+		"payload":     payload,
+		"rc_limit":    5000000,
+		"intents":     []interface{}{},
+	}
+	witness := fmt.Sprintf("%s%d", e.d.cfg.WitnessPrefix, node)
+	return e.d.BroadcastCustomJSON("vsc.call", []string{witness}, callTx, e.d.cfg.InitminerWIF)
+}
+
+// fundDID transfers HBD from the owner witness to an arbitrary L2 DID (e.g. an
+// evm did:pkh) so it has RC. The unmapETH caller is the depositor's evm DID,
+// which (not being "hive:") gets no free RC — it needs a real HBD balance.
+func (e *evmBridgeEnv) fundDID(did, hbdAmount string) error {
+	witness := fmt.Sprintf("%s%d", e.d.cfg.WitnessPrefix, e.ownerNode)
+	payload := map[string]interface{}{
+		"from":   e.ownerAcct, // hive:magi.testN
+		"to":     did,         // did:pkh:... (vsc.transfer accepts did:/hive: recipients)
+		"amount": hbdAmount,
+		"asset":  "hbd",
+		"net_id": e.d.netId(),
+	}
+	if _, err := e.d.BroadcastCustomJSON("vsc.transfer", []string{witness}, payload, e.d.cfg.InitminerWIF); err != nil {
+		return err
+	}
+	return pollUntil(e.ctx, 2*time.Minute, func() bool {
+		bal, err := e.d.GetAccountBalance(e.ctx, e.gqlNode, did)
+		return err == nil && bal != nil && bal.Hbd > 0
+	})
+}
+
+// depositETH performs a full ETH deposit (L1 anvil -> mock-planted header -> map)
+// and returns the credited L2 DID. The relayer (ownerAcct) must be registered.
+// amountWei is the deposit value; the credited gwei = amountWei/1e9 minus 1% gas tax.
+func (e *evmBridgeEnv) depositETH(anvil *Anvil, depKey *ecdsa.PrivateKey, vaultAddr ethcommon.Address, amountWei *big.Int) (string, error) {
+	ctx := e.ctx
+	depAddr := ethCrypto.PubkeyToAddress(depKey.PublicKey)
+	if err := anvil.SetBalance(ctx, depAddr, new(big.Int).Add(amountWei, big.NewInt(1e18))); err != nil {
+		return "", err
+	}
+	txHash, blockM, err := anvil.SendETH(ctx, depKey, vaultAddr, amountWei)
+	if err != nil {
+		return "", fmt.Errorf("deposit send: %w", err)
+	}
+	_ = anvil.Mine(ctx, 6)
+	if err := pollUntil(ctx, 60*time.Second, func() bool { f, e2 := anvil.Finalized(ctx); return e2 == nil && f >= blockM }); err != nil {
+		return "", fmt.Errorf("deposit block %d not finalized", blockM)
+	}
+	hdr, err := anvil.Header(ctx, blockM)
+	if err != nil {
+		return "", err
+	}
+	if err := e.plantHeader(hdr, 1); err != nil {
+		return "", err
+	}
+	txIndex, err := anvil.FindTxIndex(ctx, blockM, txHash)
+	if err != nil {
+		return "", err
+	}
+	rawHex, proofHex, err := anvil.TxTrieProof(ctx, blockM, txIndex)
+	if err != nil {
+		return "", err
+	}
+	payload := fmt.Sprintf(`{"tx_data":{"block_height":%d,"tx_index":%d,"raw_hex":"%s","merkle_proof_hex":"%s","deposit_type":"eth"},"instructions":[]}`,
+		blockM, txIndex, rawHex, proofHex)
+	if _, err := e.callOnce(e.ownerNode, e.amID, "map", payload); err != nil {
+		return "", fmt.Errorf("map: %w", err)
+	}
+	did := "did:pkh:eip155:1:" + strings.ToLower(depAddr.Hex())
+	balKey := "a-" + did + "-eth"
+	if err := pollUntil(ctx, 3*time.Minute, func() bool {
+		m, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{balKey})
+		return m != nil && m[balKey] != nil && fmt.Sprintf("%v", m[balKey]) != "" && fmt.Sprintf("%v", m[balKey]) != "0"
+	}); err != nil {
+		return "", fmt.Errorf("deposit not credited to %s", did)
+	}
+	return did, nil
+}
+
+// getTssPubKey returns the contract's "primary" TSS public key (empty until keygen completes).
+func (e *evmBridgeEnv) getTssPubKey() string {
+	const q = `query($id:String!){ getTssKey(keyId:$id){ public_key } }`
+	var out struct {
+		GetTssKey *struct {
+			PublicKey string `json:"public_key"`
+		} `json:"getTssKey"`
+	}
+	if err := e.d.gqlQuery(e.ctx, e.gqlNode, q, map[string]any{"id": e.amID + "-primary"}, &out); err != nil {
+		return ""
+	}
+	if out.GetTssKey == nil {
+		return ""
+	}
+	return out.GetTssKey.PublicKey
+}
+
+// createTssKey schedules the contract's primary TSS keygen (createKey, short
+// timelock) and waits for it to complete. unmapETH's requireTssKey gates on it.
+func (e *evmBridgeEnv) createTssKey(timeout time.Duration) error {
+	if err := e.proposeExecute("createKey", "{}"); err != nil {
+		return err
+	}
+	return pollUntil(e.ctx, timeout, func() bool { return e.getTssPubKey() != "" })
+}
+
+// plantHeader stores an anvil block header into the mock verifier (real roots).
+func (e *evmBridgeEnv) plantHeader(h *AnvilHeader, chainID uint64) error {
+	plant := fmt.Sprintf(`{"block_number":%d,"state_root":"%s","tx_root":"%s","receipts_root":"%s","base_fee":%d,"gas_limit":%d,"timestamp":%d,"chain_id":%d}`,
+		h.Number, h.StateRoot, h.TxRoot, h.ReceiptsRoot, h.BaseFee, h.GasLimit, h.Timestamp, chainID)
+	if _, err := e.d.CallContract(e.ctx, e.ownerNode, e.mockID, "devSetHeader", plant); err != nil {
+		return fmt.Errorf("devSetHeader %d: %w", h.Number, err)
+	}
+	return pollUntil(e.ctx, 60*time.Second, func() bool {
+		got, _ := e.d.getStateHex(e.ctx, e.gqlNode, e.mockID, fmt.Sprintf("b-%d", h.Number))
+		return got != ""
+	})
+}

--- a/tests/devnet/evm_bridge_w0_devnet_test.go
+++ b/tests/devnet/evm_bridge_w0_devnet_test.go
@@ -1,0 +1,110 @@
+//go:build evm_devnet
+
+// EVM-bridge devnet harness — the piece tests/devnet was missing.
+// W0.2: prove the ROUND-5 host instantiates the REAL gc.custom contract WASM,
+// i.e. that sdk.crypto.ecrecover_strict / ecrecover_canonical (DS-RE-1) resolve
+// at instantiate time on the live host. A host missing them makes instantiation
+// fail with "vm requested non-existing function" (wasm.go), so a contract that
+// deploys + initContract-executes is proof the round-5 host fix works.
+//
+// Run: go test -tags evm_devnet -run TestEVMBridge_W0_2 ./tests/devnet/ -timeout 40m -v
+package devnet
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Pre-built round-5 gc.custom WASM (imports verified: ecrecover_strict/canonical present,
+// hive.draw_from DCE-stripped). Built via Docker tinygo to bypass the make /go-perm gate.
+const evmBridgeWasmR5 = "/home/clauderfly/r6-wt/account-mapping/evm-mapping-contract/bin/main.wasm"
+
+func TestEVMBridge_W0_2_HostInstantiate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping EVM-bridge devnet test in short mode")
+	}
+	requireDocker(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Minute)
+	defer cancel()
+
+	cfg := DefaultConfig()
+	cfg.Nodes = 5
+	cfg.GenesisNode = 5
+	// Free port range (avoid the live testnet on 1808x/1072x and the timelock test's 2808x).
+	cfg.GQLBasePort = 38080
+	cfg.P2PBasePort = 31720
+	cfg.MongoPort = 38057
+	cfg.HivePort = 38091
+	cfg.DronePort = 39000
+	cfg.BitcoindRPCPort = 38543
+	cfg.DashdRPCPort = 39898
+
+	d, err := New(cfg)
+	if err != nil {
+		t.Fatalf("creating devnet: %v", err)
+	}
+	t.Cleanup(func() { d.Stop() })
+	if err := d.Start(ctx); err != nil {
+		t.Fatalf("starting devnet: %v", err)
+	}
+
+	const deployNode = 1
+	const queryNode = 2
+
+	// DEPLOY the real round-5 WASM. The deployer collects a storage proof, which
+	// instantiates the contract; a missing host import would fail here already.
+	id, err := d.DeployContract(ctx, ContractDeployOpts{
+		WasmPath:     evmBridgeWasmR5,
+		Name:         "evm-bridge-r5",
+		DeployerNode: deployNode,
+		GQLNode:      queryNode,
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "non-existing function") {
+			t.Fatalf("DS-RE-1 NOT FIXED — host missing a contract import at deploy: %v", err)
+		}
+		t.Fatalf("deploying evm-bridge contract: %v", err)
+	}
+	t.Logf("deployed evm-bridge (round-5 WASM): %s", id)
+
+	if err := d.WaitForBlockProcessing(ctx, queryNode, 10, 5*time.Minute); err != nil {
+		t.Fatalf("query node never synced: %v", err)
+	}
+
+	// initContract triggers WASM instantiation + execution -> ALL 17 imports must
+	// resolve, including crypto.ecrecover_strict / ecrecover_canonical.
+	txId, err := d.CallContract(ctx, queryNode, id, "initContract", `{"is_testnet":true}`)
+	if err != nil {
+		t.Fatalf("calling initContract: %v", err)
+	}
+	t.Logf("initContract tx: %s", txId)
+
+	// Poll the tx to a terminal status.
+	var status string
+	deadline := time.Now().Add(4 * time.Minute)
+	for time.Now().Before(deadline) {
+		status, _ = d.FindTransactionStatus(ctx, queryNode, txId)
+		if status != "" && !strings.EqualFold(status, "UNCONFIRMED") && !strings.EqualFold(status, "PENDING") {
+			break
+		}
+		time.Sleep(3 * time.Second)
+	}
+	t.Logf("initContract tx status: %q", status)
+
+	if strings.EqualFold(status, "FAILED") {
+		t.Fatalf("initContract FAILED — likely DS-RE-1 (missing import) or instantiation error; check magi container logs for 'non-existing function' (tx=%s)", txId)
+	}
+
+	// State read: any successful contract execution proves instantiation (all imports resolved).
+	st, serr := d.GetStateByKeys(ctx, queryNode, id, []string{"chainid", "is_testnet", "h"})
+	t.Logf("post-init state sample: %v (err=%v)", st, serr)
+
+	if status == "" {
+		t.Fatalf("initContract tx never reached a terminal status within deadline (tx=%s) — inconclusive; inspect node logs", txId)
+	}
+	t.Logf("W0.2 PASS — round-5 host INSTANTIATED the real gc.custom WASM and executed initContract (status=%q). "+
+		"crypto.ecrecover_strict / ecrecover_canonical resolved at runtime — DS-RE-1 host fix CONFIRMED on devnet. contractId=%s", status, id)
+}

--- a/tests/devnet/evm_bridge_w1_devnet_test.go
+++ b/tests/devnet/evm_bridge_w1_devnet_test.go
@@ -1,0 +1,161 @@
+//go:build evm_devnet
+
+// W1 — ETH deposit pipeline on real devnet + anvil L1. Proves the deposit-side
+// fixes at runtime: ecrecover_canonical (recovers the L1 depositor from the
+// EIP-1559 tx), tx-trie proof verification against a REAL anvil block root
+// (planted via the mock verifier), and the credit landing at the depositor's
+// derived DID. No TSS needed (deposits aren't TSS-gated).
+//
+// Run: go test -tags evm_devnet -run TestEVMBridge_W1 ./tests/devnet/ -timeout 50m -v
+package devnet
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethCrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestEVMBridge_W1_DepositETH(t *testing.T) {
+	if testing.Short() {
+		t.Skip("devnet")
+	}
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Minute)
+	t.Cleanup(cancel)
+
+	e := setupEvmBridgeDevnet(t, ctx)
+
+	anvil := StartAnvil(t, ctx, 1, nextAnvilPort()) // contract chainId() defaults to 1
+	t.Cleanup(anvil.Stop)
+
+	// Vault (deposits land here on L1) + register the relayer (ETH map is
+	// relayer-gated) + setVault. ownerAcct (magi.test1) is the relayer.
+	vaultKey, _ := ethCrypto.GenerateKey()
+	vaultAddr := ethCrypto.PubkeyToAddress(vaultKey.PublicKey)
+	if err := e.proposeExecute("registerRelayer", fmt.Sprintf(`{"account":"%s"}`, e.ownerAcct)); err != nil {
+		t.Fatalf("registerRelayer: %v", err)
+	}
+	if err := e.setVault(vaultAddr.Hex()); err != nil {
+		t.Fatalf("setVault: %v", err)
+	}
+	t.Logf("vault=%s relayer=%s", vaultAddr.Hex(), e.ownerAcct)
+
+	// Depositor K: fund on anvil, send 1 ETH to the vault.
+	depKey, _ := ethCrypto.GenerateKey()
+	depAddr := ethCrypto.PubkeyToAddress(depKey.PublicKey)
+	tenEth := new(big.Int).Mul(big.NewInt(10), big.NewInt(1e18))
+	if err := anvil.SetBalance(ctx, depAddr, tenEth); err != nil {
+		t.Fatalf("fund depositor: %v", err)
+	}
+	oneEth := big.NewInt(1e18)
+	txHash, blockM, err := anvil.SendETH(ctx, depKey, vaultAddr, oneEth)
+	if err != nil {
+		t.Fatalf("deposit tx: %v", err)
+	}
+	t.Logf("deposit tx %s in anvil block %d (depositor %s)", txHash.Hex(), blockM, depAddr.Hex())
+
+	// Advance anvil so block M is finalized, then plant its real header.
+	_ = anvil.Mine(ctx, 6)
+	if err := pollUntil(ctx, 60*time.Second, func() bool {
+		f, e2 := anvil.Finalized(ctx)
+		return e2 == nil && f >= blockM
+	}); err != nil {
+		t.Fatalf("anvil block %d never finalized", blockM)
+	}
+	hdr, err := anvil.Header(ctx, blockM)
+	if err != nil {
+		t.Fatalf("read header: %v", err)
+	}
+	if err := e.plantHeader(hdr, 1); err != nil {
+		t.Fatalf("plant header: %v", err)
+	}
+	t.Logf("planted header %d (txRoot %s)", blockM, hdr.TxRoot)
+
+	// Build the deposit proof (tx-trie, root-verified locally) + relay via map.
+	txIndex, err := anvil.FindTxIndex(ctx, blockM, txHash)
+	if err != nil {
+		t.Fatalf("tx index: %v", err)
+	}
+	rawHex, proofHex, err := anvil.TxTrieProof(ctx, blockM, txIndex)
+	if err != nil {
+		t.Fatalf("build proof: %v", err)
+	}
+	payload := fmt.Sprintf(`{"tx_data":{"block_height":%d,"tx_index":%d,"raw_hex":"%s","merkle_proof_hex":"%s","deposit_type":"eth"},"instructions":[]}`,
+		blockM, txIndex, rawHex, proofHex)
+	// Single-broadcast: `map` is non-idempotent (no L2 nonce dedup); CallContract's
+	// 3x retry can double-process -> "deposit already processed" with net-zero state.
+	mapTx, err := e.callOnce(e.ownerNode, e.amID, "map", payload)
+	if err != nil {
+		t.Fatalf("map broadcast: %v", err)
+	}
+
+	// ASSERT: depositor's derived DID is credited the ETH (in gwei).
+	did := "did:pkh:eip155:1:" + strings.ToLower(depAddr.Hex())
+	balKey := "a-" + did + "-eth"
+	if err := pollUntil(ctx, 3*time.Minute, func() bool {
+		m, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{balKey})
+		if m == nil || m[balKey] == nil {
+			return false
+		}
+		return fmt.Sprintf("%v", m[balKey]) != "" && fmt.Sprintf("%v", m[balKey]) != "0"
+	}); err != nil {
+		// Diagnostic: dump the map call's contract output (the real abort if any).
+		dumpMapErr(t, e, ctx, mapTx)
+		// State diagnostics: did credit happen anywhere (supply), is the deposit
+		// observed, and what's at the expected balance key?
+		// Compute the EXACT observedEntryKey the contract checks (o-{h}-hex(txHash||index)).
+		rawB, _ := hex.DecodeString(rawHex)
+		txh := ethCrypto.Keccak256(rawB) // == signed.Hash() for typed tx
+		entry := append(append([]byte{}, txh...), byte(txIndex>>8), byte(txIndex))
+		obKey := fmt.Sprintf("o-%d-%s", blockM, hex.EncodeToString(entry))
+		// Sanity keys (KNOWN set) to validate that our state reads work + node is current.
+		diag, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{
+			"vault", "rl-" + e.ownerAcct, "s-eth", fmt.Sprintf("oc-%d", blockM), balKey, obKey,
+		})
+		t.Logf("DIAG sanity vault=%v relayer(rl-%s)=%v", diag["vault"], e.ownerAcct, diag["rl-"+e.ownerAcct])
+		t.Logf("DIAG supply(s-eth)=%v observedCount(oc-%d)=%v balance(%s)=%v observedEntry(%s)=%v",
+			diag["s-eth"], blockM, diag[fmt.Sprintf("oc-%d", blockM)], balKey, diag[balKey], obKey, diag[obKey])
+		t.Logf("DIAG depositor=%s vault=%s blockM=%d txIndex=%d", depAddr.Hex(), vaultAddr.Hex(), blockM, txIndex)
+		m, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{balKey})
+		t.Fatalf("deposit not credited to %s (bal=%v) — see DIAG/DAG above", did, m[balKey])
+	}
+	m, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{balKey})
+	t.Logf("W1 PASS — ETH deposit credited %s = %v gwei (ecrecover_canonical recovered depositor, tx-trie verified vs real anvil root)", did, m[balKey])
+	_ = ethcommon.Address{}
+}
+
+// dumpMapErr reads the map tx's contract-output ret (the hidden abort message).
+func dumpMapErr(t *testing.T, e *evmBridgeEnv, ctx context.Context, txID string) {
+	const q = `query($id:String!){findTransaction(filterOptions:{byId:$id}){id status output{id}}}`
+	var out struct {
+		FindTransaction []struct {
+			Id, Status string
+			Output     []struct {
+				Id string `json:"id"`
+			} `json:"output"`
+		} `json:"findTransaction"`
+	}
+	if err := e.d.gqlQuery(ctx, e.gqlNode, q, map[string]any{"id": txID}, &out); err != nil {
+		t.Logf("map DAG query err: %v", err)
+		return
+	}
+	for _, tx := range out.FindTransaction {
+		t.Logf("map tx %s status=%s", tx.Id, tx.Status)
+		for _, o := range tx.Output {
+			const dq = `query($c:String!){getDagByCID(cidString:$c)}`
+			var d2 struct {
+				GetDagByCID any `json:"getDagByCID"`
+			}
+			if err := e.d.gqlQuery(ctx, e.gqlNode, dq, map[string]any{"c": o.Id}, &d2); err == nil {
+				t.Logf("map output %s = %v", o.Id, d2.GetDagByCID)
+			}
+		}
+	}
+}

--- a/tests/devnet/evm_bridge_w2_devnet_test.go
+++ b/tests/devnet/evm_bridge_w2_devnet_test.go
@@ -1,0 +1,164 @@
+//go:build evm_devnet
+
+// W2 — ETH withdrawal close-out on real devnet + anvil L1. Proves the
+// launch-blocking withdrawal HIGHs at runtime, contract-side, with a controlled
+// vault key (TSS keygen still required for unmapETH's requireTssKey; TSS signing
+// is replaced by signing the L1 tx with the controlled vault, which confirmSpend
+// recovers via ecrecover_strict == VaultAtQueue):
+//   H-F1  : PendingSpend stored as JSON, read back + parsed.
+//   H-F2  : confirmSpend flat-10 schema (intent binding + tx-trie + receipt-trie).
+//   CC-1  : receipt-trie proof of a no-log ETH transfer (all-zero bloom) matches
+//           the planted real receiptsRoot.
+//   DS-F1 : EcrecoverStrict recovers the vault from the withdrawal tx signature.
+//   ML-1  : confirmed nonce advances exactly once.
+//
+// Run: go test -tags evm_devnet -run TestEVMBridge_W2 ./tests/devnet/ -timeout 70m -v
+package devnet
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	ethCrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestEVMBridge_W2_WithdrawalCloseout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("devnet")
+	}
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 70*time.Minute)
+	t.Cleanup(cancel)
+
+	e := setupEvmBridgeDevnet(t, ctx)
+	anvil := StartAnvil(t, ctx, 1, nextAnvilPort())
+	t.Cleanup(anvil.Stop)
+
+	// Relayer (for the deposit), TSS primary key (unmapETH gate), controlled vault.
+	if err := e.proposeExecute("registerRelayer", fmt.Sprintf(`{"account":"%s"}`, e.ownerAcct)); err != nil {
+		t.Fatalf("registerRelayer: %v", err)
+	}
+	t.Logf("waiting for TSS primary keygen...")
+	if err := e.createTssKey(25 * time.Minute); err != nil {
+		t.Fatalf("TSS keygen: %v", err)
+	}
+	t.Logf("TSS primary key ready")
+
+	vaultKey, _ := ethCrypto.GenerateKey()
+	vaultAddr := ethCrypto.PubkeyToAddress(vaultKey.PublicKey)
+	if err := e.setVault(vaultAddr.Hex()); err != nil {
+		t.Fatalf("setVault: %v", err)
+	}
+	// Fund the vault on anvil so it can broadcast the withdrawal.
+	_ = anvil.SetBalance(ctx, vaultAddr, new(big.Int).Mul(big.NewInt(100), big.NewInt(1e18)))
+
+	// Deposit 6 ETH for depositor K — the 1% gas tax (60M gwei) exceeds
+	// MinGasReserve (50M gwei) so unmapETH's gas-reserve gate passes.
+	depKey, _ := ethCrypto.GenerateKey()
+	depHex := hex.EncodeToString(ethCrypto.FromECDSA(depKey))
+	sixEth := new(big.Int).Mul(big.NewInt(6), big.NewInt(1e18))
+	did, err := e.depositETH(anvil, depKey, vaultAddr, sixEth)
+	if err != nil {
+		t.Fatalf("deposit: %v", err)
+	}
+	t.Logf("deposited; L2 credit at %s", did)
+
+	// Fund K's evm DID with HBD so it has RC to submit the L2 unmapETH.
+	if err := e.fundDID(did, "10000.000"); err != nil {
+		t.Fatalf("fund K DID for RC: %v", err)
+	}
+
+	// unmapETH as K (evm-signed) — withdraw 1 ETH (1e9 gwei) to a fresh recipient.
+	K, err := NewEthKey(depHex)
+	if err != nil {
+		t.Fatalf("eth key: %v", err)
+	}
+	recipKey, _ := ethCrypto.GenerateKey()
+	recipAddr := ethCrypto.PubkeyToAddress(recipKey.PublicKey)
+	unmapPayload := fmt.Sprintf(`{"to":"%s","amount":"1000000000"}`, recipAddr.Hex())
+	if _, err := e.d.CallContractEvm(ctx, e.gqlNode, K, e.amID, "unmapETH", unmapPayload, 5000000); err != nil {
+		t.Fatalf("unmapETH broadcast: %v", err)
+	}
+
+	// Read PendingSpend d-0 (H-F1: JSON) and parse it.
+	type pendingSpend struct {
+		Nonce         uint64 `json:"nonce"`
+		Amount        int64  `json:"amount"`
+		To            string `json:"to"`
+		Asset         string `json:"asset"`
+		VaultAtQueue  string `json:"vault_at_queue"`
+		UnsignedTxHex string `json:"unsigned_tx_hex"`
+	}
+	var ps pendingSpend
+	if err := pollUntil(ctx, 3*time.Minute, func() bool {
+		m, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{"d-0"})
+		if m == nil || m["d-0"] == nil {
+			return false
+		}
+		return json.Unmarshal([]byte(fmt.Sprintf("%v", m["d-0"])), &ps) == nil && ps.UnsignedTxHex != ""
+	}); err != nil {
+		t.Fatalf("PendingSpend d-0 not created (unmapETH failed) — check RC/gas-reserve")
+	}
+	t.Logf("H-F1 PendingSpend(JSON): nonce=%d to=%s amount=%d asset=%s vault=%s", ps.Nonce, ps.To, ps.Amount, ps.Asset, ps.VaultAtQueue)
+
+	// Broadcast the vault withdrawal tx (V -> recipient, value = amount*1e9 wei).
+	// V's first L1 tx has nonce 0 == ps.Nonce, matching the contract's unsigned tx.
+	valueWei := new(big.Int).Mul(big.NewInt(ps.Amount), big.NewInt(1e9))
+	wTxHash, blockN, err := anvil.SendETH(ctx, vaultKey, recipAddr, valueWei)
+	if err != nil {
+		t.Fatalf("withdrawal broadcast: %v", err)
+	}
+	_ = anvil.Mine(ctx, 6)
+	if err := pollUntil(ctx, 60*time.Second, func() bool { f, e2 := anvil.Finalized(ctx); return e2 == nil && f >= blockN }); err != nil {
+		t.Fatalf("withdrawal block %d not finalized", blockN)
+	}
+	hdrN, err := anvil.Header(ctx, blockN)
+	if err != nil {
+		t.Fatalf("header: %v", err)
+	}
+	if err := e.plantHeader(hdrN, 1); err != nil {
+		t.Fatalf("plant: %v", err)
+	}
+
+	// Build tx-trie + receipt-trie proofs (the no-log ETH transfer = CC-1 all-zero bloom).
+	wIdx, err := anvil.FindTxIndex(ctx, blockN, wTxHash)
+	if err != nil {
+		t.Fatalf("tx index: %v", err)
+	}
+	txHex, txProofHex, err := anvil.TxTrieProof(ctx, blockN, wIdx)
+	if err != nil {
+		t.Fatalf("tx proof: %v", err)
+	}
+	rcptHex, rcptProofHex, err := anvil.ReceiptTrieProof(ctx, blockN, wIdx)
+	if err != nil {
+		t.Fatalf("receipt proof: %v", err)
+	}
+
+	// confirmSpend (flat-10). intent_* must match the stored PendingSpend exactly.
+	csPayload := fmt.Sprintf(`{"block_height":%d,"tx_index":%d,"tx_hex":"%s","tx_proof_hex":"%s","receipt_hex":"%s","receipt_proof_hex":"%s","intent_nonce":%d,"intent_to":"%s","intent_amount":%d,"intent_asset":"%s"}`,
+		blockN, wIdx, txHex, txProofHex, rcptHex, rcptProofHex, ps.Nonce, ps.To, ps.Amount, ps.Asset)
+	csTx, err := e.callOnce(e.ownerNode, e.amID, "confirmSpend", csPayload)
+	if err != nil {
+		t.Fatalf("confirmSpend broadcast: %v", err)
+	}
+
+	// ASSERT: confirmed nonce advanced 0 -> 1.
+	if err := pollUntil(ctx, 3*time.Minute, func() bool {
+		m, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{"n"})
+		return m != nil && fmt.Sprintf("%v", m["n"]) == "1"
+	}); err != nil {
+		dumpMapErr(t, e, ctx, csTx)
+		m, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{"n", "np"})
+		t.Fatalf("confirmSpend did not advance confirmed nonce (n=%v np=%v) — see DAG above", m["n"], m["np"])
+	}
+	_ = strings.ToLower
+	t.Logf("W2 PASS — withdrawal confirmed, confirmed nonce 0->1. Proven: H-F1 (PendingSpend JSON), "+
+		"H-F2 (confirmSpend flat-10 + intent bind + tx/receipt trie), CC-1 (all-zero-bloom receiptsRoot match), "+
+		"DS-F1 (ecrecover_strict==vault), ML-1 (single nonce advance).")
+}

--- a/tests/devnet/evm_bridge_w3_devnet_test.go
+++ b/tests/devnet/evm_bridge_w3_devnet_test.go
@@ -1,0 +1,324 @@
+//go:build evm_devnet
+
+// W3 — Double-spend attack on a SUCCEEDED ETH withdrawal (real devnet + anvil L1).
+// Proves the launch-blocking state-machine HIGHs at runtime, contract-side:
+//   H-SM2 (Type-B disabled): a `block_inclusion_without_tx` drop-proof is
+//         REJECTED. Its premise ("vault advanced past nonce N ⇒ tx N dropped")
+//         is unsound — a SUCCEEDED withdrawal also advances the nonce — so the
+//         contract disables Type-B entirely (handlers.go:1688). cancelMyWithdrawal
+//         with a Type-B proof MUST abort.
+//   H-SM1 (Type-A needs status==0): a `reverted_receipt` drop-proof carrying the
+//         SUCCEEDED withdrawal's real receipt (status==1) is REJECTED with
+//         "receipt status != 0 — tx not reverted" (handlers.go:1559). A tx that
+//         paid the recipient on L1 cannot be claimed as reverted.
+//   No double-spend: after BOTH failed attacks the PendingSpend d-0 still exists,
+//         the confirmed nonce `n` did NOT advance, and the depositor's eth balance
+//         was NOT re-credited above its post-unmap value. The withdrawal can only
+//         be closed by confirmSpend (W2), never force-refunded.
+//
+// Mirrors W2 up to the withdrawal SUCCEEDING on L1, then attacks instead of
+// calling confirmSpend.
+//
+// Run: go test -tags evm_devnet -run TestEVMBridge_W3 ./tests/devnet/ -timeout 70m -v
+package devnet
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	ethCrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestEVMBridge_W3_DoubleSpendAttack(t *testing.T) {
+	if testing.Short() {
+		t.Skip("devnet")
+	}
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 70*time.Minute)
+	t.Cleanup(cancel)
+
+	e := setupEvmBridgeDevnet(t, ctx)
+	anvil := StartAnvil(t, ctx, 1, nextAnvilPort())
+	t.Cleanup(anvil.Stop)
+
+	// Relayer (for the deposit), TSS primary key (unmapETH gate), controlled vault.
+	if err := e.proposeExecute("registerRelayer", fmt.Sprintf(`{"account":"%s"}`, e.ownerAcct)); err != nil {
+		t.Fatalf("registerRelayer: %v", err)
+	}
+	t.Logf("waiting for TSS primary keygen...")
+	if err := e.createTssKey(25 * time.Minute); err != nil {
+		t.Fatalf("TSS keygen: %v", err)
+	}
+	t.Logf("TSS primary key ready")
+
+	vaultKey, _ := ethCrypto.GenerateKey()
+	vaultAddr := ethCrypto.PubkeyToAddress(vaultKey.PublicKey)
+	if err := e.setVault(vaultAddr.Hex()); err != nil {
+		t.Fatalf("setVault: %v", err)
+	}
+	// Fund the vault on anvil so it can broadcast the withdrawal.
+	_ = anvil.SetBalance(ctx, vaultAddr, new(big.Int).Mul(big.NewInt(100), big.NewInt(1e18)))
+
+	// Deposit 6 ETH for depositor K — the 1% gas tax (60M gwei) exceeds
+	// MinGasReserve (50M gwei) so unmapETH's gas-reserve gate passes.
+	depKey, _ := ethCrypto.GenerateKey()
+	depHex := hex.EncodeToString(ethCrypto.FromECDSA(depKey))
+	sixEth := new(big.Int).Mul(big.NewInt(6), big.NewInt(1e18))
+	did, err := e.depositETH(anvil, depKey, vaultAddr, sixEth)
+	if err != nil {
+		t.Fatalf("deposit: %v", err)
+	}
+	t.Logf("deposited; L2 credit at %s", did)
+
+	// Fund K's evm DID with HBD so it has RC for THREE L2 calls (unmapETH +
+	// the two cancelMyWithdrawal attacks), each gated on available RC >= 5M
+	// rc_limit. 30000 HBD (~30M RC) clears all three with margin.
+	if err := e.fundDID(did, "30000.000"); err != nil {
+		t.Fatalf("fund K DID for RC: %v", err)
+	}
+
+	// unmapETH as K (evm-signed) — withdraw 1 ETH (1e9 gwei) to a fresh recipient.
+	K, err := NewEthKey(depHex)
+	if err != nil {
+		t.Fatalf("eth key: %v", err)
+	}
+	recipKey, _ := ethCrypto.GenerateKey()
+	recipAddr := ethCrypto.PubkeyToAddress(recipKey.PublicKey)
+	unmapPayload := fmt.Sprintf(`{"to":"%s","amount":"1000000000"}`, recipAddr.Hex())
+	if _, err := e.d.CallContractEvm(ctx, e.gqlNode, K, e.amID, "unmapETH", unmapPayload, 5000000); err != nil {
+		t.Fatalf("unmapETH broadcast: %v", err)
+	}
+
+	// Read PendingSpend d-0 (JSON) and parse it.
+	type pendingSpend struct {
+		Nonce         uint64 `json:"nonce"`
+		Amount        int64  `json:"amount"`
+		To            string `json:"to"`
+		Asset         string `json:"asset"`
+		VaultAtQueue  string `json:"vault_at_queue"`
+		UnsignedTxHex string `json:"unsigned_tx_hex"`
+	}
+	var ps pendingSpend
+	if err := pollUntil(ctx, 3*time.Minute, func() bool {
+		m, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{"d-0"})
+		if m == nil || m["d-0"] == nil {
+			return false
+		}
+		return json.Unmarshal([]byte(fmt.Sprintf("%v", m["d-0"])), &ps) == nil && ps.UnsignedTxHex != ""
+	}); err != nil {
+		t.Fatalf("PendingSpend d-0 not created (unmapETH failed) — check RC/gas-reserve")
+	}
+	t.Logf("PendingSpend(JSON): nonce=%d to=%s amount=%d asset=%s vault=%s", ps.Nonce, ps.To, ps.Amount, ps.Asset, ps.VaultAtQueue)
+
+	// Record the depositor's post-unmap eth balance — it must NOT increase
+	// across either attack (no force-refund). unmapETH already debited
+	// amount + fee from K, so this is the floor the attacks must not exceed.
+	balKey := fmt.Sprintf("a-%s-eth", did)
+	postUnmapBal := readIntState(t, e, ctx, balKey)
+	t.Logf("post-unmap depositor balance %s = %d gwei", balKey, postUnmapBal)
+
+	// Broadcast the vault withdrawal tx (V -> recipient, value = amount*1e9 wei).
+	// V's first L1 tx has nonce 0 == ps.Nonce, matching the contract's unsigned tx.
+	// This SUCCEEDS on L1 (status==1, recipient PAID) — the precise condition under
+	// which a drop-proof must NEVER be accepted.
+	valueWei := new(big.Int).Mul(big.NewInt(ps.Amount), big.NewInt(1e9))
+	wTxHash, blockN, err := anvil.SendETH(ctx, vaultKey, recipAddr, valueWei)
+	if err != nil {
+		t.Fatalf("withdrawal broadcast: %v", err)
+	}
+	_ = anvil.Mine(ctx, 6)
+	if err := pollUntil(ctx, 60*time.Second, func() bool { f, e2 := anvil.Finalized(ctx); return e2 == nil && f >= blockN }); err != nil {
+		t.Fatalf("withdrawal block %d not finalized", blockN)
+	}
+	hdrN, err := anvil.Header(ctx, blockN)
+	if err != nil {
+		t.Fatalf("header: %v", err)
+	}
+	if err := e.plantHeader(hdrN, 1); err != nil {
+		t.Fatalf("plant: %v", err)
+	}
+
+	// Build tx-trie + receipt-trie proofs for the SUCCEEDED withdrawal.
+	wIdx, err := anvil.FindTxIndex(ctx, blockN, wTxHash)
+	if err != nil {
+		t.Fatalf("tx index: %v", err)
+	}
+	txHex, txProofHex, err := anvil.TxTrieProof(ctx, blockN, wIdx)
+	if err != nil {
+		t.Fatalf("tx proof: %v", err)
+	}
+	rcptHex, rcptProofHex, err := anvil.ReceiptTrieProof(ctx, blockN, wIdx)
+	if err != nil {
+		t.Fatalf("receipt proof: %v", err)
+	}
+	t.Logf("SUCCEEDED withdrawal mined: block=%d txIndex=%d hash=%s (recipient %s PAID)", blockN, wIdx, wTxHash, recipAddr.Hex())
+
+	// ──────────────────────────────────────────────────────────────────────
+	// ATTACK A — H-SM2: Type-B "block_inclusion_without_tx" drop-proof.
+	// The attacker (depositor K = ps.From, the only allowed canceller) tries to
+	// force-refund the SUCCEEDED withdrawal by claiming a "drop" via the disabled
+	// Type-B shape, feeding the SUCCEEDED tx's own tx-trie proof. The contract
+	// MUST reject. Two valid rejection gates may fire first (both prove no
+	// double-spend): (1) the SUCCEEDED tx is at nonce 0 == ps.Nonce, so the
+	// "nonce does not exceed cleared nonce — vault has not advanced" gate trips;
+	// (2) the Type-B-disabled H-SM2 gate. We accept either.
+	// ──────────────────────────────────────────────────────────────────────
+	typeBProof := fmt.Sprintf(`{"type":"block_inclusion_without_tx","block_height":%d,"tx_index":%d,"tx_nonce":%d,"tx_at_index_hex":"%s","tx_proof_hex":"%s"}`,
+		blockN, wIdx, ps.Nonce, txHex, txProofHex)
+	cancelB := fmt.Sprintf(`{"nonce":%d,"proof":%s}`, ps.Nonce, typeBProof)
+	// Call AS K (the original withdrawer / ps.From) via evm-DID signing — the
+	// contract's cancelMyWithdrawal authorizes only the original withdrawer, so
+	// an owner-signed call (callOnce) is rejected at the auth gate before reaching
+	// the Type-B/Type-A guards. K already has RC (funded 10000 HBD above).
+	txB, err := e.d.CallContractEvm(ctx, e.gqlNode, K, e.amID, "cancelMyWithdrawal", cancelB, 5000000)
+	if err != nil {
+		t.Fatalf("ATTACK A cancelMyWithdrawal broadcast: %v", err)
+	}
+	outB, okB := txOutputMsg(t, e, ctx, txB)
+	t.Logf("ATTACK A (Type-B) output: ok=%v msg=%q", okB, outB)
+	if okB {
+		dumpMapErr(t, e, ctx, txB)
+		t.Fatalf("ATTACK A SUCCEEDED — Type-B drop-proof force-refunded a SUCCEEDED withdrawal (H-SM2 BROKEN, double-spend)")
+	}
+	if !(strings.Contains(outB, "Type-B") || strings.Contains(outB, "block_inclusion_without_tx") ||
+		strings.Contains(outB, "vault has not advanced") || strings.Contains(outB, "does not exceed cleared nonce")) {
+		dumpMapErr(t, e, ctx, txB)
+		t.Fatalf("ATTACK A rejected for the WRONG reason — expected Type-B-disabled (H-SM2) or nonce-not-advanced; got %q", outB)
+	}
+	t.Logf("ATTACK A REJECTED (H-SM2): Type-B drop-proof cannot force-refund a SUCCEEDED withdrawal")
+
+	// ──────────────────────────────────────────────────────────────────────
+	// ATTACK B — H-SM1: Type-A "reverted_receipt" drop-proof carrying the
+	// SUCCEEDED withdrawal's REAL receipt (status==1) + tx proof. The receipt
+	// proves the tx was mined and PAID; claiming it as "reverted" must fail with
+	// "receipt status != 0 — tx not reverted".
+	// ──────────────────────────────────────────────────────────────────────
+	typeAProof := fmt.Sprintf(`{"type":"reverted_receipt","block_height":%d,"tx_index":%d,"tx_nonce":%d,"receipt_hex":"%s","receipt_proof_hex":"%s","tx_at_index_hex":"%s","tx_proof_hex":"%s"}`,
+		blockN, wIdx, ps.Nonce, rcptHex, rcptProofHex, txHex, txProofHex)
+	cancelA := fmt.Sprintf(`{"nonce":%d,"proof":%s}`, ps.Nonce, typeAProof)
+	// Call AS K (original withdrawer) via evm-DID signing — see ATTACK A note.
+	txA, err := e.d.CallContractEvm(ctx, e.gqlNode, K, e.amID, "cancelMyWithdrawal", cancelA, 5000000)
+	if err != nil {
+		t.Fatalf("ATTACK B cancelMyWithdrawal broadcast: %v", err)
+	}
+	outA, okA := txOutputMsg(t, e, ctx, txA)
+	t.Logf("ATTACK B (Type-A, status==1) output: ok=%v msg=%q", okA, outA)
+	if okA {
+		dumpMapErr(t, e, ctx, txA)
+		t.Fatalf("ATTACK B SUCCEEDED — Type-A drop-proof accepted a SUCCEEDED (status==1) receipt as reverted (H-SM1 BROKEN, double-spend)")
+	}
+	if !strings.Contains(outA, "receipt status != 0") {
+		dumpMapErr(t, e, ctx, txA)
+		t.Fatalf("ATTACK B rejected for the WRONG reason — expected \"receipt status != 0\" (H-SM1); got %q", outA)
+	}
+	t.Logf("ATTACK B REJECTED (H-SM1): Type-A drop-proof of a status==1 receipt rejected (\"receipt status != 0\")")
+
+	// ──────────────────────────────────────────────────────────────────────
+	// ASSERT NO DOUBLE-SPEND — the withdrawal state machine is intact:
+	//   1. PendingSpend d-0 still exists (not deleted by either attack).
+	//   2. Confirmed nonce `n` did NOT advance (absent or 0).
+	//   3. Depositor eth balance was NOT re-credited above its post-unmap value.
+	// ──────────────────────────────────────────────────────────────────────
+	dm, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{"d-0"})
+	if dm == nil || dm["d-0"] == nil {
+		t.Fatalf("DOUBLE-SPEND: PendingSpend d-0 was DELETED by a failed attack — withdrawal state corrupted")
+	}
+	var psAfter pendingSpend
+	if err := json.Unmarshal([]byte(fmt.Sprintf("%v", dm["d-0"])), &psAfter); err != nil || psAfter.UnsignedTxHex == "" {
+		t.Fatalf("DOUBLE-SPEND: PendingSpend d-0 unreadable/cleared after attacks: %v", dm["d-0"])
+	}
+
+	nm, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{"n"})
+	nStr := "0"
+	if nm != nil && nm["n"] != nil {
+		nStr = strings.TrimSpace(fmt.Sprintf("%v", nm["n"]))
+	}
+	if nStr != "0" && nStr != "<nil>" && nStr != "" {
+		t.Fatalf("DOUBLE-SPEND: confirmed nonce advanced to %q after a failed attack — withdrawal counted as closed without confirmSpend", nStr)
+	}
+
+	finalBal := readIntState(t, e, ctx, balKey)
+	if finalBal > postUnmapBal {
+		t.Fatalf("DOUBLE-SPEND: depositor eth balance re-credited %d -> %d gwei by a failed attack (refund of an already-paid withdrawal)", postUnmapBal, finalBal)
+	}
+
+	t.Logf("W3 PASS — succeeded withdrawal cannot be force-refunded (Type-B disabled H-SM2; Type-A needs status==0 H-SM1); no double-spend "+
+		"(d-0 present, confirmed nonce n=%q unchanged, depositor balance %d gwei unchanged)", nStr, finalBal)
+}
+
+// txOutputMsg reads a map tx's contract-output result: returns (message, ok).
+// ok==true means the contract call SUCCEEDED (results[].ok true / no err); a
+// non-empty message is the abort/error string when ok==false. Mirrors the DAG
+// walk in dumpMapErr (findTransaction{output{id}} -> getDagByCID).
+func txOutputMsg(t *testing.T, e *evmBridgeEnv, ctx context.Context, txID string) (string, bool) {
+	t.Helper()
+	// Poll until the tx is processed and an output DAG is available.
+	const q = `query($id:String!){findTransaction(filterOptions:{byId:$id}){id status output{id}}}`
+	var outputCID string
+	_ = pollUntil(ctx, 3*time.Minute, func() bool {
+		var out struct {
+			FindTransaction []struct {
+				Id, Status string
+				Output     []struct {
+					Id string `json:"id"`
+				} `json:"output"`
+			} `json:"findTransaction"`
+		}
+		if err := e.d.gqlQuery(ctx, e.gqlNode, q, map[string]any{"id": txID}, &out); err != nil {
+			return false
+		}
+		for _, tx := range out.FindTransaction {
+			for _, o := range tx.Output {
+				if o.Id != "" {
+					outputCID = o.Id
+					return true
+				}
+			}
+		}
+		return false
+	})
+	if outputCID == "" {
+		t.Logf("txOutputMsg: no output DAG for tx %s", txID)
+		return "", false
+	}
+	const dq = `query($c:String!){getDagByCID(cidString:$c)}`
+	var d2 struct {
+		GetDagByCID any `json:"getDagByCID"`
+	}
+	if err := e.d.gqlQuery(ctx, e.gqlNode, dq, map[string]any{"c": outputCID}, &d2); err != nil {
+		t.Logf("txOutputMsg: getDagByCID err: %v", err)
+		return "", false
+	}
+	// The output DAG is a contract-output object whose results carry ok/err/ret.
+	// We stringify the whole thing and look for failure markers + the abort msg;
+	// the contract aborts wrap the handler error string (e.g. "receipt status != 0").
+	raw := fmt.Sprintf("%v", d2.GetDagByCID)
+	blob, _ := json.Marshal(d2.GetDagByCID)
+	combined := raw + " " + string(blob)
+	// ok if there is no error/abort marker present.
+	lc := strings.ToLower(combined)
+	ok := !strings.Contains(lc, "err") && !strings.Contains(lc, "abort") && !strings.Contains(lc, "fail")
+	return combined, ok
+}
+
+// readIntState reads a contract state key and parses it as an int64 (0 if absent).
+func readIntState(t *testing.T, e *evmBridgeEnv, ctx context.Context, key string) int64 {
+	t.Helper()
+	m, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{key})
+	if m == nil || m[key] == nil {
+		return 0
+	}
+	s := strings.TrimSpace(fmt.Sprintf("%v", m[key]))
+	s = strings.Trim(s, `"`)
+	var v int64
+	if _, err := fmt.Sscan(s, &v); err != nil {
+		return 0
+	}
+	return v
+}

--- a/tests/devnet/evm_bridge_w4_devnet_test.go
+++ b/tests/devnet/evm_bridge_w4_devnet_test.go
@@ -1,0 +1,112 @@
+//go:build evm_devnet
+
+// W4: consensus version-gating no-fork. The round-5 fixes that touch deterministic
+// WASM-host / state paths (#92 sdk-error-determinism, #119 read_ex, #130 init-guard,
+// #136 runtime-versioning, #56 gateway schedule, CD-1 IsSupportedAt) are gated on
+// Version0_2_0Height. This run pins it to 200, deploys + exercises the EVM contract
+// (which drives the WASM host) on BOTH sides of the activation, and asserts ALL nodes
+// stay in consensus across it — i.e. the gates are election-height-deterministic and
+// the legacy path is byte-identical (no node-vs-node fork at activation).
+//
+// Run: go test -tags evm_devnet -run TestEVMBridge_W4 ./tests/devnet/ -timeout 55m -v
+package devnet
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestEVMBridge_W4_ConsensusGatingNoFork(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping EVM-bridge devnet test in short mode")
+	}
+	requireDocker(t)
+
+	const v020Height = 200
+
+	cfg := regressionConfig() // has SysConfigOverrides initialized
+	cfg.Nodes = 5
+	cfg.GenesisNode = 5
+	cp := cfg.SysConfigOverrides.ConsensusParams
+	cp.ElectionInterval = 20
+	cp.Version0_2_0Height = v020Height // override devnet default (1) to exercise both sides
+	cp.BondInclusionActivationHeight = 0
+	// free port range (avoid live testnet + the W0.2/timelock ranges)
+	cfg.GQLBasePort = 38080
+	cfg.P2PBasePort = 31720
+	cfg.MongoPort = 38057
+	cfg.HivePort = 38091
+	cfg.DronePort = 39000
+	cfg.BitcoindRPCPort = 38543
+	cfg.DashdRPCPort = 39898
+
+	ctx, cancel := context.WithTimeout(context.Background(), 55*time.Minute)
+	t.Cleanup(cancel)
+
+	d, err := New(cfg)
+	if err != nil {
+		t.Fatalf("creating devnet: %v", err)
+	}
+	t.Cleanup(func() { d.Stop() })
+	if err := d.Start(ctx); err != nil {
+		t.Fatalf("starting devnet: %v", err)
+	}
+
+	const queryNode = 2
+
+	// Deploy + init the EVM contract PRE-activation (drives the WASM host on the legacy gate).
+	id, err := d.DeployContract(ctx, ContractDeployOpts{
+		WasmPath: evmBridgeWasmR5, Name: "evm-bridge-w4", DeployerNode: 1, GQLNode: queryNode,
+	})
+	if err != nil {
+		t.Fatalf("deploy: %v", err)
+	}
+	t.Logf("deployed evm-bridge (W4): %s", id)
+	if _, err := d.CallContract(ctx, queryNode, id, "initContract", `{"is_testnet":true}`); err != nil {
+		t.Fatalf("pre-activation initContract: %v", err)
+	}
+
+	// Cross the activation height.
+	if err := d.WaitForBlockProcessing(ctx, queryNode, v020Height+20, 35*time.Minute); err != nil {
+		t.Fatalf("never crossed activation height %d: %v", v020Height, err)
+	}
+	t.Logf("crossed activation height %d", v020Height)
+
+	// Exercise a POST-activation contract call (gated WASM-host paths now active).
+	if _, err := d.CallContract(ctx, queryNode, id, "initContract", `{"is_testnet":true}`); err != nil {
+		t.Logf("post-activation call returned (expected: already-init rejection is fine, not a fork): %v", err)
+	}
+
+	// NO-FORK assertion: every node agrees on epoch and is within a tiny block window.
+	type ni struct {
+		last, epoch uint64
+	}
+	infos := make([]ni, 0, cfg.Nodes)
+	var minB, maxB, ep0 uint64
+	for n := 1; n <= cfg.Nodes; n++ {
+		lb, ep, err := d.LocalNodeInfo(ctx, n)
+		if err != nil {
+			t.Fatalf("node %d LocalNodeInfo: %v", n, err)
+		}
+		infos = append(infos, ni{lb, ep})
+		if n == 1 {
+			minB, maxB, ep0 = lb, lb, ep
+		}
+		if lb < minB {
+			minB = lb
+		}
+		if lb > maxB {
+			maxB = lb
+		}
+		if ep != ep0 {
+			t.Fatalf("FORK: node %d epoch=%d != node1 epoch=%d (version-gating diverged across activation)", n, ep, ep0)
+		}
+		t.Logf("node %d: lastBlock=%d epoch=%d", n, lb, ep)
+	}
+	if maxB-minB > 5 {
+		t.Fatalf("FORK/STALL: node block spread %d..%d (>5) across activation — nodes not in consensus", minB, maxB)
+	}
+	t.Logf("W4 PASS — 5 nodes crossed Version0_2_0Height=%d in consensus (epoch=%d, block spread %d..%d). "+
+		"Version-gated WASM-host/state fixes (#92/#119/#130/#136/#56/CD-1) are election-height-deterministic; no fork at activation.", v020Height, ep0, minB, maxB)
+}

--- a/tests/devnet/evm_bridge_w6neg_devnet_test.go
+++ b/tests/devnet/evm_bridge_w6neg_devnet_test.go
@@ -1,0 +1,454 @@
+//go:build evm_devnet
+
+// W6Neg — admin-bounds (W6.3) + negative-matrix (W6.5) validation for the
+// account-mapping EVM bridge. NO anvil, NO TSS: pure contract-call validation
+// that the MED admin/validation fixes REJECT bad inputs at runtime on a real
+// 5-node devnet (local Go unit tests don't exercise the WASM-host + state path).
+//
+// Each case: perform the call, read the resulting tx's contract-output (ok,err),
+// and assert the expected outcome (reject with a specific error substring, or
+// accept with the expected state mutation).
+//
+// Cases asserted:
+//   1. pause gate      — pause -> unmapETH "contract is paused"; unpause ->
+//                        unmapETH "invalid amount" (gate lifted, calls flow).
+//   2. registerToken   — empty symbol / pipe symbol / min<0 / min>max REJECTED;
+//                        a valid registration ACCEPTED (token state key written).
+//   3. setGasReserve   — non-numeric / out-of-range REJECTED; valid ACCEPTED
+//                        (gr state key written).
+//   4. unmapETH degen  — amount 0 "invalid amount"; below-min "below minimum
+//                        ETH withdrawal"; zero-address "withdrawal to zero
+//                        address rejected". (All reject BEFORE the header/balance
+//                        checks — the validation guards fire first.)
+//   5. map degen       — bad deposit_type "deposit_type must be 'eth' or 'erc20'";
+//                        non-whitelisted-relayer eth "caller is not a whitelisted
+//                        relayer".
+//
+// Run: go test -tags evm_devnet -run TestEVMBridge_W6Neg ./tests/devnet/ -timeout 40m -v
+package devnet
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEVMBridge_W6Neg_AdminAndNegativeMatrix(t *testing.T) {
+	if testing.Short() {
+		t.Skip("devnet")
+	}
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Minute)
+	t.Cleanup(cancel)
+
+	e := setupEvmBridgeDevnet(t, ctx)
+
+	// Track each asserted case so the final summary is honest about coverage.
+	asserted := 0
+	total := 0
+	assertCase := func(name string, gotOk bool, gotErr string, wantOk bool, wantSub string) {
+		total++
+		if gotOk != wantOk {
+			t.Fatalf("[%s] expected ok=%v, got ok=%v (err=%q)", name, wantOk, gotOk, gotErr)
+		}
+		if !wantOk && wantSub != "" && !strings.Contains(gotErr, wantSub) {
+			t.Fatalf("[%s] expected reject containing %q, got ok=%v err=%q", name, wantSub, gotOk, gotErr)
+		}
+		asserted++
+		if wantOk {
+			t.Logf("[%s] ACCEPTED (ok=true) as expected", name)
+		} else {
+			t.Logf("[%s] REJECTED %q (contains %q) as expected", name, gotErr, wantSub)
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Vault must be configured so the `map` deposit_type test reaches the type
+	// switch (HandleMap rejects an unset vault with "vault address not
+	// configured" before the switch). Use the W1 vault setter (short timelock).
+	// -------------------------------------------------------------------------
+	const vaultAddr = "0x00000000000000000000000000000000000000aa"
+	if err := e.setVault(vaultAddr); err != nil {
+		t.Fatalf("setVault: %v", err)
+	}
+	t.Logf("vault configured: %s", vaultAddr)
+
+	// =========================================================================
+	// CASE 1 — pause gate (Immediate timelock).
+	// =========================================================================
+	if err := e.proposeExecute("pause", "{}"); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	if err := pollUntil(ctx, 90*time.Second, func() bool {
+		m, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{"paused"})
+		return m != nil && fmt.Sprintf("%v", m["paused"]) == "1"
+	}); err != nil {
+		t.Fatalf("pause did not set paused=1")
+	}
+	// A well-formed unmapETH (valid amount, valid non-zero to) must now be
+	// rejected at the FIRST gate — "contract is paused" — proving the pause
+	// short-circuits before any amount/address validation.
+	{
+		payload := fmt.Sprintf(`{"amount":"20000000","to":"%s"}`, vaultAddr)
+		tx, err := e.callOnce(e.ownerNode, e.amID, "unmapETH", payload)
+		if err != nil {
+			t.Fatalf("unmapETH(paused) broadcast: %v", err)
+		}
+		ok, em := e.outResult(ctx, tx)
+		assertCase("pause/unmapETH-blocked", ok, em, false, "contract is paused")
+	}
+	if err := e.proposeExecute("unpause", "{}"); err != nil {
+		t.Fatalf("unpause: %v", err)
+	}
+	if err := pollUntil(ctx, 90*time.Second, func() bool {
+		m, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{"paused"})
+		// StateDeleteObject -> key absent -> read returns nil/empty.
+		return m == nil || m["paused"] == nil || fmt.Sprintf("%v", m["paused"]) == ""
+	}); err != nil {
+		t.Fatalf("unpause did not clear paused")
+	}
+	// After unpause, the SAME surface no longer hits the pause gate: an amount=0
+	// unmapETH now reaches (and is rejected by) the amount validator, proving
+	// calls flow again.
+	{
+		payload := fmt.Sprintf(`{"amount":"0","to":"%s"}`, vaultAddr)
+		tx, err := e.callOnce(e.ownerNode, e.amID, "unmapETH", payload)
+		if err != nil {
+			t.Fatalf("unmapETH(unpaused) broadcast: %v", err)
+		}
+		ok, em := e.outResult(ctx, tx)
+		if strings.Contains(em, "contract is paused") {
+			t.Fatalf("pause gate not lifted: %q", em)
+		}
+		assertCase("unpause/unmapETH-flows", ok, em, false, "invalid amount")
+	}
+
+	// =========================================================================
+	// CASE 2 — registerToken bounds (Operational timelock, validated in
+	// dispatchAdmin "registerToken").
+	// =========================================================================
+	const tokAddr = "0x1111111111111111111111111111111111111111"
+	tokKey := "t-1-" + strings.ToLower(strings.TrimPrefix(tokAddr, "0x")) // chainId()=1
+
+	// Reject: empty symbol.
+	{
+		inner := fmt.Sprintf(`{"address":"%s","symbol":"","decimals":6,"min_withdrawal":1000000}`, tokAddr)
+		ok, em := e.proposeExecuteResult("registerToken", inner)
+		assertCase("registerToken/empty-symbol", ok, em, false, "symbol empty or too long")
+	}
+	// Reject: symbol contains '|' (corrupts the pipe-delimited registry record).
+	{
+		inner := fmt.Sprintf(`{"address":"%s","symbol":"BA|D","decimals":6,"min_withdrawal":1000000}`, tokAddr)
+		ok, em := e.proposeExecuteResult("registerToken", inner)
+		assertCase("registerToken/pipe-symbol", ok, em, false, "symbol must not contain '|'")
+	}
+	// Reject: min_withdrawal negative.
+	{
+		inner := fmt.Sprintf(`{"address":"%s","symbol":"USDC","decimals":6,"min_withdrawal":-1}`, tokAddr)
+		ok, em := e.proposeExecuteResult("registerToken", inner)
+		assertCase("registerToken/min-negative", ok, em, false, "min_withdrawal out of range")
+	}
+	// Reject: min_withdrawal above MaxTokenMinWithdrawal (1e15) — admin DoS.
+	{
+		inner := fmt.Sprintf(`{"address":"%s","symbol":"USDC","decimals":6,"min_withdrawal":2000000000000000}`, tokAddr)
+		ok, em := e.proposeExecuteResult("registerToken", inner)
+		assertCase("registerToken/min-too-large", ok, em, false, "min_withdrawal out of range")
+	}
+	// Accept: a valid registration — assert the token state key is written
+	// (symbol|decimals|minWithdrawal).
+	{
+		inner := fmt.Sprintf(`{"address":"%s","symbol":"USDC","decimals":6,"min_withdrawal":1000000}`, tokAddr)
+		if err := e.proposeExecute("registerToken", inner); err != nil {
+			t.Fatalf("registerToken(valid): %v", err)
+		}
+		const wantRec = "USDC|6|1000000"
+		if err := pollUntil(ctx, 60*time.Second, func() bool {
+			m, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{tokKey})
+			return m != nil && m[tokKey] != nil && fmt.Sprintf("%v", m[tokKey]) == wantRec
+		}); err != nil {
+			m, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{tokKey})
+			t.Fatalf("registerToken(valid) not stored: %s=%v want=%q", tokKey, m[tokKey], wantRec)
+		}
+		total++
+		asserted++
+		t.Logf("[registerToken/valid] ACCEPTED — %s=%q", tokKey, wantRec)
+	}
+
+	// =========================================================================
+	// CASE 3 — setGasReserve bounds. The payload is the RAW decimal value
+	// string (dispatchAdmin does strconv.ParseInt(string(payload)...)), so the
+	// inner "JSON" is just the literal digits (no quotes, no braces).
+	// =========================================================================
+	// Reject: non-numeric value.
+	{
+		ok, em := e.proposeExecuteResult("setGasReserve", "not-a-number")
+		assertCase("setGasReserve/non-numeric", ok, em, false, "value must be a base-10 int64")
+	}
+	// Reject: above MaxGasReserve (1e18).
+	{
+		ok, em := e.proposeExecuteResult("setGasReserve", "2000000000000000000")
+		assertCase("setGasReserve/out-of-range", ok, em, false, "value out of range")
+	}
+	// Accept: a valid in-range gwei reserve — assert the gr state key is written.
+	{
+		const valid = "60000000" // 0.06 ETH in gwei, > MinGasReserve(5e7), < MaxGasReserve
+		if err := e.proposeExecute("setGasReserve", valid); err != nil {
+			t.Fatalf("setGasReserve(valid): %v", err)
+		}
+		if err := pollUntil(ctx, 60*time.Second, func() bool {
+			m, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{"gr"})
+			return m != nil && m["gr"] != nil && fmt.Sprintf("%v", m["gr"]) == valid
+		}); err != nil {
+			m, _ := e.d.GetStateByKeys(ctx, e.gqlNode, e.amID, []string{"gr"})
+			t.Fatalf("setGasReserve(valid) not stored: gr=%v want=%q", m["gr"], valid)
+		}
+		total++
+		asserted++
+		t.Logf("[setGasReserve/valid] ACCEPTED — gr=%q", valid)
+	}
+
+	// =========================================================================
+	// CASE 4 — unmapETH degenerate inputs (reject at the validation guards,
+	// which all fire BEFORE the "no block headers available"/balance checks).
+	// Owner-signed single broadcast (reverts before any state mutation).
+	// =========================================================================
+	// amount "0" -> "invalid amount".
+	{
+		payload := fmt.Sprintf(`{"amount":"0","to":"%s"}`, vaultAddr)
+		tx, err := e.callOnce(e.ownerNode, e.amID, "unmapETH", payload)
+		if err != nil {
+			t.Fatalf("unmapETH(amount=0): %v", err)
+		}
+		ok, em := e.outResult(ctx, tx)
+		assertCase("unmapETH/amount-zero", ok, em, false, "invalid amount")
+	}
+	// amount below MinETHWithdrawal (10_000_000 gwei) -> "below minimum ETH withdrawal".
+	{
+		payload := fmt.Sprintf(`{"amount":"5","to":"%s"}`, vaultAddr)
+		tx, err := e.callOnce(e.ownerNode, e.amID, "unmapETH", payload)
+		if err != nil {
+			t.Fatalf("unmapETH(below-min): %v", err)
+		}
+		ok, em := e.outResult(ctx, tx)
+		assertCase("unmapETH/below-minimum", ok, em, false, "below minimum ETH withdrawal")
+	}
+	// to == zero address (amount valid + >= min so we reach the zero-addr guard).
+	{
+		const zeroAddr = "0x0000000000000000000000000000000000000000"
+		payload := fmt.Sprintf(`{"amount":"20000000","to":"%s"}`, zeroAddr)
+		tx, err := e.callOnce(e.ownerNode, e.amID, "unmapETH", payload)
+		if err != nil {
+			t.Fatalf("unmapETH(zero-addr): %v", err)
+		}
+		ok, em := e.outResult(ctx, tx)
+		assertCase("unmapETH/zero-address", ok, em, false, "withdrawal to zero address rejected")
+	}
+
+	// =========================================================================
+	// CASE 5 — map degenerate inputs.
+	// =========================================================================
+	// Unknown deposit_type -> switch default. Vault is set (above) so HandleMap
+	// reaches the type switch; a non-relayer caller still reaches default
+	// because the relayer gate lives only inside the "eth" case.
+	{
+		payload := `{"tx_data":{"block_height":1,"tx_index":0,"raw_hex":"00","merkle_proof_hex":"00","deposit_type":"bogus"},"instructions":[]}`
+		tx, err := e.callOnce(e.ownerNode, e.amID, "map", payload)
+		if err != nil {
+			t.Fatalf("map(bad-type): %v", err)
+		}
+		ok, em := e.outResult(ctx, tx)
+		assertCase("map/bad-deposit-type", ok, em, false, "deposit_type must be")
+	}
+	// eth deposit by a NON-whitelisted relayer (we never registerRelayer the
+	// owner) -> rejected at the relayer gate, BEFORE any proof verification.
+	{
+		payload := `{"tx_data":{"block_height":1,"tx_index":0,"raw_hex":"00","merkle_proof_hex":"00","deposit_type":"eth"},"instructions":[]}`
+		tx, err := e.callOnce(e.ownerNode, e.amID, "map", payload)
+		if err != nil {
+			t.Fatalf("map(non-relayer-eth): %v", err)
+		}
+		ok, em := e.outResult(ctx, tx)
+		assertCase("map/non-relayer-eth", ok, em, false, "not a whitelisted relayer")
+	}
+
+	t.Logf("W6Neg PASS — admin bounds + negative matrix: %d/%d cases asserted "+
+		"[pause-blocked, unpause-flows, registerToken{empty,pipe,min<0,min>max,valid}, "+
+		"setGasReserve{non-numeric,out-of-range,valid}, unmapETH{amount0,below-min,zero-addr}, "+
+		"map{bad-type,non-relayer-eth}]", asserted, total)
+}
+
+// outResult reads a tx's contract-output (ok, errMsg). It first reads the
+// indexed findContractOutput{ret,ok} (the abort message lands in `ret`), and
+// falls back to the raw output DAG (getDagByCID -> results[].errMsg) per the
+// dumpMapErr pattern so the specific reject string is recoverable even if the
+// indexed `ret` is empty. Polls until an output is observed (the contract call
+// is a separate L1 tx that lands a block or two later).
+func (e *evmBridgeEnv) outResult(ctx context.Context, txID string) (bool, string) {
+	var ok, found bool
+	var msg string
+	// The raw DAG (getDagByCID) is the ground truth: results[].ret is written
+	// atomically with the block and carries the revert/abort message (host
+	// `revert` import → WasmResultStruct.Error → transactions.go Ret). The
+	// indexed `findContractOutput.ret` resolver lags/empties for reverts under
+	// parallel load, so we PREFER the DAG and only fall back to the index. For a
+	// reject (ok=false) we keep polling until the message is non-empty, so a
+	// transient empty read never wins (which previously made a rejected call look
+	// like it had no reason string).
+	_ = pollUntil(ctx, 5*time.Minute, func() bool {
+		// Primary: raw DAG — has both ret and errMsg for the stored result.
+		if o, e2 := e.outResultViaDAG(ctx, txID); e2 {
+			ok, found = o.ok, true
+			if o.msg != "" {
+				msg = o.msg
+			}
+			// Accept once we have a usable signal: success, or a reject WITH a
+			// reason. Keep polling a reject that still has no reason (indexing
+			// race) until the message lands or we time out.
+			if ok || msg != "" {
+				return true
+			}
+		}
+		// Fallback: indexed contract output keyed by the input tx id.
+		const q = `query($id:String!){findContractOutput(filterOptions:{byInput:$id}){results{ret ok}}}`
+		var out struct {
+			FindContractOutput []struct {
+				Results []struct {
+					Ret string `json:"ret"`
+					Ok  bool   `json:"ok"`
+				} `json:"results"`
+			} `json:"findContractOutput"`
+		}
+		if err := e.d.gqlQuery(ctx, e.gqlNode, q, map[string]any{"id": txID}, &out); err == nil {
+			for _, o := range out.FindContractOutput {
+				for _, r := range o.Results {
+					ok, found = r.Ok, true
+					if r.Ret != "" {
+						msg = r.Ret
+					}
+					if ok || msg != "" {
+						return true
+					}
+				}
+			}
+		}
+		return false
+	})
+	if !found {
+		e.t.Logf("WARN: no contract output observed for tx %s within timeout", txID)
+	} else if !ok && msg == "" {
+		e.t.Logf("WARN: tx %s rejected (ok=false) but no reason string observed within timeout", txID)
+	}
+	return ok, msg
+}
+
+type dagOut struct {
+	ok  bool
+	msg string
+}
+
+// outResultViaDAG reads the raw contract-output DAG for a tx and returns the
+// first result's (ok, message). The getDagByCID resolver may hand back the
+// output either as a JSON object OR as a JSON-encoded string, so we capture it
+// as `any` (like the proven txOutputMsg), re-marshal to bytes, and parse a
+// typed view. message = errMsg, else ret; if BOTH are empty (e.g. a panic-path
+// abort that lands the text in an unexpected field, or a different contract's
+// output shape), we fall back to the WHOLE stringified blob so a downstream
+// strings.Contains can still find the reason string. This is what made the ZK
+// verifier reject paths (a separate contract) extractable.
+func (e *evmBridgeEnv) outResultViaDAG(ctx context.Context, txID string) (dagOut, bool) {
+	const q = `query($id:String!){findTransaction(filterOptions:{byId:$id}){output{id}}}`
+	var out struct {
+		FindTransaction []struct {
+			Output []struct {
+				Id string `json:"id"`
+			} `json:"output"`
+		} `json:"findTransaction"`
+	}
+	if err := e.d.gqlQuery(ctx, e.gqlNode, q, map[string]any{"id": txID}, &out); err != nil {
+		return dagOut{}, false
+	}
+	for _, tx := range out.FindTransaction {
+		for _, o := range tx.Output {
+			const dq = `query($c:String!){getDagByCID(cidString:$c)}`
+			var dout struct {
+				GetDagByCID any `json:"getDagByCID"`
+			}
+			if err := e.d.gqlQuery(ctx, e.gqlNode, dq, map[string]any{"c": o.Id}, &dout); err != nil {
+				continue
+			}
+			if dout.GetDagByCID == nil {
+				continue
+			}
+			// Re-marshal the untyped value, then parse a typed view. If the value
+			// was a JSON string, unmarshal it once more to reach the object.
+			rawBytes, _ := json.Marshal(dout.GetDagByCID)
+			var parsed struct {
+				Results []struct {
+					Ok     bool   `json:"ok"`
+					Ret    string `json:"ret"`
+					ErrMsg string `json:"errMsg"`
+					Err    string `json:"err"`
+				} `json:"results"`
+			}
+			if json.Unmarshal(rawBytes, &parsed); len(parsed.Results) == 0 {
+				// value may itself be a quoted JSON string
+				var inner string
+				if json.Unmarshal(rawBytes, &inner) == nil && inner != "" {
+					_ = json.Unmarshal([]byte(inner), &parsed)
+				}
+			}
+			rawBlob := fmt.Sprintf("%v", dout.GetDagByCID) + " " + string(rawBytes)
+			if len(parsed.Results) > 0 {
+				r := parsed.Results[0]
+				msg := r.ErrMsg
+				if msg == "" {
+					msg = r.Ret
+				}
+				if msg == "" && !r.Ok {
+					msg = rawBlob // fallback: whole blob, substring-matchable
+				}
+				return dagOut{ok: r.Ok, msg: msg}, true
+			}
+			// Couldn't parse results at all — return the raw blob so the caller
+			// can still substring-match; treat as a reject (ok=false) only if the
+			// blob shows a failure marker.
+			lc := strings.ToLower(rawBlob)
+			ok := !strings.Contains(lc, `"ok":false`) && !strings.Contains(lc, `"err"`)
+			return dagOut{ok: ok, msg: rawBlob}, true
+		}
+	}
+	return dagOut{}, false
+}
+
+// proposeExecuteResult runs an owner admin action through the short (devnet)
+// timelock like proposeExecute, but captures the EXECUTE tx id and returns its
+// contract-output (ok, errMsg) so a dispatchAdmin reject (the bounds checks
+// fire inside execute()) can be asserted. payloadJSON is the action's inner
+// payload, hex-encoded into payload_hex.
+func (e *evmBridgeEnv) proposeExecuteResult(action, payloadJSON string) (bool, string) {
+	d := e.d
+	payloadHex := hex.EncodeToString([]byte(payloadJSON))
+	if _, err := d.CallContract(e.ctx, e.ownerNode, e.amID, "propose",
+		fmt.Sprintf(`{"action":"%s","payload_hex":"%s"}`, action, payloadHex)); err != nil {
+		e.t.Fatalf("propose %s: %v", action, err)
+	}
+	id := e.propID
+	e.propID++
+	lb, _, err := d.LocalNodeInfo(e.ctx, e.gqlNode)
+	if err != nil {
+		e.t.Fatalf("node info: %v", err)
+	}
+	if err := d.WaitForBlockProcessing(e.ctx, e.gqlNode, lb+12, 6*time.Minute); err != nil {
+		e.t.Fatalf("await timelock %s: %v", action, err)
+	}
+	execTx, err := d.CallContract(e.ctx, e.ownerNode, e.amID, "execute", fmt.Sprintf(`{"proposal_id":%d}`, id))
+	if err != nil {
+		e.t.Fatalf("execute %s broadcast: %v", action, err)
+	}
+	return e.outResult(e.ctx, execTx)
+}

--- a/tests/devnet/evm_bridge_wmock_devnet_test.go
+++ b/tests/devnet/evm_bridge_wmock_devnet_test.go
@@ -1,0 +1,325 @@
+//go:build evm_devnet
+
+// W-MOCK — foundation test for the L1 bridge waves (W1/W2/W3) under the
+// "proof is Milo's" scope. Validates the TWO new test-harness mechanisms on a
+// real 5-node devnet, BEFORE the heavier bot/anvil deposit pipeline:
+//
+//   (1) Short-timelock devnet build of account-mapping (build tag
+//       devnet_fasttimelock, TimelockLong=5) lets setVerifierContract be
+//       bootstrapped within the devnet's block budget. ASSERT: after
+//       propose -> wait -> execute, account-mapping's "zkverifier" state key
+//       == the mock verifier id (the 400K-block timelock would make this
+//       impossible). Production 400K timelock is unchanged + tested separately.
+//
+//   (2) Mock ZK header verifier (devSetHeader) plants a header with the REAL,
+//       independently-verified roots of Sepolia block 10764834 (the 2026-05-01
+//       testnet-verified header) in the EXACT 137-byte layout the real
+//       zk-review6 verifier's storeHeader produces. ASSERT: the mock's
+//       b-10764834 state == the expected byte-exact header; h == "10764834".
+//
+// Cross-contract CONSUMPTION of the header (deposit credit / withdrawal
+// close-out / double-spend) is proven in the W1/W2/W3 waves that build on this.
+//
+// Run: go test -tags evm_devnet -run TestEVMBridge_WMock ./tests/devnet/ -timeout 40m -v
+package devnet
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	// account-mapping med/am-review6, built WITH -tags devnet_fasttimelock (short timelock).
+	evmBridgeWasmDevnet = "/home/clauderfly/r6-wt/account-mapping/evm-mapping-contract/bin/main-devnet.wasm"
+	// mock ZK header verifier (test double) — zk-review6 worktree.
+	mockVerifierWasm = "/home/clauderfly/r6-wt/zk-header-verifier/bin/mock-verifier.wasm"
+)
+
+// REAL verified header — Sepolia block 10764834 (REAL-VERIFIED-HEADER-10764834.md):
+// pulled byte-exact from testnet verifier b-10764834 AND re-verified vs Sepolia RPC.
+const (
+	hdrBlockNumber = uint64(10764834)
+	hdrStateRoot   = "6efab94327bc2fd7eae04922c44be6be72f4e9f402410df10131be20870dc15e"
+	hdrTxRoot      = "c0411a58e6d4ef53b9ac5bda11a6673ed0773e3716e1a1172a152d79819a592b"
+	hdrRcptRoot    = "a57f50e0b81cee33609c2472b9bc9a83d6565d8b8042327f3e39665409737df5"
+	hdrBaseFee     = uint64(464667)
+	hdrGasLimit    = uint64(60000000)
+	hdrTimestamp   = uint64(1777587936)
+	hdrChainId     = uint64(11155111)
+)
+
+// expectedHeaderHex = the 137-byte review6 layout (version 0x01 + fields + chainId),
+// exactly what zk-review6 storeHeader writes and review6 DeserializeHeader reads.
+func expectedHeaderHex() string {
+	u64 := func(v uint64) string { b := make([]byte, 8); for i := 0; i < 8; i++ { b[7-i] = byte(v >> (8 * i)) }; return hex.EncodeToString(b) }
+	return "01" + u64(hdrBlockNumber) + hdrStateRoot + hdrTxRoot + hdrRcptRoot +
+		u64(hdrBaseFee) + u64(hdrGasLimit) + u64(hdrTimestamp) + u64(hdrChainId)
+}
+
+// callRet reads the contract-output result (ret message + ok) for a tx id —
+// the actual contract-level abort message that tx status ("FAILED") hides.
+func (d *Devnet) callRet(ctx context.Context, node int, txId string) (string, bool, bool) {
+	const q = `query($id:String!){findContractOutput(filterOptions:{byInput:$id}){results{ret ok}}}`
+	var out struct {
+		FindContractOutput []struct {
+			Results []struct {
+				Ret string `json:"ret"`
+				Ok  bool   `json:"ok"`
+			} `json:"results"`
+		} `json:"findContractOutput"`
+	}
+	if err := d.gqlQuery(ctx, node, q, map[string]any{"id": txId}, &out); err != nil {
+		return "", false, false
+	}
+	for _, o := range out.FindContractOutput {
+		for _, r := range o.Results {
+			return r.Ret, r.Ok, true
+		}
+	}
+	return "", false, false
+}
+
+// getStateHex reads a contract state key as hex (binary-safe, unlike the
+// UTF-8-decoding GetStateByKeys helper).
+func (d *Devnet) getStateHex(ctx context.Context, node int, contractId, key string) (string, error) {
+	const q = `query($c:String!,$k:[String!]!){getStateByKeys(contractId:$c,keys:$k,encoding:"hex")}`
+	var out struct {
+		GetStateByKeys map[string]any `json:"getStateByKeys"`
+	}
+	if err := d.gqlQuery(ctx, node, q, map[string]any{"c": contractId, "k": []string{key}}, &out); err != nil {
+		return "", err
+	}
+	if v, ok := out.GetStateByKeys[key]; ok && v != nil {
+		return strings.TrimPrefix(fmt.Sprintf("%v", v), "0x"), nil
+	}
+	return "", nil
+}
+
+func TestEVMBridge_WMock_HeaderInjection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("devnet")
+	}
+	requireDocker(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Minute)
+	t.Cleanup(cancel)
+
+	cfg := regressionConfig()
+	cfg.Nodes = 5
+	cfg.GenesisNode = 5
+	cfg.SysConfigOverrides.ConsensusParams.ElectionInterval = 20
+	cfg.SysConfigOverrides.ConsensusParams.BondInclusionActivationHeight = 0
+	cfg.GQLBasePort = 38080
+	cfg.P2PBasePort = 31720
+	cfg.MongoPort = 38057
+	cfg.HivePort = 38091
+	cfg.DronePort = 39000
+	cfg.BitcoindRPCPort = 38543
+	cfg.DashdRPCPort = 39898
+
+	d, err := New(cfg)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	t.Cleanup(func() { d.Stop() })
+	if err := d.Start(ctx); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	const ownerNode = 1 // deployer == contract.owner == magi.test1; owner ops sign as node 1
+	const gqlNode = 2
+	ownerAcct := "hive:" + fmt.Sprintf("%s%d", cfg.WitnessPrefix, ownerNode)
+
+	// RC bootstrap: the owner witness starts with only the ~10k free RC, whose
+	// gas budget (gas=min(availableGas,rc_limit) * CYCLE_GAS_PER_RC) is too small
+	// for the heavier admin calls — `execute` does a full LoadProposal
+	// JSON-unmarshal + dispatch and hit gas_limit_hit ("cost limit exceeded").
+	// Deposit HBD into the owner's L2 ledger so CanConsume sees real RC. Broadcast
+	// now; it credits via the gateway during the deploys (waited on below).
+	if _, err := d.Deposit(ctx, ownerNode, "5000.000", "hbd"); err != nil {
+		t.Fatalf("RC bootstrap deposit: %v", err)
+	}
+
+	// 1) Deploy the short-timelock account-mapping + init.
+	amId, err := d.DeployContract(ctx, ContractDeployOpts{WasmPath: evmBridgeWasmDevnet, Name: "evm-bridge-mockwire", DeployerNode: ownerNode, GQLNode: gqlNode})
+	if err != nil {
+		t.Fatalf("deploy account-mapping(devnet): %v", err)
+	}
+	t.Logf("account-mapping (devnet build): %s", amId)
+	dumpState := func(label, cid string, keys ...string) {
+		m, e := d.GetStateByKeys(ctx, gqlNode, cid, keys)
+		t.Logf("STATE[%s] %v (err=%v)", label, m, e)
+	}
+	logTx := func(label, txId string) {
+		if txId == "" {
+			t.Logf("TX[%s] empty txId", label)
+			return
+		}
+		var st string
+		_ = pollUntil(ctx, 90*time.Second, func() bool {
+			st, _ = d.FindTransactionStatus(ctx, gqlNode, txId)
+			return st != "" && st != "UNCONFIRMED" && st != "INCLUDED"
+		})
+		// also fetch the contract-output ret (the real abort message)
+		var ret string
+		var ok, found bool
+		_ = pollUntil(ctx, 30*time.Second, func() bool {
+			ret, ok, found = d.callRet(ctx, gqlNode, txId)
+			return found
+		})
+		t.Logf("TX[%s] id=%s status=%q ok=%v ret=%q", label, txId, st, ok, ret)
+	}
+	// dumpTxDag reads the raw contract-output DAG for a tx (the un-hidden
+	// error message that findContractOutput.ret strips — getDagByCID per
+	// feedback_check_raw_dag_errors).
+	dumpTxDag := func(label, txId string) {
+		const q = `query($id:String!){findTransaction(filterOptions:{byId:$id}){id status output{id}}}`
+		var out struct {
+			FindTransaction []struct {
+				Id     string `json:"id"`
+				Status string `json:"status"`
+				Output []struct {
+					Id string `json:"id"`
+				} `json:"output"`
+			} `json:"findTransaction"`
+		}
+		if err := d.gqlQuery(ctx, gqlNode, q, map[string]any{"id": txId}, &out); err != nil {
+			t.Logf("DAG[%s] tx query err: %v", label, err)
+			return
+		}
+		for _, tx := range out.FindTransaction {
+			t.Logf("DAG[%s] tx=%s status=%s outputs=%d", label, tx.Id, tx.Status, len(tx.Output))
+			for _, o := range tx.Output {
+				const dq = `query($c:String!){getDagByCID(cidString:$c)}`
+				var dout struct {
+					GetDagByCID any `json:"getDagByCID"`
+				}
+				if err := d.gqlQuery(ctx, gqlNode, dq, map[string]any{"c": o.Id}, &dout); err != nil {
+					t.Logf("DAG[%s] getDagByCID(%s) err: %v", label, o.Id, err)
+					continue
+				}
+				b, _ := json.Marshal(dout.GetDagByCID)
+				t.Logf("DAG[%s] output %s = %s", label, o.Id, string(b))
+			}
+		}
+	}
+
+	// Wait for the RC-bootstrap deposit to credit the owner's L2 HBD before any
+	// owner contract-call (which need the gas budget it provides).
+	if err := pollUntil(ctx, 7*time.Minute, func() bool {
+		bal, e := d.GetAccountBalance(ctx, gqlNode, ownerAcct)
+		return e == nil && bal != nil && bal.Hbd >= 4_000_000
+	}); err != nil {
+		bal, _ := d.GetAccountBalance(ctx, gqlNode, ownerAcct)
+		t.Fatalf("RC-bootstrap HBD deposit never credited %s (hbd=%v) — gateway deposit path may be down", ownerAcct, func() any { if bal != nil { return bal.Hbd }; return nil }())
+	}
+	t.Logf("RC bootstrap: %s L2 HBD credited — gas budget raised for owner calls", ownerAcct)
+
+	initTx, err := d.CallContract(ctx, ownerNode, amId, "initContract", `{"is_testnet":true}`)
+	if err != nil {
+		t.Fatalf("initContract broadcast: %v", err)
+	}
+	logTx("initContract", initTx)
+	dumpState("am.init-marker", amId, "init") // expect "1" iff init's owner check PASSED
+
+	// 2) Deploy the mock verifier + init (sets is_testnet sentinel for devSetHeader).
+	mockId, err := d.DeployContract(ctx, ContractDeployOpts{WasmPath: mockVerifierWasm, Name: "mock-zk-verifier", DeployerNode: ownerNode, GQLNode: gqlNode})
+	if err != nil {
+		t.Fatalf("deploy mock verifier: %v", err)
+	}
+	t.Logf("mock verifier: %s", mockId)
+	mockInitTx, err := d.CallContract(ctx, ownerNode, mockId, "init", `{}`)
+	if err != nil {
+		t.Fatalf("mock init broadcast: %v", err)
+	}
+	logTx("mock.init", mockInitTx)
+	dumpState("mock.is_testnet", mockId, "is_testnet")
+
+	// 3) Bootstrap wiring: propose -> wait > TimelockLong(5) -> execute setVerifierContract.
+	payloadHex := hex.EncodeToString([]byte(fmt.Sprintf(`{"contract_id":"%s"}`, mockId)))
+	proposeTx, err := d.CallContract(ctx, ownerNode, amId, "propose",
+		fmt.Sprintf(`{"action":"setVerifierContract","payload_hex":"%s"}`, payloadHex))
+	if err != nil {
+		t.Fatalf("propose broadcast: %v", err)
+	}
+	logTx("propose", proposeTx)
+	// Diagnostic: did propose create proposal pr-1? (counter -> "2", pr-1 -> JSON with exec_height)
+	if err := pollUntil(ctx, 90*time.Second, func() bool {
+		m, _ := d.GetStateByKeys(ctx, gqlNode, amId, []string{"pr-1"})
+		return m != nil && m["pr-1"] != nil && fmt.Sprintf("%v", m["pr-1"]) != ""
+	}); err != nil {
+		t.Logf("WARN: proposal pr-1 not present after propose (propose likely aborted — owner/payload)")
+	}
+	dumpState("am.proposal", amId, "proposal_next_id", "pr-1")
+
+	lb, _, err := d.LocalNodeInfo(ctx, gqlNode)
+	if err != nil {
+		t.Fatalf("node info: %v", err)
+	}
+	// TimelockLong=5 in the devnet build; wait a generous margin past it.
+	if err := d.WaitForBlockProcessing(ctx, gqlNode, lb+12, 8*time.Minute); err != nil {
+		t.Fatalf("waiting out timelock: %v", err)
+	}
+	executeTx, err := d.CallContract(ctx, ownerNode, amId, "execute", `{"proposal_id":1}`)
+	if err != nil {
+		t.Fatalf("execute broadcast: %v", err)
+	}
+	logTx("execute", executeTx)
+
+	// ASSERT (1): account-mapping is now wired to the mock verifier.
+	if err := pollUntil(ctx, 60*time.Second, func() bool {
+		m, e := d.GetStateByKeys(ctx, gqlNode, amId, []string{"zkverifier"})
+		return e == nil && m != nil && fmt.Sprintf("%v", m["zkverifier"]) == mockId
+	}); err != nil {
+		dumpState("am.FINAL", amId, "init", "proposal_next_id", "pr-1", "zkverifier")
+		dumpTxDag("execute", executeTx) // raw output DAG = the real abort message
+		dumpTxDag("propose", proposeTx)
+		t.Fatalf("setVerifierContract did not take effect (short-timelock wiring FAILED) — see DAG[execute] above for the real abort. want zkverifier=%s", mockId)
+	}
+	t.Logf("WIRED: account-mapping zkverifier == %s (short-timelock devnet build bootstrapped the 400K-gated setVerifierContract)", mockId)
+
+	// 4) Plant the REAL verified header via devSetHeader (no proof).
+	plant := fmt.Sprintf(`{"block_number":%d,"state_root":"%s","tx_root":"%s","receipts_root":"%s","base_fee":%d,"gas_limit":%d,"timestamp":%d,"chain_id":%d}`,
+		hdrBlockNumber, hdrStateRoot, hdrTxRoot, hdrRcptRoot, hdrBaseFee, hdrGasLimit, hdrTimestamp, hdrChainId)
+	if _, err := d.CallContract(ctx, ownerNode, mockId, "devSetHeader", plant); err != nil {
+		t.Fatalf("devSetHeader: %v", err)
+	}
+
+	// ASSERT (2): the mock stored the byte-exact real header at b-10764834, h=10764834.
+	want := expectedHeaderHex()
+	if err := pollUntil(ctx, 3*time.Minute, func() bool {
+		got, e := d.getStateHex(ctx, gqlNode, mockId, "b-10764834")
+		return e == nil && strings.EqualFold(got, want)
+	}); err != nil {
+		got, _ := d.getStateHex(ctx, gqlNode, mockId, "b-10764834")
+		t.Fatalf("planted header mismatch:\n got=%s\nwant=%s", got, want)
+	}
+	hMap, _ := d.GetStateByKeys(ctx, gqlNode, mockId, []string{"h"})
+	t.Logf("PLANTED: mock b-10764834 == real verified header (137B, byte-exact); h=%v", hMap["h"])
+
+	t.Logf("W-MOCK PASS — short-timelock devnet wiring + real-header injection both work on devnet. " +
+		"Foundation for W1/W2/W3 (deposit / withdrawal close-out / double-spend) is validated.")
+}
+
+// pollUntil retries fn every 3s until true or timeout.
+func pollUntil(ctx context.Context, timeout time.Duration, fn func() bool) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if fn() {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("condition not met within %s", timeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(3 * time.Second):
+		}
+	}
+}

--- a/tests/devnet/evm_bridge_zk_devnet_test.go
+++ b/tests/devnet/evm_bridge_zk_devnet_test.go
@@ -1,0 +1,216 @@
+//go:build evm_devnet
+
+// W-ZK — runtime proof of the REAL zk-review6 header verifier's INPUT-VALIDATION
+// reject paths on a 5-node devnet.
+//
+// Scope: this test deploys the REAL `zk-header-verifier` contract (built from
+// med/zk-review6 contract/main.go via the pinned tinygo Makefile, bin/main.wasm)
+// and proves that submitProof REJECTS malformed / fake submissions at runtime,
+// BEFORE the expensive Sp1VerifyGroth16 host pairing check where it can. It does
+// NOT attempt the ACCEPT path — a valid SP1 proof is Milo's GPU prover and is
+// explicitly OUT OF SCOPE here (no real proof is constructed or asserted).
+//
+// Reject paths proven (each a distinct abort in submitProof, contract/main.go):
+//
+//   (a) #85 shape gate (main.go:361-363) — the cheap pre-verify guard:
+//         len(public_values)%2 != 0  ||  len(public_values) < PvMinLenWithChainId*2 (=832)
+//       => "public_values too short or odd-length hex".
+//       Tested with an odd-length hex ("abc") and a too-short even hex ("00").
+//
+//   (b) fake/zero proof (main.go:315-369) — a correctly-SHAPED but bogus
+//       submission (832 hex zeros = 416 zero bytes) clears the shape gate, then
+//       fails the host Sp1VerifyGroth16 ("proof verification failed"). This is
+//       the residual-DoS case the shape gate intentionally cannot stop (only the
+//       host pairing check distinguishes a valid proof from correctly-sized
+//       garbage). The chainId-binding check (main.go:397-399) sits AFTER the
+//       groth16 verify, so a fake proof can never reach it — we assert ok==false
+//       (either reject is a valid rejection of a fake proof).
+//
+//   (c) required-fields gate (main.go:315-317):
+//         proof=="" || public_values=="" || len(headers)==0
+//       => "proof, public_values, and headers required". Tested with empty proof.
+//
+// The shape gate / required-fields gate run BEFORE any host call, so the proof
+// bytes are irrelevant for (a)/(c); for (b) the host is reached and fails on
+// garbage. readRLPLen (#65, main.go:635) is the header-side length cap; it is
+// only reachable AFTER a successful groth16 verify + chainId match (header
+// parsing begins at main.go:423), so it cannot be exercised without Milo's real
+// proof and is documented here as out-of-scope-for-runtime (covered by the
+// contract's own Go unit tests).
+//
+// Run: go test -tags evm_devnet -run TestEVMBridge_ZK_VerifierRejectPaths ./tests/devnet/ -timeout 40m -v
+package devnet
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	// REAL zk-review6 header verifier, built from contract/main.go via the
+	// pinned tinygo Makefile (docker tinygo/tinygo:0.41.1 @sha256:b216f534...):
+	//   cd /home/clauderfly/r6-wt/zk-header-verifier && make build
+	// produces bin/main.wasm (the load-bearing artifact for this test).
+	zkVerifierWasm = "/home/clauderfly/r6-wt/zk-header-verifier/bin/main.wasm"
+
+	// v6.1.0 SP1 init values (GPU-PROVER-SETUP.md). groth16_vk is NOT required
+	// to be the real circuit VK for the reject-path test: every reject case
+	// aborts BEFORE (a/c) or AT (b) the host verify, and the host treats the VK
+	// as opaque bytes — a non-empty placeholder satisfies the init non-empty
+	// guard (main.go:123) and the not-initialized guard (main.go:323-334). The
+	// real VK only matters for the ACCEPT path, which is Milo's (out of scope).
+	zkSp1VkeyHash = "00f701535d87c17492e85e1b32649f2578a4e02e7e314401c726af21bba2523d"
+	zkVkRoot      = "002f850ee998974d6cc00e50cd0814b098c05bfade466d28573240d057f25352"
+	// Non-empty placeholder groth16_vk (real binary VK is Milo's; only the
+	// accept path consumes it). 64 hex chars of a recognizable sentinel.
+	zkGroth16VkPlaceholder = "00f701535d87c17492e85e1b32649f2578a4e02e7e314401c726af21bba2523d"
+
+	// Anchor + chain binding for init. initial_block_hash must be 0x + 64 hex
+	// (main.go:184 looksLikeBlockHash), initial_height non-zero (main.go:131),
+	// expected_chain_id non-zero (main.go:142). Sepolia = 11155111.
+	zkInitialBlockHash = "0x00000000000000000000000000000000000000000000000000000000000000ab"
+	zkExpectedChainId  = 11155111
+)
+
+// TestEVMBridge_ZK_VerifierRejectPaths deploys the REAL zk-review6 header
+// verifier and proves its input-validation reject paths at runtime. The accept
+// path (a valid SP1 proof) is Milo's and is OUT OF SCOPE.
+func TestEVMBridge_ZK_VerifierRejectPaths(t *testing.T) {
+	if testing.Short() {
+		t.Skip("devnet")
+	}
+	t.Parallel()
+	requireDocker(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Minute)
+	defer cancel()
+
+	// Foundation: running 5-node devnet with the owner (node 1) RC-bootstrapped.
+	// We reuse the validated bridge setup (it deploys account-mapping + mock and
+	// credits the owner) and then deploy the REAL verifier on top.
+	e := setupEvmBridgeDevnet(t, ctx)
+
+	// Deploy the REAL zk-review6 verifier (bin/main.wasm) as a fresh contract.
+	// Use deployWithRetry — the contract-deployer's storage-proof request can
+	// transiently time out under I/O pressure on a constrained box.
+	verifierID, err := deployWithRetry(ctx, e.d, ContractDeployOpts{
+		WasmPath:     zkVerifierWasm,
+		Name:         "zk-header-verifier",
+		DeployerNode: e.ownerNode,
+		GQLNode:      e.gqlNode,
+	}, 3)
+	if err != nil {
+		t.Fatalf("deploy zk verifier: %v", err)
+	}
+	t.Logf("zk verifier deployed: %s", verifierID)
+
+	// --- init the verifier (owner = deployer node) ---
+	// All-required fields per InitContractParams (main.go:89-101). The owner is
+	// node 1 (the deployer), so the checkOwner() gate (main.go:105) passes.
+	initPayload := fmt.Sprintf(
+		`{"groth16_vk":"%s","vk_root":"%s","sp1_vkey_hash":"%s","max_retention":10000,"initial_height":1,"initial_block_hash":"%s","is_testnet":true,"expected_chain_id":%d}`,
+		zkGroth16VkPlaceholder, zkVkRoot, zkSp1VkeyHash, zkInitialBlockHash, zkExpectedChainId,
+	)
+	initTx, err := e.callOnce(e.ownerNode, verifierID, "init", initPayload)
+	if err != nil {
+		t.Fatalf("init zk verifier broadcast: %v", err)
+	}
+	// Assert init succeeded by observing the KeyGroth16Vk ("vk") state key land.
+	if err := pollUntil(ctx, 3*time.Minute, func() bool {
+		m, _ := e.d.GetStateByKeys(ctx, e.gqlNode, verifierID, []string{"vk"})
+		return m != nil && m["vk"] != nil && fmt.Sprintf("%v", m["vk"]) != ""
+	}); err != nil {
+		dumpMapErr(t, e, ctx, initTx)
+		t.Fatalf("zk verifier init did not install vk state (init tx %s)", initTx)
+	}
+	// Also confirm the bound chainId ("cid") and anchor ("lbh") were set, so we
+	// know the contract is in the fully-initialized state that submitProof's
+	// guards expect (otherwise a reject could be a not-initialized false pass).
+	if m, _ := e.d.GetStateByKeys(ctx, e.gqlNode, verifierID, []string{"cid", "lbh"}); m != nil {
+		t.Logf("zk verifier initialized: vk set, cid=%v lbh=%v", m["cid"], m["lbh"])
+	}
+
+	// zkSubmit broadcasts a single submitProof call (non-idempotent path; no
+	// retry) and returns its tx id.
+	zkSubmit := func(proof, publicValues, headersJSON string) (string, error) {
+		payload := fmt.Sprintf(`{"proof":"%s","public_values":"%s","headers":%s}`, proof, publicValues, headersJSON)
+		return e.callOnce(e.ownerNode, verifierID, "submitProof", payload)
+	}
+
+	// assertReject submits a malformed/fake proof and asserts the contract
+	// REJECTED it (ok==false). If wantSubstrs is non-empty, at least one must
+	// appear in the reject message (the abort string surfaced via the contract
+	// output DAG). The contract-output read reuses the validated outResult
+	// helper (findContractOutput.ret, falling back to the raw output DAG ->
+	// results[].{ok,errMsg,ret}) — the same walk as zkOutMsg in the task brief.
+	assertReject := func(label, proof, pv, headersJSON string, wantSubstrs ...string) {
+		t.Helper()
+		tx, err := zkSubmit(proof, pv, headersJSON)
+		if err != nil {
+			t.Fatalf("[%s] submitProof broadcast: %v", label, err)
+		}
+		ok, msg := e.outResult(ctx, tx)
+		if ok {
+			t.Fatalf("[%s] submitProof was ACCEPTED (ok=true) — expected reject; msg=%q tx=%s", label, msg, tx)
+		}
+		if len(wantSubstrs) > 0 {
+			matched := false
+			for _, s := range wantSubstrs {
+				if strings.Contains(msg, s) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				t.Fatalf("[%s] rejected (ok=false) but message %q did not contain any of %v (tx=%s)", label, msg, wantSubstrs, tx)
+			}
+		}
+		t.Logf("[%s] REJECTED ok=false msg=%q", label, msg)
+	}
+
+	const headersOne = `[{"rlp_hex":"00"}]`
+
+	// (a) #85 shape gate — odd-length hex public_values.
+	//     proof + headers non-empty so the required-fields gate (b/c order) is
+	//     passed; "abc" (len 3, odd) trips the shape gate at main.go:361.
+	assertReject("shape-gate/odd-length", "00", "abc", headersOne,
+		"public_values too short or odd-length hex")
+
+	// (a) #85 shape gate — too-short (even) hex public_values.
+	//     "00" (len 2, even, < 832) trips the same gate.
+	assertReject("shape-gate/too-short", "00", "00", headersOne,
+		"public_values too short or odd-length hex")
+
+	// (b) fake/zero proof — 832 hex zeros (416 zero bytes) clears the shape gate
+	//     (832 == PvMinLenWithChainId*2, even), then fails the host
+	//     Sp1VerifyGroth16 with garbage => "proof verification failed". The
+	//     chainId-binding check (main.go:397) is AFTER the host verify, so a fake
+	//     proof can never reach it; either reject (verify-fail OR chainId) is a
+	//     valid rejection of a fake proof. We accept either substring.
+	zeroPv := strings.Repeat("0", PvMinLenWithChainIdHexLen) // 832 '0' chars
+	assertReject("fake-proof/zero-pv", "00", zeroPv, headersOne,
+		"proof verification failed", "does not match verifier's bound chainId")
+
+	// (c) required-fields gate — empty proof (main.go:315-317).
+	assertReject("required-fields/empty-proof", "", zeroPv, headersOne,
+		"proof, public_values, and headers required")
+
+	// (c) required-fields gate — empty headers array.
+	assertReject("required-fields/empty-headers", "00", zeroPv, `[]`,
+		"proof, public_values, and headers required")
+
+	t.Log("ZK PASS — verifier reject paths: " +
+		"shape-gate(odd-length + too-short) rejected with 'public_values too short or odd-length hex'; " +
+		"fake/zero-pv proof rejected at host groth16 verify (or chainId bind); " +
+		"required-fields(empty-proof + empty-headers) rejected with 'proof, public_values, and headers required'. " +
+		"accept path = Milo's real SP1 proof (OUT OF SCOPE — not attempted).")
+}
+
+// PvMinLenWithChainIdHexLen is the hex-character length of a public_values blob
+// that exactly clears the #85 shape gate: PvMinLenWithChainId (416 bytes) * 2.
+// Kept local to this test (the contract const is in the verifier package, not
+// importable here).
+const PvMinLenWithChainIdHexLen = 416 * 2 // 832

--- a/tests/devnet/evm_l2_sign.go
+++ b/tests/devnet/evm_l2_sign.go
@@ -1,0 +1,120 @@
+//go:build evm_devnet
+
+// Evm-key-signed L2 contract calls for the EVM-bridge waves (W1/W2/W3).
+//
+// The default harness CallContract signs as a Hive witness account. But an ETH
+// deposit credits the L2 balance to AddressToDID(depositor_evm_addr) (review6 H9
+// disables ETH deposit routing), so unmapETH must be called AS that evm DID —
+// i.e. an L2 tx signed by the depositor's secp256k1 key. This mirrors the bot's
+// callContractL2 exactly (transactionpool + lib/dids), reusing the same vsc-node
+// libraries so the envelope is byte-faithful.
+package devnet
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"vsc-node/lib/dids"
+	"vsc-node/modules/db/vsc/contracts"
+	transactionpool "vsc-node/modules/transaction-pool"
+
+	ethCrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+// EthKey bundles a secp256k1 key with its derived L2 DID + 0x address.
+type EthKey struct {
+	Priv *ecdsa.PrivateKey
+	DID  dids.EthDID
+	Addr string // 0x-prefixed checksummed
+}
+
+// NewEthKey builds an EthKey from a 64-hex private key (no 0x).
+func NewEthKey(privHex string) (*EthKey, error) {
+	priv, err := ethCrypto.HexToECDSA(privHex)
+	if err != nil {
+		return nil, fmt.Errorf("bad eth privkey: %w", err)
+	}
+	addr := ethCrypto.PubkeyToAddress(priv.PublicKey).Hex() // EIP-55 checksummed (display)
+	// The contract credits deposits to AddressToDID = lowercase ("0x"+hex). Balance
+	// and RC lookups are case-sensitive on the exact DID string, so the L2 caller
+	// DID MUST be lowercase to match. Signature verification is case-insensitive
+	// (EthDID.Verify uses strings.EqualFold), so a lowercase DID still verifies.
+	did := dids.NewEthDID(strings.ToLower(addr))
+	return &EthKey{Priv: priv, DID: did, Addr: addr}, nil
+}
+
+// FetchL2Nonce reads the L2 account nonce for a DID/account string.
+func (d *Devnet) FetchL2Nonce(ctx context.Context, node int, account string) (uint64, error) {
+	const q = `query($a:String!){ getAccountNonce(account:$a){ nonce } }`
+	var out struct {
+		GetAccountNonce struct {
+			Nonce uint64 `json:"nonce"`
+		} `json:"getAccountNonce"`
+	}
+	if err := d.gqlQuery(ctx, node, q, map[string]any{"a": account}, &out); err != nil {
+		return 0, err
+	}
+	return out.GetAccountNonce.Nonce, nil
+}
+
+// SubmitL2Tx submits a signed (base64url) VSC L2 transaction, returns its CID id.
+func (d *Devnet) SubmitL2Tx(ctx context.Context, node int, txB64, sigB64 string) (string, error) {
+	const q = `query($tx:String!,$sig:String!){ submitTransactionV1(tx:$tx, sig:$sig){ id } }`
+	var out struct {
+		SubmitTransactionV1 struct {
+			Id string `json:"id"`
+		} `json:"submitTransactionV1"`
+	}
+	if err := d.gqlQuery(ctx, node, q, map[string]any{"tx": txB64, "sig": sigB64}, &out); err != nil {
+		return "", err
+	}
+	return out.SubmitTransactionV1.Id, nil
+}
+
+// CallContractEvm broadcasts an L2 contract call signed by an evm key, so the
+// contract sees Caller == the key's evm DID (mirrors bot callContractL2).
+func (d *Devnet) CallContractEvm(ctx context.Context, node int, key *EthKey, contractID, action, payload string, rcLimit uint64) (string, error) {
+	if rcLimit == 0 {
+		rcLimit = 5_000_000
+	}
+	nonce, err := d.FetchL2Nonce(ctx, node, key.DID.String())
+	if err != nil {
+		return "", fmt.Errorf("fetch L2 nonce for %s: %w", key.DID.String(), err)
+	}
+	call := &transactionpool.VscContractCall{
+		ContractId: contractID,
+		Action:     action,
+		Payload:    payload,
+		RcLimit:    uint(rcLimit),
+		Intents:    []contracts.Intent{},
+		Caller:     key.DID.String(),
+		NetId:      d.netId(),
+	}
+	op, err := call.SerializeVSC()
+	if err != nil {
+		return "", fmt.Errorf("serialize L2 op: %w", err)
+	}
+	vscTx := transactionpool.VSCTransaction{
+		Ops:     []transactionpool.VSCTransactionOp{op},
+		Nonce:   nonce,
+		NetId:   d.netId(),
+		RcLimit: rcLimit,
+	}
+	crafter := transactionpool.TransactionCrafter{
+		Identity: dids.NewEthProvider(key.Priv),
+		Did:      key.DID,
+	}
+	sTx, err := crafter.SignFinal(vscTx)
+	if err != nil {
+		return "", fmt.Errorf("sign L2 tx: %w", err)
+	}
+	if len(sTx.Tx) > transactionpool.MAX_TX_SIZE {
+		return "", fmt.Errorf("L2 tx too large: %d > %d", len(sTx.Tx), transactionpool.MAX_TX_SIZE)
+	}
+	return d.SubmitL2Tx(ctx, node,
+		base64.URLEncoding.EncodeToString(sTx.Tx),
+		base64.URLEncoding.EncodeToString(sTx.Sig))
+}

--- a/tests/devnet/funding.go
+++ b/tests/devnet/funding.go
@@ -21,7 +21,7 @@ func (d *Devnet) fundAccounts() error {
 			hivego.TransferOperation{
 				From:   "initminer",
 				To:     witnessName,
-				Amount: "100.000 TBD",
+				Amount: "100000.000 TBD",
 				Memo:   "devnet funding",
 			},
 			hivego.TransferOperation{

--- a/tests/devnet/hive_ops.go
+++ b/tests/devnet/hive_ops.go
@@ -14,33 +14,15 @@ import (
 // method. The caller is the witness at the given node index (1-indexed).
 // Retries up to 3 times on transient connection errors.
 func (d *Devnet) CallContract(ctx context.Context, node int, contractId, action, payload string) (string, error) {
-	return d.CallContractWithIntents(ctx, node, contractId, action, payload, nil, 500000)
-}
-
-// CallContractWithIntents is CallContract plus an `intents` array (e.g. a
-// transfer.allow intent that authorizes the contract to hive.draw a token from
-// the caller) and an explicit rc_limit. Each intent is
-// {"type": "...", "args": {"k":"v"}}.
-//
-// rc_limit matters for intent draws: PullBalance reserves
-// (rc_limit - free_rc) HBD of the caller's balance against RC, so a call that
-// draws HBD must use a LOW rc_limit (<= RC_HIVE_FREE_AMOUNT) or the caller's
-// balance is reserved out from under the draw (see [[vsc_rc_limit_hbd_exclusion]]).
-func (d *Devnet) CallContractWithIntents(ctx context.Context, node int, contractId, action, payload string, intents []map[string]interface{}, rcLimit int) (string, error) {
 	witnessName := fmt.Sprintf("%s%d", d.cfg.WitnessPrefix, node)
-
-	intentsField := make([]interface{}, 0, len(intents))
-	for _, it := range intents {
-		intentsField = append(intentsField, it)
-	}
 
 	callTx := map[string]interface{}{
 		"net_id":      "vsc-devnet",
 		"contract_id": contractId,
 		"action":      action,
 		"payload":     payload,
-		"rc_limit":    rcLimit,
-		"intents":     intentsField,
+		"rc_limit":    5000000,
+		"intents":     []interface{}{},
 	}
 	txJSON, err := json.Marshal(callTx)
 	if err != nil {


### PR DESCRIPTION
# PR — go-vsc-node: MED fix batch (gateway/wasm/oracle/runtime/dids/keystore) + ecrecover host-import HIGH + EVM-bridge devnet test suite

**37 files** changed = 21 (5 MED commits) + 16 new devnet test/helper files.

## Title
fix(go-vsc): register crypto.ecrecover_strict/canonical host imports (un-brick contract ecrecover, HIGH) + 22 review6 MEDs across gateway/wasm/oracle/runtime/dids/keystore + EVM-bridge devnet test suite

---

## ⚠ THE HIGH — DS-RE-1: contract ecrecover host imports were never registered
`df295dc1` — The account-mapping + zk contracts import `crypto.ecrecover_strict` (withdrawals) and `crypto.ecrecover_canonical` (deposits), but **go-vsc never registered these host functions**. On a real `gc.custom` WASM build the contract bricks on every ecrecover path. It was masked locally because the `!gc.custom` SDK stub delegates `strict`→plain. FIXED: both host imports registered in `modules/wasm/runtime_ipc/wasm.go`; `strict` rejects high-S (malleability), `canonical` normalizes — both empirically verified against go-ethereum. **This is the cross-repo lynchpin: deploy this host BEFORE any contract WASM that imports them (see Deploy Order) or the contract bricks on instantiate.**

---

## MED findings closed (22 numbered + round hardening)

### gateway/p2p — `7e9ab539`
- **#3 / #6** `ValidateMessage`: switch/default to drop junk message types instead of processing them.
- **#55** `sign_response` made relay-safe.
- **#110** `ParseMessage` now propagates the JSON error instead of swallowing it.
- (also) `electionPeerIDs` rebuilt every `ACTION_INTERVAL` rather than only on epoch change — stale peer set fix.

### gateway/multisig — `7e9ab539`
- **#54** `bhMu` data-race guard around `storeBh`/`loadBh`.
- **#56** rotation-alone scheduling gated on `Version0_2_0Active` (fixes the MED-56 co-fire race; see also R2-6c below).
- **#81** per-signer telemetry in `waitForSigs`.
- **#105** rotation timeout 5s → 30s.
- **#112** ticker-based `waitCheckBh` replaces a busy-wait.
- **GatewayKeyFromBlsSeed** defer-zeroize of key material.

### wasm/sdk + host — `7e9ab539`, round3/5
- **#37** additive `sp1_verify_groth16_ex` host fn.
- **#92** deterministic `system.call` panic rendering, gated on `SdkErrorDeterminismVersion {0,2,0}`.
- **#119** additive `contracts.read_ex` returning an `exists` bool.
- **#130** WASM init-guard: host captures the `_initialize` result and aborts with `WASM_INIT_ERROR` when the gate is active; gated on `WasmInitGuardVersion {0,3,0}`; threaded via `WasmInitGuardCtxKey` through `transactions.go`, `execution-context.go` (`WithInitGuard`), and the GQL simulate path; `currentConsensus` 2→3.

### oracle — `7e9ab539`, round3
- **#109 / #111 / #113** `relayDedupStore` persistence interface (`loadDedup`/`storeDedup`/`clearDedup`); `prunedRecoveryBudget` 20s + `prunedRecoveryPerPeerPolls=7`; Warn on full-channel sig drop.
- **#114** eth-header parent-hash chain check on producer + witness, gated on `Version0_2_0Active`.
- **C-F5** (round3) `verifyEthHeaderChain` guards a typed-nil `*ethChainData` before any field deref (a typed nil satisfies the interface assertion but panics on `.ParentHash`).

### runtime — `7e9ab539`, round2/3/4
- **#136 / CD-1** `IsSupportedAt()` version-gates runtime acceptance at create/update AND at the call site (`transactions.go`, before `w.Execute`) so a contract record with an invalid runtime inserted directly into Mongo yields a deterministic tx-level failure on all nodes instead of reaching the `Execute` default-case panic.
- **C-R24 / R2-4** `Execute` default branch: explicitly-commented unreachable-assertion panic with the determinism rationale (the generic signature can't build `result.Err[Result]`; zero-value `Result[T]` has `IsOk()==true` which would mask a wiring regression — so panic, but documented as provably-unreachable since `IsSupportedAt` gates create/update).
- **C-RV / R2-5** `SimulateContractCalls` now adds `WithTryCatch` gated on `TryCatchICCVersion`, matching the four options the on-chain path sets (`WithPendulumApplier`, `WithTryCatch`, `WithSdkErrorDeterminism`, `WithInitGuard`) — Simulate was missing `WithTryCatch`, diverging from on-chain ICC try-semantics.
- **C-RV / R2-6c** `assertIntervalDivisibility` strengthened to require strict ordering `ACTION_INTERVAL < ROTATION_INTERVAL < SYNC_INTERVAL` (equal intervals pass divisibility but permanently starve actions — reintroduces MED-56).

### dids — `7e9ab539`
- **#9** `EthDID.Verify` length guard (65 bytes) before indexing `sigBytes[64]` (panic-on-malformed-sig fix).

### keystore — `7e9ab539`
- **MED-13** `os.Chmod(tssKeysDir, 0700)` after `flatfs.CreateOrOpen` — TSS key dir perms.

---

## CONSENSUS-VERSION GATING — review this carefully (determinism)
The fixes that change on-chain behavior are version-gated so nodes stay in lockstep until activation:
- `Version0_2_0Active` gates: **#114** oracle relay/witness, **#56** BlockTick scheduling.
- `SdkErrorDeterminismVersion {0,2,0}` gates: **#92** deterministic system.call panic.
- `WasmInitGuardVersion {0,3,0}` gates: **#130** init-guard (`currentConsensus` 2→3).
- `TryCatchICCVersion` gates: **R2-5** simulate `WithTryCatch`.
- **Ungated (off consensus path, safe to land immediately):** additive host fns **#37 #119**, plus **#112 #111 #113 #109 #105 #81 #54 #9 #13**.
**Reviewer:** confirm no behavior-changing fix is ungated, and that the gating versions match the intended activation height.

---

## EVM-BRIDGE DEVNET TEST SUITE (16 new files — this is the integration proof for THIS PR *and* the account-mapping PR)
Real 5-node docker devnet + anvil L1. `tests/devnet/`: `evm_anvil.go` (anvil + MPT tx/receipt-trie proofs), `evm_l2_sign.go` (evm-DID L2 signing), `evm_bot.go` (bot runner), `evm_bridge_setup.go` (shared harness: deploy + wire mock verifier + RC bootstrap + deployWithRetry), and the waves:

| Wave | Proves |
|------|--------|
| W1 `evm_bridge_w1` | ETH deposit: **ecrecover_canonical** recovers L1 depositor (proves DS-RE-1 host import), tx-trie verify vs real anvil root, observed-dedup, chainId, gas-tax. **FAIL→PASS demonstrates the account-mapping host-`""` HIGH fix.** |
| W2 `evm_bridge_w2` | Withdrawal close-out: PendingSpend JSON (H-F1), confirmSpend flat-10 + intent-bind + tx/receipt-trie (H-F2), all-zero-bloom receiptsRoot (CC-1), **ecrecover_strict==vault (DS-F1)**, single nonce advance. |
| W3 `evm_bridge_w3` | Double-spend: Type-B drop-proof can't force-refund a SUCCEEDED withdrawal (H-SM2), Type-A status!=0 (H-SM1), no refund/no double-spend. |
| ZK `evm_bridge_zk` | zk-verifier reject paths (#85 shape gate, #65, required-fields). Accept path = Milo's SP1 proof (out of scope). |
| W6Neg `evm_bridge_w6neg` | admin/negative matrix 15/15 (pause, registerToken/setGasReserve bounds, unmapETH/map degenerate). |
| BotRes `evm_bridge_botres` | bot checkpoint persist/resume + the bot-`"h"` scan-height fix (see PR3); LastScannedBlock 0→74. |
| BotH `evm_bridge_both` | proves the bot-`"h"` contract↔bot mismatch finding. |

All green; full regression re-swept (W1/W2/W3/ZK/W6Neg PASS). Status: `/mnt/o/MED-FIX-2026-06-19/devnet-results/STATUS-DEVNET.md`.

---

## DEPLOY ORDER (mandatory — cross-repo coupling)
1. **THIS host first** (`med/gv-develop`, ecrecover_strict/canonical imports) BEFORE any contract WASM that imports them, or the contract bricks on instantiate.
2. Then account-mapping (review6) + bot (#154) + zk per the campaign handoff.

## Reviewer guide
1. **DS-RE-1 is the headline** — verify both host imports registered in `runtime_ipc/wasm.go`, strict rejects high-S, canonical normalizes.
2. **Consensus gating** (section above) — no behavior change ungated; versions correct.
3. **Init-guard (#130)** threads a ctx key through 3 call sites — confirm all three (transactions.go, execution-context.go, GQL simulate).
4. Devnet suite is the integration proof; it deploys the account-mapping WASM, so this PR + the account-mapping PR verify together.

## NOTE — branch base
`med/gv-develop` is 5 commits ahead of `origin/develop`. If you want a tests-only or fixes-only split, say so; as-is the branch carries both the 5 MED commits and the devnet suite → one PR to `develop`.

## Hygiene
LF line endings (verified). No `.wasm`/binaries staged. **TODO before merge:** 3 devnet test files (`evm_bridge_w0/wmock/zk`) hardcode a local `/home/clauderfly/...` WASM path — being parameterized to an env var w/ default (does not affect CI logic, but shouldn't ship a machine path).
