### PR TITLE
fix(consensus): temporarily disable H-6 PoP gate to recover stalled elections

### DIFF
--- a/modules/common/consensusversion/feature_gates.go
+++ b/modules/common/consensusversion/feature_gates.go
@@ -56,7 +56,14 @@ func Version0_2_0Active(active Version) bool {
 // which is exactly the safety the prior dedicated height was hand-positioned to
 // provide.
 func WitnessKeyStrictActive(active Version) bool {
-	return Version0_2_0Active(active)
+	// TEMPORARILY DISABLED (2026-06-22) — emergency liveness fix. The H-6 strict
+	// PoP gate starved the mainnet committee below the floor at epoch 1699,
+	// halting elections (1698 was the last election produced). Returning false
+	// reverts to the pre-0.2.0 warn-only key behavior so the committee re-fills
+	// and elections resume. RE-ENABLE (restore the line below) once witnesses
+	// have re-announced valid consensus + gateway-key PoPs.
+	return false
+	// return Version0_2_0Active(active)
 }
 
 // ContractUpdateTimelockActive reports whether the contract-update timelock (and


### PR DESCRIPTION
## Problem
Mainnet elections have been stalled since **epoch 1698** (~33h+). Root cause:
the v0.2.0 strict witness-key gate (`WitnessKeyStrictActive`, audit H-6).

- 1695–1697 = protocol_version 1; **1698 = protocol_version 2** (first 0.2.0
  election, produced fine); **1699 never formed**.
- The gate resolves eligibility from the *prior* ratified election's version, so
  it's inert through 1698 (anchor 1697 = v1) and **first bites at 1699** (anchor
  1698 = v2). It then excludes any witness whose consensus BLS / gateway key
  fails proof-of-possession, dropping the eligible committee below
  `bondCommitteeFloor` → `HoldElection` aborts → epoch stalls.
- Same failure mode previously hit testnet at epoch 662 (fixed in `52736136`).

## Change
Make `WitnessKeyStrictActive` return `false`, reverting the election build to the
pre-0.2.0 warn-only key behavior. The gate activating is the **only** difference
between the last election that worked (1698) and the first that failed (1699), so
disabling it reverts to known-working behavior and the committee re-fills.

Surgical — only the PoP gate is disabled; the rest of the v0.2.0 batch (LP-floor
fee fix, try/catch ICC, contract-update timelock) is unaffected.

## ⚠️ Temporary stopgap
- Restores liveness by turning **off** a security check (H-6 stops a witness
  claiming consensus/gateway keys it doesn't control — these guard the gateway
  multisig + TSS custody). **Re-enable** once witnesses re-announce valid PoPs.
- **Consensus-critical:** takes effect only once a stake-supermajority of the
  producing witnesses runs this binary — needs a coordinated rollout, not a
  single push.
- Does **not** disable the announce-side PoP rejection (commit `9e11b439`); flag
  if you want the system fully off.
- Please sanity-check the **bond-maturity gate** isn't *also* trimming the
  committee — if it is, this alone may not fully recover.