### PR TITLE
height windows for safety slash enablement

### DIFF
--- a/modules/common/params/params.go
+++ b/modules/common/params/params.go
@@ -298,23 +298,41 @@ type ConsensusParams struct {
 	// re-mature. 0 == disabled. Only consulted when the bond gate is active.
 	BondInclusionEstablishedGraceBlocks uint64 `json:"bondInclusionEstablishedGraceBlocks,omitempty"`
 
-	// SafetySlashActivationHeight gates verifiable-fault PRINCIPAL slashing (the
-	// HIVE_CONSENSUS bond debit in slashForEvidenceIfPolicyAllows →
-	// SafetySlashConsensusBond). At blockHeight >= this value the detectors debit
-	// the bond; below it — and when 0 — they still run and log but never touch the
-	// ledger (0 = inert, the safe default). Kept as its OWN height (NOT folded into
-	// the v0.2.0 version line) because principal slashing is on a more cautious
-	// maturity timeline than the rest of v0.2.0 and must be stageable independently.
+	// SafetySlashWindows is the schedule of half-open [Start, End) block-height
+	// ranges over which verifiable-fault PRINCIPAL slashing (the HIVE_CONSENSUS
+	// bond debit in slashForEvidenceIfPolicyAllows → SafetySlashConsensusBond) is
+	// IN FORCE. Outside every window the detectors still run and log but never
+	// touch the ledger. Semantics (see SafetySlashActive):
+	//   - empty / nil → slashing is never active (inert; the safe default).
+	//   - End == 0    → open-ended: active from Start onward. Only the FINAL
+	//                   window may be open-ended.
+	//   - End != 0    → active for Start <= h < End (End exclusive).
+	// An on→off→on cycle is expressed by closing the current window (set its End)
+	// and APPENDING a new one — never by editing an existing entry. Kept as its OWN
+	// per-network schedule (NOT folded into the v0.2.0 version line) because
+	// principal slashing is on a more cautious maturity timeline than the rest of
+	// v0.2.0 and must be stageable independently.
 	//
-	// CONSENSUS-CRITICAL: the slash changes ledger state, so this MUST be a fixed
-	// network-wide constant set STRICTLY ABOVE the current chain head before
-	// deploy, identical on every node (reindex or not). A height at/below an
-	// already-processed block is a consensus footgun — live nodes ran the
-	// no-slash path over those blocks; a reindex with this binary would slash them
-	// and diverge — exactly like EvmAddressChecksumHeight.
-	// Every witness must run a binary carrying this height BEFORE Hive reaches it.
-	// Ephemeral networks may pin it low to exercise the active path.
-	SafetySlashActivationHeight uint64 `json:"safetySlashActivationHeight,omitempty"`
+	// CONSENSUS-CRITICAL: the slash changes ledger state, so every boundary MUST be
+	// a fixed network-wide constant, identical on every node (reindex or not). Any
+	// boundary at or below current chain head is FROZEN history — live nodes already
+	// ran each past block's slash/no-slash path, so a reindex on a binary that moved
+	// a past boundary would debit (or skip) different bonds and diverge, exactly
+	// like EvmAddressChecksumHeight. Only ever APPEND a window, or set the End of the
+	// final still-future window, STRICTLY ABOVE chain head, with every witness
+	// upgraded BEFORE Hive reaches it. A malformed schedule (overlapping, out of
+	// order, or mid-list open-ended) is rejected by ValidSafetySlashWindows, which
+	// is asserted against every shipped config in tests.
+	SafetySlashWindows []HeightWindow `json:"safetySlashWindows,omitempty"`
+}
+
+// HeightWindow is a half-open [Start, End) range of L1 block heights. End == 0
+// means open-ended (no upper bound). Used by SafetySlashWindows to schedule
+// on/off cycles of a consensus rule; see ValidSafetySlashWindows for the
+// well-formedness invariant a schedule of these must satisfy.
+type HeightWindow struct {
+	Start uint64 `json:"start"`
+	End   uint64 `json:"end,omitempty"`
 }
 
 // ───── Named activation predicates (Ethereum ChainConfig style) ─────
@@ -341,12 +359,47 @@ func (cp ConsensusParams) EvmAddressChecksumActive(blockHeight uint64) bool {
 // version line (see each predicate's note).
 
 // SafetySlashActive reports whether verifiable-fault principal (HIVE_CONSENSUS
-// bond) slashing is in force at blockHeight. Call sites gate the ledger debit on
-// this instead of reading a compile-time constant, so activation is a per-network
-// height pinned above chain head (see SafetySlashActivationHeight). Zero height
-// means slashing is inert (detectors still run and log; no bond is debited).
+// bond) slashing is in force at blockHeight — true iff blockHeight falls within
+// one of the configured SafetySlashWindows. An empty schedule is never active; a
+// final window with End == 0 is active from its Start onward. Call sites gate the
+// ledger debit on this so the decision is a pure function of (schedule, height)
+// and replays identically on every node. Assumes a well-formed schedule
+// (ValidSafetySlashWindows); the lookup itself tolerates any slice but a
+// malformed schedule's meaning is only defined once it passes validation.
 func (cp ConsensusParams) SafetySlashActive(blockHeight uint64) bool {
-	return cp.SafetySlashActivationHeight != 0 && blockHeight >= cp.SafetySlashActivationHeight
+	for _, w := range cp.SafetySlashWindows {
+		if blockHeight >= w.Start && (w.End == 0 || blockHeight < w.End) {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidSafetySlashWindows reports an error if the SafetySlashWindows schedule is
+// malformed. Well-formed means a sorted list of disjoint half-open [Start, End)
+// intervals in which every window is non-empty (Start < End) and only the FINAL
+// window may be open-ended (End == 0). An empty schedule is valid (slashing never
+// active). Because the slash debit is replay-derived, a malformed schedule would
+// diverge nodes, so this is asserted against every shipped network config in
+// tests — a bad constant fails the build rather than forking the chain at runtime.
+func (cp ConsensusParams) ValidSafetySlashWindows() error {
+	ws := cp.SafetySlashWindows
+	for i, w := range ws {
+		last := i == len(ws)-1
+		if w.End == 0 {
+			if !last {
+				return fmt.Errorf("safety slash window %d {start:%d}: only the final window may be open-ended (End == 0)", i, w.Start)
+			}
+			continue // open-ended final window: nothing after it to order against
+		}
+		if w.End <= w.Start {
+			return fmt.Errorf("safety slash window %d: End (%d) must be greater than Start (%d)", i, w.End, w.Start)
+		}
+		if !last && w.End > ws[i+1].Start {
+			return fmt.Errorf("safety slash windows %d and %d overlap or are out of order: End %d > next Start %d", i, i+1, w.End, ws[i+1].Start)
+		}
+	}
+	return nil
 }
 
 // BondInclusionActive reports whether the bond inclusion-window maturity gate

--- a/modules/common/params/safety_slash_window_test.go
+++ b/modules/common/params/safety_slash_window_test.go
@@ -1,0 +1,125 @@
+package params
+
+import "testing"
+
+// TestSafetySlashActive_Schedules pins the windowed gate semantics the consensus
+// boundary depends on: empty schedule is never active, a final open-ended window
+// (End == 0) is active from its Start onward, closed windows are half-open
+// [Start, End), and an on→off→on (reactivation) schedule is inactive in the gap.
+// The gate must be a pure function of (schedule, height) so every node replays
+// the identical slash/no-slash decision.
+func TestSafetySlashActive_Schedules(t *testing.T) {
+	cases := []struct {
+		name    string
+		windows []HeightWindow
+		checks  map[uint64]bool // height -> expected active
+	}{
+		{
+			name:    "empty is never active",
+			windows: nil,
+			checks:  map[uint64]bool{0: false, 1: false, 1_000_000: false},
+		},
+		{
+			name:    "single open-ended window active from Start onward",
+			windows: []HeightWindow{{Start: 100}},
+			checks:  map[uint64]bool{0: false, 99: false, 100: true, 101: true, 1_000_000: true},
+		},
+		{
+			name:    "single closed window is half-open [Start,End)",
+			windows: []HeightWindow{{Start: 100, End: 200}},
+			checks:  map[uint64]bool{99: false, 100: true, 150: true, 199: true, 200: false, 201: false},
+		},
+		{
+			name:    "closed then open-ended with a gap (reactivation) is off in the gap",
+			windows: []HeightWindow{{Start: 100, End: 200}, {Start: 300}},
+			checks: map[uint64]bool{
+				100: true, 199: true, // first window
+				200: false, 250: false, 299: false, // gap: slashing disabled
+				300: true, 9_999_999: true, // reactivated, open-ended
+			},
+		},
+		{
+			name: "mainnet-shaped: activate, emergency-disable, reactivate",
+			windows: []HeightWindow{
+				{Start: 107454300, End: 109_000_000},
+				{Start: 120_000_000},
+			},
+			checks: map[uint64]bool{
+				107454299:   false,
+				107454300:   true,
+				108_999_999: true,
+				109_000_000: false, // disabled at H
+				115_000_000: false, // still off in the gap
+				120_000_000: true,  // reactivated
+				200_000_000: true,
+			},
+		},
+		{
+			name:    "two closed windows, off after the last",
+			windows: []HeightWindow{{Start: 10, End: 20}, {Start: 30, End: 40}},
+			checks:  map[uint64]bool{15: true, 25: false, 35: true, 40: false, 50: false},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cp := ConsensusParams{SafetySlashWindows: tc.windows}
+			// A valid-by-construction schedule must pass the validator too.
+			if err := cp.ValidSafetySlashWindows(); err != nil {
+				t.Fatalf("schedule should be valid: %v", err)
+			}
+			for h, want := range tc.checks {
+				if got := cp.SafetySlashActive(h); got != want {
+					t.Errorf("SafetySlashActive(%d) = %v, want %v", h, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestValidSafetySlashWindows covers the well-formedness invariant: sorted,
+// disjoint, non-empty half-open intervals with only the final window open-ended.
+// A malformed schedule is replay-divergent, so it must be rejected here (and is
+// asserted against every shipped config in the systemconfig package).
+func TestValidSafetySlashWindows(t *testing.T) {
+	valid := []struct {
+		name    string
+		windows []HeightWindow
+	}{
+		{"empty", nil},
+		{"single open", []HeightWindow{{Start: 1}}},
+		{"single closed", []HeightWindow{{Start: 100, End: 200}}},
+		{"closed then open with gap", []HeightWindow{{Start: 100, End: 200}, {Start: 300}}},
+		{"closed then closed with gap", []HeightWindow{{Start: 100, End: 200}, {Start: 300, End: 400}}},
+		{"touching back-to-back windows", []HeightWindow{{Start: 100, End: 200}, {Start: 200, End: 300}}},
+		{"all closed, ends off", []HeightWindow{{Start: 10, End: 20}, {Start: 30, End: 40}}},
+	}
+	for _, tc := range valid {
+		t.Run("valid/"+tc.name, func(t *testing.T) {
+			cp := ConsensusParams{SafetySlashWindows: tc.windows}
+			if err := cp.ValidSafetySlashWindows(); err != nil {
+				t.Errorf("expected valid, got error: %v", err)
+			}
+		})
+	}
+
+	invalid := []struct {
+		name    string
+		windows []HeightWindow
+	}{
+		{"mid-list open-ended", []HeightWindow{{Start: 100}, {Start: 200, End: 300}}},
+		{"two open-ended", []HeightWindow{{Start: 100}, {Start: 200}}},
+		{"empty interval End==Start", []HeightWindow{{Start: 100, End: 100}}},
+		{"inverted End<Start", []HeightWindow{{Start: 200, End: 100}}},
+		{"overlap", []HeightWindow{{Start: 100, End: 250}, {Start: 200, End: 300}}},
+		{"overlap into open-ended", []HeightWindow{{Start: 100, End: 250}, {Start: 200}}},
+		{"out of order", []HeightWindow{{Start: 300, End: 400}, {Start: 100, End: 200}}},
+	}
+	for _, tc := range invalid {
+		t.Run("invalid/"+tc.name, func(t *testing.T) {
+			cp := ConsensusParams{SafetySlashWindows: tc.windows}
+			if err := cp.ValidSafetySlashWindows(); err == nil {
+				t.Errorf("expected error for malformed schedule %v, got nil", tc.windows)
+			}
+		})
+	}
+}

--- a/modules/common/system-config/safety_slash_window_test.go
+++ b/modules/common/system-config/safety_slash_window_test.go
@@ -1,0 +1,93 @@
+package systemconfig
+
+import "testing"
+
+// TestShippedSafetySlashWindowsValid asserts every network's compiled-in safety
+// slash schedule is well-formed. Because the slash debit is replay-derived, a
+// malformed (overlapping / out-of-order / mid-list open-ended) schedule would
+// diverge nodes on reindex — so a bad constant must fail the build here, not the
+// chain at runtime.
+func TestShippedSafetySlashWindowsValid(t *testing.T) {
+	configs := map[string]SystemConfig{
+		"mainnet": MainnetConfig(),
+		"testnet": TestnetConfig(),
+		"devnet":  DevnetConfig(),
+		"mocknet": MocknetConfig(),
+	}
+	for name, conf := range configs {
+		t.Run(name, func(t *testing.T) {
+			if err := conf.ConsensusParams().ValidSafetySlashWindows(); err != nil {
+				t.Fatalf("%s safety slash schedule is malformed: %v", name, err)
+			}
+		})
+	}
+}
+
+// TestShippedSafetySlashFrozenActivation pins each network's IMMUTABLE first
+// activation height — the block at which safety slashing first went live. That
+// boundary is settled history (live nodes already ran it), so it must never
+// move; this fails the build if an edit changes it. The UPPER bound of a window
+// (an emergency-disable height, or a later reactivation Start) is intentionally
+// MUTABLE and is deliberately NOT pinned here — TestShippedSafetySlashWindowsBoundaries
+// validates whatever schedule is shipped instead.
+func TestShippedSafetySlashFrozenActivation(t *testing.T) {
+	frozen := map[string]struct {
+		conf  SystemConfig
+		start uint64 // 0 == inert: schedule must be empty
+	}{
+		"mainnet": {MainnetConfig(), 107454300},
+		"testnet": {TestnetConfig(), 3_870_000},
+		"devnet":  {DevnetConfig(), 1},
+		"mocknet": {MocknetConfig(), 0},
+	}
+	for name, f := range frozen {
+		t.Run(name, func(t *testing.T) {
+			ws := f.conf.ConsensusParams().SafetySlashWindows
+			if f.start == 0 {
+				if len(ws) != 0 {
+					t.Fatalf("%s: expected inert (no windows), got %v", name, ws)
+				}
+				return
+			}
+			if len(ws) == 0 {
+				t.Fatalf("%s: expected first activation at frozen %d, got empty schedule", name, f.start)
+			}
+			if ws[0].Start != f.start {
+				t.Fatalf("%s: first activation height moved (frozen history): got %d, want %d", name, ws[0].Start, f.start)
+			}
+		})
+	}
+}
+
+// TestShippedSafetySlashWindowsBoundaries validates the on/off transitions of
+// each network's ACTUAL shipped schedule against the gate, so the assertions
+// track edits (closing a window at an emergency-disable height, appending a
+// reactivation window) without baking in mutable magic heights. It still catches
+// off-by-one / inverted gate logic at every real boundary.
+func TestShippedSafetySlashWindowsBoundaries(t *testing.T) {
+	for _, conf := range []SystemConfig{MainnetConfig(), TestnetConfig(), DevnetConfig(), MocknetConfig()} {
+		cp := conf.ConsensusParams()
+		for i, w := range cp.SafetySlashWindows {
+			// Active at Start.
+			if !cp.SafetySlashActive(w.Start) {
+				t.Errorf("window %d {start:%d}: expected active at Start", i, w.Start)
+			}
+			// First window: inactive just before activation (frozen boundary).
+			// Later windows' lower edge is covered by the prior window's "inactive
+			// at End" check below, so we skip Start-1 there to avoid the
+			// touching-window edge case.
+			if i == 0 && w.Start > 0 && cp.SafetySlashActive(w.Start-1) {
+				t.Errorf("window 0 {start:%d}: expected inactive at Start-1", w.Start)
+			}
+			// Closed window: active at End-1, inactive at End (the disable edge).
+			if w.End != 0 {
+				if !cp.SafetySlashActive(w.End - 1) {
+					t.Errorf("window %d: expected active at End-1 (%d)", i, w.End-1)
+				}
+				if cp.SafetySlashActive(w.End) {
+					t.Errorf("window %d: expected inactive at End (%d)", i, w.End)
+				}
+			}
+		}
+	}
+}

--- a/modules/common/system-config/system-config.go
+++ b/modules/common/system-config/system-config.go
@@ -233,12 +233,20 @@ func MainnetConfig() SystemConfig {
 			// it drops out. Only meaningful when the bond gate is active. (mainnet
 			// 403,200 ≈ 2 weeks @ 3s.)
 			BondInclusionEstablishedGraceBlocks: 403_200,
-			// Principal (HIVE_CONSENSUS bond) safety slashing. 0 = INERT
-			// (detectors log but never debit). PIN a future mainnet height
-			// (strictly above chain head, every witness upgraded first) before
-			// turning slashing on — same reindex/upgrade-window footgun as the
-			// other height gates. Stage AFTER the v0.2.0 batch has soaked.
-			SafetySlashActivationHeight: 107454300,
+			// Principal (HIVE_CONSENSUS bond) safety slashing schedule — a list of
+			// [Start, End) height windows in which slashing debits the bond (see
+			// params.SafetySlashActive). Empty = never; a final window with End == 0
+			// is open-ended. Activated at 107454300 alongside the v0.2.0 batch.
+			//
+			// TO DISABLE (emergency wrongful-slash stop): close this window by
+			// setting End to a height H STRICTLY ABOVE current chain head, with every
+			// witness upgraded before Hive reaches H, e.g. {Start: 107454300, End: H}.
+			// TO REACTIVATE later (committee stable): APPEND a new open-ended window
+			// above head — never edit the closed one, its bounds are frozen history:
+			//   {Start: 107454300, End: H}, {Start: R, End: 0}  // R > H, above head.
+			SafetySlashWindows: []params.HeightWindow{
+				{Start: 107454300, End: 107565100},
+			},
 		},
 		oracleParams: params.OracleParams{
 			ChainContracts: map[string]string{
@@ -322,10 +330,13 @@ func TestnetConfig() SystemConfig {
 			// it drops out. Only meaningful when the bond gate is active. (mainnet
 			// 403,200 ≈ 2 weeks @ 3s.)
 			BondInclusionEstablishedGraceBlocks: 33_600,
-			// Principal (HIVE_CONSENSUS bond) safety slashing. 0 = INERT until
-			// pinned. Set a future testnet height (above chain head) to soak
-			// slashing before mainnet — same above-head rule as mainnet.
-			SafetySlashActivationHeight: 3_870_000,
+			// Principal (HIVE_CONSENSUS bond) safety slashing schedule (see
+			// params.SafetySlashActive). Active from 3_870_000 onward to soak
+			// slashing before mainnet. Same above-head / frozen-past rules as
+			// mainnet apply when closing or appending windows.
+			SafetySlashWindows: []params.HeightWindow{
+				{Start: 3_870_000, End: 0},
+			},
 		},
 		oracleParams: params.OracleParams{
 			ChainContracts: map[string]string{
@@ -395,13 +406,15 @@ func DevnetConfig() SystemConfig {
 			// 403,200 ≈ 2 weeks @ 3s.)
 			BondInclusionEstablishedGraceBlocks: 400,
 			// Principal safety slashing ACTIVE from genesis on this ephemeral net
-			// (its own height, matching the 0.2.0 floor pin above) so the devnet
+			// (its own schedule, matching the 0.2.0 floor pin above) so the devnet
 			// double-sign integration
 			// test (tests/devnet/malicious_doublesign_test.go) can observe a real
 			// bond slash. Honest nodes never equivocate / propose invalid blocks,
 			// so no slash fires in normal runs; internal unit tests still pin their
-			// own height via an sconf override.
-			SafetySlashActivationHeight: 1,
+			// own schedule via an sconf override.
+			SafetySlashWindows: []params.HeightWindow{
+				{Start: 1, End: 0},
+			},
 		},
 		tssParams: params.DefaultTssParams,
 		// Devnet operators set via -sysconfig pendulumPoolWhitelist on each node.
@@ -451,9 +464,9 @@ func MocknetConfig() SystemConfig {
 			// it drops out. Only meaningful when the bond gate is active. (mainnet
 			// 403,200 ≈ 2 weeks @ 3s.)
 			BondInclusionEstablishedGraceBlocks: 400,
-			// Principal safety slashing. 0 = INERT; the in-process e2e harness
-			// and internal unit tests pin their own height via an sconf override.
-			SafetySlashActivationHeight: 0,
+			// Principal safety slashing. Empty = INERT; the in-process e2e harness
+			// and internal unit tests pin their own schedule via an sconf override.
+			SafetySlashWindows: nil,
 		},
 		tssParams: params.MocknetTssParams,
 	}

--- a/modules/state-processing/safety_evidence_internal_test.go
+++ b/modules/state-processing/safety_evidence_internal_test.go
@@ -115,8 +115,8 @@ func TestBlamedAccountsFromBitSet(t *testing.T) {
 }
 
 // safetySlashSconf wraps a base SystemConfig so a test can pin the principal-
-// slash activation height (ConsensusParams.SafetySlashActivationHeight) without a
-// JSON override loader — mirroring timelockHeightSconf for the timelock gate.
+// slash schedule (ConsensusParams.SafetySlashWindows) without a JSON override
+// loader — mirroring timelockHeightSconf for the timelock gate.
 type safetySlashSconf struct {
 	systemconfig.SystemConfig
 	cp params.ConsensusParams
@@ -127,7 +127,13 @@ func (s *safetySlashSconf) ConsensusParams() params.ConsensusParams { return s.c
 func mocknetWithSafetySlashHeight(h uint64) systemconfig.SystemConfig {
 	base := systemconfig.MocknetConfig()
 	cp := base.ConsensusParams()
-	cp.SafetySlashActivationHeight = h
+	// Mirror the old scalar gate: 0 = inert (no windows); otherwise a single
+	// open-ended window active from h onward.
+	if h == 0 {
+		cp.SafetySlashWindows = nil
+	} else {
+		cp.SafetySlashWindows = []params.HeightWindow{{Start: h}}
+	}
 	return &safetySlashSconf{SystemConfig: base, cp: cp}
 }
 


### PR DESCRIPTION
- adds height enabled/disabled windows for safety slashing, to allow for a consensus safe pause of the safety slashing feature and a consensus-safe re-enablement later once fixes have been applied 