### PR TITLE
Techcoder's Reindex fixes 

### DIFF
--- a/cmd/vsc-node/args.go
+++ b/cmd/vsc-node/args.go
@@ -13,7 +13,6 @@ type args struct {
 	network string
 	dataDir string
 
-	disableTss    bool
 	forceReindex  bool
 	logLevel      string
 	sysconfigPath string
@@ -29,7 +28,6 @@ func ParseArgs() (args, error) {
 	isInit := flag.Bool("init", false, "Initialize the node (run init instead of run)")
 	network := flag.String("network", "mainnet", "Name of the network (mainnet or testnet)")
 	dataDir := flag.String("data-dir", "data", "Data directory for config and storage")
-	disableTss := flag.Bool("disable-tss", false, "Disable TSS plugin (testnet only)")
 	forceReindex := flag.Bool("force-reindex", false, "Force a database reindex on startup (wipes derived state and replays from genesis)")
 	logLevel := flag.String("log-level", "info", "Log level spec: error|warn|info|debug|verbose|trace or comma-separated with module overrides (e.g. error,tss=verbose,bp=info)")
 	sysconfigPath := flag.String("sysconfig", "", "Path to JSON file with system config overrides")
@@ -41,7 +39,6 @@ func ParseArgs() (args, error) {
 		*isInit,
 		*network,
 		*dataDir,
-		*disableTss,
 		*forceReindex,
 		*logLevel,
 		*sysconfigPath,

--- a/cmd/vsc-node/main.go
+++ b/cmd/vsc-node/main.go
@@ -119,11 +119,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	if sysConfig.OnMainnet() && args.disableTss {
-		log.Error("cannot disable TSS plugin on mainnet")
-		os.Exit(1)
-	}
-
 	// choose the source
 	hiveRpcClient := hivego.NewHiveRpc(hiveURIs)
 	hiveRpcClient.ChainID = sysConfig.HiveChainId()
@@ -140,6 +135,7 @@ func main() {
 	streamerPlugin := streamer.NewStreamer(hiveRpcClient, hiveBlocks, filters, vFilters, &stBlock) // optional starting block #
 
 	identityConfig := common.NewIdentityConfig(args.dataDir)
+	hasPrivateKey := identityConfig.HasPrivateKey()
 
 	hiveCreator := hive.LiveTransactionCreator{
 		TransactionCrafter: hive.TransactionCrafter{},
@@ -318,18 +314,12 @@ func main() {
 		consensusStateDb,
 
 		p2p,
-		da,                   //Deps: [p2p]
-		dataAvailability,     //Deps: [p2p]
-		announcementsManager, // Deps: [p2p]
-
+		da,               //Deps: [p2p]
+		dataAvailability, //Deps: [p2p]
 		blockConsumer,
 		//Startup main state processing pipeline
 		streamerPlugin,
 		se,
-		bp,
-		oracle,
-		ep,
-		multisig,
 		sr,
 
 		//WASM execution environment
@@ -337,8 +327,8 @@ func main() {
 		txpool,
 	)
 
-	if !args.disableTss {
-		plugins = append(plugins, tssMgr)
+	if hasPrivateKey {
+		plugins = append(plugins, announcementsManager, bp, oracle, ep, multisig, tssMgr)
 	}
 
 	//Setup graphql manager after everything is initialized

--- a/lib/test_utils/mock_hive_blocks.go
+++ b/lib/test_utils/mock_hive_blocks.go
@@ -1,0 +1,149 @@
+package test_utils
+
+import (
+	"context"
+	"fmt"
+
+	"vsc-node/lib/utils"
+	"vsc-node/modules/aggregate"
+	"vsc-node/modules/db/vsc/hive_blocks"
+
+	"github.com/chebyrash/promise"
+)
+
+type MockHiveBlockDb struct {
+	aggregate.Plugin
+	Blocks             []hive_blocks.HiveBlock
+	LastProcessedBlock uint64
+	HeadHeight         uint64
+	Metadata           hive_blocks.Document
+}
+
+var _ hive_blocks.HiveBlocks = &MockHiveBlockDb{}
+
+// StoreBlocks implements hive_blocks.HiveBlocks.
+func (m *MockHiveBlockDb) StoreBlocks(headBlock uint64, blocks ...hive_blocks.HiveBlock) error {
+	m.Blocks = append(m.Blocks, blocks...)
+	m.HeadHeight = headBlock
+	return nil
+}
+
+// ClearBlocks implements hive_blocks.HiveBlocks.
+func (m *MockHiveBlockDb) ClearBlocks() error {
+	m.Blocks = nil
+	m.LastProcessedBlock = 0
+	return nil
+}
+
+// StoreLastProcessedBlock implements hive_blocks.HiveBlocks.
+func (m *MockHiveBlockDb) StoreLastProcessedBlock(blockNumber uint64) error {
+	m.LastProcessedBlock = blockNumber
+	return nil
+}
+
+// GetLastProcessedBlock implements hive_blocks.HiveBlocks.
+func (m *MockHiveBlockDb) GetLastProcessedBlock() (uint64, error) {
+	if m.Blocks == nil {
+		return 0, nil
+	}
+	return m.LastProcessedBlock, nil
+}
+
+// FetchStoredBlocks implements hive_blocks.HiveBlocks.
+func (m *MockHiveBlockDb) FetchStoredBlocks(startBlock, endBlock uint64) ([]hive_blocks.HiveBlock, error) {
+	if m.Blocks == nil {
+		return []hive_blocks.HiveBlock{}, nil
+	}
+
+	startIndex := len(m.Blocks)
+	endIndex := len(m.Blocks)
+	for i, block := range m.Blocks {
+		if block.BlockNumber == startBlock {
+			startIndex = i
+		}
+		if block.BlockNumber == endBlock {
+			endIndex = i
+			break
+		}
+	}
+
+	return m.Blocks[startIndex : endIndex+1], nil
+}
+
+// ListenToBlockUpdates implements hive_blocks.HiveBlocks.
+func (m *MockHiveBlockDb) ListenToBlockUpdates(
+	ctx context.Context,
+	startBlock uint64,
+	listener func(block hive_blocks.HiveBlock, headHeight *uint64) error,
+) (context.CancelFunc, <-chan error) {
+	ctx, cancel := context.WithCancel(ctx)
+	errChan := make(chan error)
+	if m.Blocks == nil {
+		return cancel, errChan
+	}
+
+	go func() {
+		for _, block := range m.Blocks {
+			if block.BlockNumber >= startBlock {
+				select {
+				case <-ctx.Done():
+					break
+				default:
+					err := listener(block, &m.HeadHeight)
+					if err != nil {
+						errChan <- err
+						break
+					}
+				}
+			}
+		}
+	}()
+
+	return cancel, errChan
+}
+
+// GetHighestBlock implements hive_blocks.HiveBlocks.
+func (m *MockHiveBlockDb) GetHighestBlock() (uint64, error) {
+	if m.Blocks == nil || len(m.Blocks) == 0 {
+		return m.HeadHeight, nil
+	}
+	return m.Blocks[len(m.Blocks)-1].BlockNumber, nil
+}
+
+// GetBlock implements hive_blocks.HiveBlocks.
+func (m *MockHiveBlockDb) GetBlock(blockNum uint64) (hive_blocks.HiveBlock, error) {
+	for _, block := range m.Blocks {
+		if block.BlockNumber == blockNum {
+			return block, nil
+		}
+	}
+	return hive_blocks.HiveBlock{}, fmt.Errorf("block not found")
+}
+
+// GetMetadata implements hive_blocks.HiveBlocks.
+func (m *MockHiveBlockDb) GetMetadata() (hive_blocks.Document, error) {
+	return m.Metadata, nil
+}
+
+// SetMetadata implements hive_blocks.HiveBlocks.
+func (m *MockHiveBlockDb) SetMetadata(doc hive_blocks.Document) error {
+	m.Metadata = doc
+	return nil
+}
+
+// Init implements hive_blocks.HiveBlocks.
+func (m *MockHiveBlockDb) Init() error {
+	return nil
+}
+
+// Start implements hive_blocks.HiveBlocks.
+func (m *MockHiveBlockDb) Start() *promise.Promise[any] {
+	return utils.PromiseResolve[any](nil)
+}
+
+// Stop implements hive_blocks.HiveBlocks.
+func (m *MockHiveBlockDb) Stop() error {
+	m.Blocks = nil
+	m.LastProcessedBlock = 0
+	return nil
+}

--- a/modules/common/config.go
+++ b/modules/common/config.go
@@ -56,6 +56,13 @@ func (ac *identityConfigStruct) SetBlsPrivKeySeed(seedHex string) error {
 	})
 }
 
+// HasPrivateKey returns true when the Hive active key has been configured
+// (not empty and not the default sentinel placeholder).
+func (ac *identityConfigStruct) HasPrivateKey() bool {
+	key := ac.Get().HiveActiveKey
+	return key != "" && key != "ADD_YOUR_PRIVATE_WIF"
+}
+
 func (ac *identityConfigStruct) HiveActiveKeyPair() (*hivego.KeyPair, error) {
 	wif := ac.Get().HiveActiveKey
 	return hivego.KeyPairFromWif(wif)

--- a/modules/db/vsc/elections/elections.go
+++ b/modules/db/vsc/elections/elections.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"vsc-node/lib/dids"
+	"vsc-node/modules/common/consensusversion"
 	"vsc-node/modules/db"
 	"vsc-node/modules/db/vsc"
 
@@ -228,12 +229,29 @@ func MinimumSigningScore(lastElectionHeight int64, memberCount int64) {
 
 }
 
+const MIN_BLOCKS_SINCE_LAST_ELECTION = 1200   // 1 hour
+const MAX_BLOCKS_SINCE_LAST_ELECTION = 403200 // 2 weeks
+
 // MinimalRequiredElectionVotes returns the vote-weight threshold to finalize an
-// election: the BFT-safe 2/3 quorum of the electorate's weight, fixed with no
-// time-based decay. GV-H3: an earlier design decayed this floor to a bare
-// majority (floor(W/2 + 1)) over the MAX_BLOCKS_SINCE_LAST_ELECTION window
-func MinimalRequiredElectionVotes(memberCountOfLastElection uint64) uint64 {
-	return (2*memberCountOfLastElection + 2) / 3
+// election. For elections under consensus version 0.2.0+, the threshold is the
+// fixed BFT-safe 2/3 quorum. For pre-0.2.0 elections, the threshold decays from
+// 2/3 down to a bare majority (floor(W/2+1)) over the MAX_BLOCKS_SINCE_LAST_ELECTION
+// window, matching the legacy behavior that was in force when those elections were
+// proposed (GV-H3 retroactive compatibility).
+func MinimalRequiredElectionVotes(blocksSinceLastElection, memberCountOfLastElection uint64, activeVersion consensusversion.Version) uint64 {
+	if consensusversion.Version0_2_0Active(activeVersion) {
+		return (2*memberCountOfLastElection + 2) / 3
+	}
+	// Pre-0.2.0: legacy decay to bare majority (GV-H3 retroactive compatibility).
+	if blocksSinceLastElection < MIN_BLOCKS_SINCE_LAST_ELECTION {
+		return uint64(math.Ceil(float64(memberCountOfLastElection) * 2.0 / 3.0))
+	}
+	minMembers := int(math.Floor(float64(memberCountOfLastElection)/2 + 1))
+	maxMembers := int(math.Ceil(float64(memberCountOfLastElection) * 2.0 / 3.0))
+	cappedBlocks := math.Min(float64(blocksSinceLastElection), float64(MAX_BLOCKS_SINCE_LAST_ELECTION))
+	drift := (float64(MAX_BLOCKS_SINCE_LAST_ELECTION) - cappedBlocks) / float64(MAX_BLOCKS_SINCE_LAST_ELECTION)
+	mappedValue := float64(minMembers) + (float64(maxMembers)-float64(minMembers))*drift
+	return uint64(math.Round(mappedValue))
 }
 
 // MinimalRequiredConsensusVersionVotes is a fixed 2/3 stake threshold for adopting a proposed

--- a/modules/db/vsc/elections/elections_test.go
+++ b/modules/db/vsc/elections/elections_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"vsc-node/lib/test_utils"
 	"vsc-node/modules/aggregate"
+	"vsc-node/modules/common/consensusversion"
 	"vsc-node/modules/config"
 	"vsc-node/modules/db"
 	"vsc-node/modules/db/vsc"
@@ -13,20 +14,29 @@ import (
 )
 
 func TestElectionMinimum(t *testing.T) {
-	//Yes it won't fail
-	// GV-H3: the decay floor is now ceil(2N/3) (the BFT-safe quorum), not the old
-	// floor(N/2+1) bare majority. The threshold no longer drops over time, so the
-	// stale/decayed cases below now equal their fresh 2/3 value.
-	val := elections.MinimalRequiredElectionVotes(0)
+	// 0.2.0+ path: fixed 2/3 quorum (no decay).
+	v020 := consensusversion.V0_2_0
+	val := elections.MinimalRequiredElectionVotes(0, 0, v020)
 	assert.Equal(t, uint64(0), val)
-	val = elections.MinimalRequiredElectionVotes(8)
-	assert.Equal(t, uint64(6), val) // GV-H3: ceil(2*8/3)=6
-	val = elections.MinimalRequiredElectionVotes(9)
-	assert.Equal(t, uint64(6), val) // GV-H3: ceil(2*9/3)=6
-	val = elections.MinimalRequiredElectionVotes(100)
-	assert.Equal(t, uint64(67), val) // GV-H3: ceil(2*100/3)=67
-	val = elections.MinimalRequiredElectionVotes(101)
-	assert.Equal(t, uint64(68), val) // GV-H3: ceil(2*101/3)=68
+	val = elections.MinimalRequiredElectionVotes(0, 8, v020)
+	assert.Equal(t, uint64(6), val) // ceil(2*8/3)=6
+	val = elections.MinimalRequiredElectionVotes(0, 9, v020)
+	assert.Equal(t, uint64(6), val) // ceil(2*9/3)=6
+	val = elections.MinimalRequiredElectionVotes(0, 100, v020)
+	assert.Equal(t, uint64(67), val) // ceil(2*100/3)=67
+	val = elections.MinimalRequiredElectionVotes(0, 101, v020)
+	assert.Equal(t, uint64(68), val) // ceil(2*101/3)=68
+
+	// Pre-0.2.0 path: decay to bare majority over time.
+	v010 := consensusversion.Version{Major: 0, Consensus: 1, NonConsensus: 0}
+	// Fresh (< 1 hour): 2/3
+	val = elections.MinimalRequiredElectionVotes(0, 100, v010)
+	assert.Equal(t, uint64(67), val) // ceil(2*100/3)=67
+	// Fully stale (≥ 2 weeks): bare majority
+	val = elections.MinimalRequiredElectionVotes(403200, 100, v010)
+	assert.Equal(t, uint64(51), val) // floor(100/2+1)=51
+	val = elections.MinimalRequiredElectionVotes(403200, 8, v010)
+	assert.Equal(t, uint64(5), val) // floor(8/2+1)=5
 }
 
 func TestGetElectionByHeight(t *testing.T) {

--- a/modules/db/vsc/elections/review8_gvh3_test.go
+++ b/modules/db/vsc/elections/review8_gvh3_test.go
@@ -9,15 +9,26 @@ import (
 	"math"
 	"testing"
 
+	"vsc-node/modules/common/consensusversion"
+
 	"github.com/stretchr/testify/require"
 )
 
 func TestReview8_GVH3_ThresholdNeverBelowTwoThirds(t *testing.T) {
+	v020 := consensusversion.V0_2_0
 	for _, n := range []uint64{7, 20, 40} {
 		twoThirds := uint64(math.Ceil(float64(n) * 2.0 / 3.0))
 
-		// Threshold is the fixed 2/3 quorum (no time-based decay).
-		require.Equalf(t, twoThirds, MinimalRequiredElectionVotes(n),
+		// Threshold at 0.2.0+ is the fixed 2/3 quorum (no time-based decay).
+		require.Equalf(t, twoThirds, MinimalRequiredElectionVotes(0, n, v020),
 			"N=%d must be the 2/3 quorum, not N/2+1", n)
 	}
+
+	// Pre-0.2.0: fully stale threshold drops to bare majority.
+	v010 := consensusversion.Version{Major: 0, Consensus: 1, NonConsensus: 0}
+	n := uint64(20)
+	bareMajority := uint64(math.Floor(float64(n)/2 + 1)) // 11
+	staleVal := MinimalRequiredElectionVotes(MAX_BLOCKS_SINCE_LAST_ELECTION, n, v010)
+	require.Equalf(t, bareMajority, staleVal,
+		"pre-0.2.0 fully-stale N=%d must be bare majority floor(N/2+1)=%d", n, bareMajority)
 }

--- a/modules/e2e/container.go
+++ b/modules/e2e/container.go
@@ -101,8 +101,9 @@ func (c *E2EContainer) initClient() {
 	for _, peerStr := range peerAddrs {
 		peerId, _ := peer.AddrInfoFromString(peerStr)
 		ctx := context.Background()
-		ctx, _ = context.WithTimeout(ctx, 5*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		client.P2PService.Connect(ctx, *peerId)
+		cancel()
 	}
 
 	c.client = client
@@ -196,7 +197,7 @@ func (c *E2EContainer) Start(t *testing.T) error {
 	c.mockReader.ProcessFunction = func(block hive_blocks.HiveBlock, headHeight *uint64) {
 		fmt.Printf("ProcessFunction: block %d, txs=%d\n", block.BlockNumber, len(block.Transactions))
 		for _, node := range c.runningNodes {
-			node.MockHiveBlocks.HighestBlock = block.BlockNumber
+			node.MockHiveBlocks.HeadHeight = block.BlockNumber
 		}
 		for _, node := range c.runningNodes {
 			node.HiveConsumer.ProcessBlock(block, headHeight)
@@ -217,8 +218,9 @@ func (c *E2EContainer) Start(t *testing.T) error {
 			for _, peerStr := range peerAddrs {
 				peerId, _ := peer.AddrInfoFromString(peerStr)
 				ctx := context.Background()
-				ctx, _ = context.WithTimeout(ctx, 5*time.Second)
+				ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 				node.P2P.Connect(ctx, *peerId)
+				cancel()
 			}
 		}
 	}()

--- a/modules/e2e/e2e_test.go
+++ b/modules/e2e/e2e_test.go
@@ -290,7 +290,7 @@ func TestE2E(t *testing.T) {
 			}
 
 			fmt.Println("txId", txId)
-			return e2e.TxStatusAssertion([]e2e.TxStatusAssert{{txId, transactions.TransactionStatusConfirmed}}, 30), nil
+			return e2e.TxStatusAssertion([]e2e.TxStatusAssert{{txId, transactions.TransactionStatusConfirmed}}, 45), nil
 		},
 	})
 
@@ -407,7 +407,7 @@ func TestE2E(t *testing.T) {
 			}
 
 			fmt.Println("txId2", txId2)
-			return e2e.TxStatusAssertion([]e2e.TxStatusAssert{{txId, transactions.TransactionStatusConfirmed}, {txId2, transactions.TransactionStatusFailed}}, 30), nil
+			return e2e.TxStatusAssertion([]e2e.TxStatusAssert{{txId, transactions.TransactionStatusConfirmed}, {txId2, transactions.TransactionStatusFailed}}, 45), nil
 		},
 	})
 	// container.AddStep(r2e.Wait(10))

--- a/modules/e2e/mocks.go
+++ b/modules/e2e/mocks.go
@@ -1,86 +1,12 @@
 package e2e
 
 import (
-	"context"
 	"encoding/json"
-	"errors"
 	"strconv"
 	"strings"
-	"vsc-node/modules/db/vsc/hive_blocks"
 
-	"github.com/chebyrash/promise"
 	"github.com/vsc-eco/hivego"
 )
-
-type MockHiveDbs struct {
-	blocks map[uint64]*hive_blocks.HiveBlock
-
-	HighestBlock uint64
-}
-
-func (m *MockHiveDbs) StoreBlocks(processedBlk uint64, blocks ...hive_blocks.HiveBlock) error {
-	for _, block := range blocks {
-		m.blocks[block.BlockNumber] = &block
-	}
-	return nil
-}
-
-func (m *MockHiveDbs) ClearBlocks() error {
-	return nil
-}
-
-func (m *MockHiveDbs) StoreLastProcessedBlock(blockNumber uint64) error {
-	return nil
-}
-
-func (m *MockHiveDbs) GetLastProcessedBlock() (uint64, error) {
-	return 0, nil
-}
-
-func (m *MockHiveDbs) FetchStoredBlocks(startBlock uint64, endBlock uint64) ([]hive_blocks.HiveBlock, error) {
-	return nil, nil
-}
-
-func (m *MockHiveDbs) ListenToBlockUpdates(ctx context.Context, startBlock uint64, listener func(block hive_blocks.HiveBlock, heightHead *uint64) error) (context.CancelFunc, <-chan error) {
-	errCh := make(chan error)
-	return func() {}, errCh
-}
-
-func (m *MockHiveDbs) GetHighestBlock() (uint64, error) {
-	return m.HighestBlock, nil
-}
-
-func (m *MockHiveDbs) GetBlock(blockNum uint64) (hive_blocks.HiveBlock, error) {
-	if m.blocks[blockNum] == nil {
-		return hive_blocks.HiveBlock{}, errors.New("block not found")
-	}
-	return *m.blocks[blockNum], nil
-}
-
-func (m *MockHiveDbs) GetMetadata() (hive_blocks.Document, error) {
-	return hive_blocks.Document{}, nil
-}
-
-func (m *MockHiveDbs) SetMetadata(doc hive_blocks.Document) error {
-	return nil
-}
-
-func (m *MockHiveDbs) Init() error {
-	m.blocks = make(map[uint64]*hive_blocks.HiveBlock)
-	return nil
-}
-
-func (m *MockHiveDbs) Start() *promise.Promise[any] {
-	return promise.New(func(resolve func(interface{}), reject func(error)) {
-		resolve(nil)
-	})
-}
-
-func (m *MockHiveDbs) Stop() error {
-	return nil
-}
-
-var _ hive_blocks.HiveBlocks = &MockHiveDbs{}
 
 func TransformTx(tx hivego.HiveTransaction) []hivego.Operation {
 	var insertOps []hivego.Operation

--- a/modules/e2e/mocks.go
+++ b/modules/e2e/mocks.go
@@ -42,7 +42,8 @@ func (m *MockHiveDbs) FetchStoredBlocks(startBlock uint64, endBlock uint64) ([]h
 }
 
 func (m *MockHiveDbs) ListenToBlockUpdates(ctx context.Context, startBlock uint64, listener func(block hive_blocks.HiveBlock, heightHead *uint64) error) (context.CancelFunc, <-chan error) {
-	return nil, nil
+	errCh := make(chan error)
+	return func() {}, errCh
 }
 
 func (m *MockHiveDbs) GetHighestBlock() (uint64, error) {

--- a/modules/e2e/node.go
+++ b/modules/e2e/node.go
@@ -34,6 +34,7 @@ import (
 	p2pInterface "vsc-node/modules/p2p"
 	stateEngine "vsc-node/modules/state-processing"
 	transactionpool "vsc-node/modules/transaction-pool"
+	"vsc-node/lib/test_utils"
 	"vsc-node/modules/tss"
 
 	data_availability "vsc-node/modules/data-availability/server"
@@ -57,7 +58,7 @@ type Node struct {
 
 	announcementsManager *announcements.AnnouncementsManager
 
-	MockHiveBlocks   *MockHiveDbs
+	MockHiveBlocks   *test_utils.MockHiveBlockDb
 	electionDb       elections.Elections
 	contractsDb      contracts.Contracts
 	balanceDb        ledger_db.Balances
@@ -115,7 +116,7 @@ func MakeNode(input MakeNodeInput) *Node {
 
 	db := db.New(dbConf)
 	vscDb := vsc.New(db, dbConf)
-	hiveBlocks := &MockHiveDbs{}
+	hiveBlocks := &test_utils.MockHiveBlockDb{}
 	vscBlocks := vscBlocks.New(vscDb)
 	witnessesDb := witnesses.New(vscDb)
 	electionDb := elections.New(vscDb)

--- a/modules/e2e/utils.go
+++ b/modules/e2e/utils.go
@@ -61,21 +61,38 @@ type TxStatusAssert struct {
 
 func TxStatusAssertion(txns []TxStatusAssert, waitTimeSec uint) EvaluateFunc {
 	return func(ctx StepCtx) error {
-		time.Sleep(time.Duration(waitTimeSec) * time.Second)
+		deadline := time.After(time.Duration(waitTimeSec) * time.Second)
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
 
 		runner := ctx.Container.Runner()
 
-		for _, txn := range txns {
-			getTransaction := runner.TxDb.GetTransaction(txn.TxId)
-			if getTransaction == nil {
-				return errors.New("non-existent transaction")
+		for {
+			allGood := true
+			var lastErr error
+			for _, txn := range txns {
+				getTransaction := runner.TxDb.GetTransaction(txn.TxId)
+				if getTransaction == nil {
+					allGood = false
+					lastErr = errors.New("non-existent transaction")
+					break
+				}
+				tx := *getTransaction
+				if tx.Status != txn.ExpectedStatus {
+					allGood = false
+					lastErr = fmt.Errorf("incorrect status should be %s status is: %s", txn.ExpectedStatus, tx.Status)
+					break
+				}
 			}
-			tx := *getTransaction
-			if tx.Status != txn.ExpectedStatus {
-				return fmt.Errorf("incorrect status should be %s status is: %s", txn.ExpectedStatus, tx.Status)
+			if allGood {
+				return nil
+			}
+
+			select {
+			case <-deadline:
+				return lastErr
+			case <-ticker.C:
 			}
 		}
-
-		return nil
 	}
 }

--- a/modules/election-proposer/election-proposer.go
+++ b/modules/election-proposer/election-proposer.go
@@ -1393,7 +1393,15 @@ func (ep *electionProposer) HoldElection(blk uint64, options ...ElectionOptions)
 			totalWeight += electionResult.Weights[i]
 		}
 
-		voteMajority := elections.MinimalRequiredElectionVotes(totalWeight)
+		blocksSinceLastElection := anchorBh
+		if !firstElection {
+			blocksSinceLastElection = anchorBh - electionResult.BlockHeight
+		}
+		var activeVersion consensusversion.Version
+		if !firstElection {
+			activeVersion = elections.ResultVersion(electionResult)
+		}
+		voteMajority := elections.MinimalRequiredElectionVotes(blocksSinceLastElection, totalWeight, activeVersion)
 
 		if (votedWeight >= voteMajority) || firstElection {
 			// Send out Election to Hive

--- a/modules/hive/streamer/streamer_test.go
+++ b/modules/hive/streamer/streamer_test.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"testing"
 	"time"
-	"vsc-node/lib/utils"
 	"vsc-node/modules/aggregate"
 	"vsc-node/modules/db/vsc/hive_blocks"
 	"vsc-node/modules/hive/streamer"
@@ -20,7 +19,6 @@ import (
 
 	rand "math/rand/v2"
 
-	"github.com/chebyrash/promise"
 	"github.com/stretchr/testify/assert"
 	"github.com/vsc-eco/hivego"
 )
@@ -72,152 +70,6 @@ func seedBlockData(t *testing.T, hiveBlocks hive_blocks.HiveBlocks, n uint64) {
 		// store block
 		assert.NoError(t, hiveBlocks.StoreBlocks(n, block))
 	}
-}
-
-// ==== mock hive block db ====
-
-type MockHiveBlockDb struct {
-	Blocks             []hive_blocks.HiveBlock
-	LastProcessedBlock uint64
-	HeadHeight         uint64
-	Metadata           hive_blocks.Document
-}
-
-// GetMetadata implements hive_blocks.HiveBlocks.
-func (m *MockHiveBlockDb) GetMetadata() (hive_blocks.Document, error) {
-	return m.Metadata, nil
-}
-
-// SetMetadata implements hive_blocks.HiveBlocks.
-func (m *MockHiveBlockDb) SetMetadata(doc hive_blocks.Document) error {
-	m.Metadata = doc
-	return nil
-}
-
-// GetBlock implements hive_blocks.HiveBlocks.
-func (m *MockHiveBlockDb) GetBlock(blockNum uint64) (hive_blocks.HiveBlock, error) {
-	for _, block := range m.Blocks {
-		if block.BlockNumber == blockNum {
-			return block, nil
-		}
-	}
-
-	return hive_blocks.HiveBlock{}, fmt.Errorf("block not found")
-}
-
-// ListenToBlockUpdates implements hive_blocks.HiveBlocks.
-func (m *MockHiveBlockDb) ListenToBlockUpdates(
-	ctx context.Context,
-	startBlock uint64,
-	listener func(block hive_blocks.HiveBlock, headHeight *uint64) error,
-) (context.CancelFunc, <-chan error) {
-	ctx, cancel := context.WithCancel(ctx)
-	errChan := make(chan error)
-	if m.Blocks == nil {
-		return cancel, errChan
-	}
-
-	go func() {
-		for _, block := range m.Blocks {
-			if block.BlockNumber >= startBlock {
-				select {
-				case <-ctx.Done():
-					break
-				default:
-					err := listener(block, &m.HeadHeight)
-					if err != nil {
-						errChan <- err
-						break
-					}
-				}
-			}
-		}
-	}()
-
-	return cancel, errChan
-}
-
-var _ hive_blocks.HiveBlocks = &MockHiveBlockDb{}
-
-// ClearBlocks implements hive_blocks.HiveBlocks.
-func (m *MockHiveBlockDb) ClearBlocks() error {
-	m.Blocks = nil
-	m.LastProcessedBlock = 0
-	return nil
-}
-
-// FetchStoredBlocks implements hive_blocks.HiveBlocks.
-func (m *MockHiveBlockDb) FetchStoredBlocks(startBlock, endBlock uint64) ([]hive_blocks.HiveBlock, error) {
-	if m.Blocks == nil {
-		return []hive_blocks.HiveBlock{}, nil
-	}
-
-	startIndex := len(m.Blocks)
-	endIndex := len(m.Blocks)
-	for i, block := range m.Blocks {
-		if block.BlockNumber == startBlock {
-			startIndex = i
-		}
-		if block.BlockNumber == endBlock {
-			endIndex = i
-			break
-		}
-	}
-
-	return m.Blocks[startIndex : endIndex+1], nil
-}
-
-// GetHighestBlock implements hive_blocks.HiveBlocks.
-func (m *MockHiveBlockDb) GetHighestBlock() (uint64, error) {
-	if m.Blocks == nil {
-		return 0, nil
-	}
-
-	// we assume our highest is 0 if we have nothing yet
-	if len(m.Blocks) <= 0 {
-		return 0, nil
-	}
-
-	return m.Blocks[len(m.Blocks)-1].BlockNumber, nil
-}
-
-// GetLastProcessedBlock implements hive_blocks.HiveBlocks.
-func (m *MockHiveBlockDb) GetLastProcessedBlock() (uint64, error) {
-	if m.Blocks == nil {
-		return 0, nil
-	}
-
-	return m.LastProcessedBlock, nil
-}
-
-// StoreBlocks implements hive_blocks.HiveBlocks.
-func (m *MockHiveBlockDb) StoreBlocks(headBlock uint64, blocks ...hive_blocks.HiveBlock) error {
-	m.Blocks = append(m.Blocks, blocks...)
-	m.HeadHeight = headBlock
-	return nil
-}
-
-// StoreLastProcessedBlock implements hive_blocks.HiveBlocks.
-func (m *MockHiveBlockDb) StoreLastProcessedBlock(blockNumber uint64) error {
-	m.LastProcessedBlock = blockNumber
-	return nil
-}
-
-// Init implements hive_blocks.HiveBlocks.
-func (m *MockHiveBlockDb) Init() error {
-	return nil
-}
-
-// Start implements hive_blocks.HiveBlocks.
-func (m *MockHiveBlockDb) Start() *promise.Promise[any] {
-	return utils.PromiseResolve[any](nil)
-}
-
-// Stop implements hive_blocks.HiveBlocks.
-func (m *MockHiveBlockDb) Stop() error {
-	m.Blocks = nil
-	m.LastProcessedBlock = 0
-	return nil
 }
 
 // ===== mock hive block client service =====
@@ -280,7 +132,7 @@ func (m *MockBlockClient) FetchVirtualOps(
 
 func TestFetchStoreBlocks(t *testing.T) {
 	// hive mocks db
-	mockHiveBlocks := &MockHiveBlockDb{}
+	mockHiveBlocks := &test_utils.MockHiveBlockDb{}
 
 	startBlock := uint64(0)
 	blockClient := &MockBlockClient{}
@@ -318,7 +170,7 @@ func TestFetchStoreBlocks(t *testing.T) {
 func TestStartBlock(t *testing.T) {
 
 	// hive blocks
-	mockHiveBlocks := &MockHiveBlockDb{}
+	mockHiveBlocks := &test_utils.MockHiveBlockDb{}
 
 	test_utils.RunPlugin(t, mockHiveBlocks)
 
@@ -332,12 +184,12 @@ func TestStartBlock(t *testing.T) {
 	assert.NoError(t, s.Init())
 
 	// should be the value we input
-	assert.Equal(t, 99, s.StartBlock())
+	assert.Equal(t, uint64(99), s.StartBlock())
 }
 
 func TestIntensePolling(t *testing.T) {
 	// hive blocks
-	mockHiveBlocks := &MockHiveBlockDb{}
+	mockHiveBlocks := &test_utils.MockHiveBlockDb{}
 
 	s := streamer.NewStreamer(&MockBlockClient{}, mockHiveBlocks, nil, nil, nil)
 	seenBlocks := make(map[uint64]int)
@@ -364,7 +216,7 @@ func TestIntensePolling(t *testing.T) {
 
 func TestStreamFilter(t *testing.T) {
 	// hive blocks
-	mockHiveBlocks := &MockHiveBlockDb{}
+	mockHiveBlocks := &test_utils.MockHiveBlockDb{}
 
 	filter := func(op hivego.Operation, blockParams *streamer.BlockParams) bool {
 		// filter everything!
@@ -399,7 +251,7 @@ func TestStreamFilter(t *testing.T) {
 func TestPersistingBlocksStored(t *testing.T) {
 
 	// hive blocks
-	mockHiveBlocks := &MockHiveBlockDb{}
+	mockHiveBlocks := &test_utils.MockHiveBlockDb{}
 
 	// start at 0
 	s := streamer.NewStreamer(&MockBlockClient{}, mockHiveBlocks, nil, nil, nil)
@@ -433,7 +285,7 @@ func TestPersistingBlocksStored(t *testing.T) {
 
 func TestPersistingBlocksProcessed(t *testing.T) {
 	// hive blocks
-	mockHiveBlocks := &MockHiveBlockDb{}
+	mockHiveBlocks := &test_utils.MockHiveBlockDb{}
 
 	// start at default
 	s := streamer.NewStreamer(&MockBlockClient{}, mockHiveBlocks, nil, nil, nil)
@@ -490,7 +342,7 @@ func TestPersistingBlocksProcessed(t *testing.T) {
 
 func TestBlockProcessing(t *testing.T) {
 	// hive blocks
-	mockHiveBlocks := &MockHiveBlockDb{}
+	mockHiveBlocks := &test_utils.MockHiveBlockDb{}
 
 	test_utils.RunPlugin(t, mockHiveBlocks)
 
@@ -512,7 +364,7 @@ func TestBlockProcessing(t *testing.T) {
 
 // func TestStreamReaderPauseResumeStop(t *testing.T) {
 // 	// hive blocks
-// 	mockHiveBlocks := &MockHiveBlockDb{}
+// 	mockHiveBlocks := &test_utils.MockHiveBlockDb{}
 
 // 	test_utils.RunPlugin(t, mockHiveBlocks)
 
@@ -562,7 +414,7 @@ func TestBlockProcessing(t *testing.T) {
 
 func TestStreamPauseResumeStop(t *testing.T) {
 	// hive blocks
-	mockHiveBlocks := &MockHiveBlockDb{}
+	mockHiveBlocks := &test_utils.MockHiveBlockDb{}
 
 	test_utils.RunPlugin(t, mockHiveBlocks)
 
@@ -612,7 +464,7 @@ func TestStreamPauseResumeStop(t *testing.T) {
 
 func TestRestartingProcessingAfterHavingStoppedWithSomeLeft(t *testing.T) {
 	// hive blocks
-	mockHiveBlocks := &MockHiveBlockDb{}
+	mockHiveBlocks := &test_utils.MockHiveBlockDb{}
 
 	test_utils.RunPlugin(t, mockHiveBlocks)
 
@@ -648,7 +500,7 @@ func TestRestartingProcessingAfterHavingStoppedWithSomeLeft(t *testing.T) {
 
 func TestFilterOrdering(t *testing.T) {
 	// hive blocks
-	mockHiveBlocks := &MockHiveBlockDb{}
+	mockHiveBlocks := &test_utils.MockHiveBlockDb{}
 
 	filter1SeenBlocks := 0
 	filter2SeenBlocks := 0
@@ -682,7 +534,7 @@ func TestFilterOrdering(t *testing.T) {
 func TestBlockLag(t *testing.T) {
 
 	// hive blocks
-	mockHiveBlocks := &MockHiveBlockDb{}
+	mockHiveBlocks := &test_utils.MockHiveBlockDb{}
 
 	streamer.AcceptableBlockLag = 5
 	streamer.DefaultBlockStart = dummyBlockHead - 3
@@ -726,7 +578,7 @@ func TestBlockLag(t *testing.T) {
 
 func TestClearingStoredBlocks(t *testing.T) {
 	// hive blocks
-	mockHiveBlocks := &MockHiveBlockDb{}
+	mockHiveBlocks := &test_utils.MockHiveBlockDb{}
 
 	test_utils.RunPlugin(t, mockHiveBlocks)
 
@@ -763,7 +615,7 @@ func TestClearingStoredBlocks(t *testing.T) {
 }
 
 func TestClearingLastProcessedBlock(t *testing.T) {
-	mockHiveBlocks := &MockHiveBlockDb{}
+	mockHiveBlocks := &test_utils.MockHiveBlockDb{}
 
 	test_utils.RunPlugin(t, mockHiveBlocks)
 
@@ -795,7 +647,7 @@ func TestClearingLastProcessedBlock(t *testing.T) {
 func TestHeadBlock(t *testing.T) {
 
 	// hive blocks
-	mockHiveBlocks := &MockHiveBlockDb{}
+	mockHiveBlocks := &test_utils.MockHiveBlockDb{}
 
 	test_utils.RunPlugin(t, mockHiveBlocks)
 
@@ -808,7 +660,7 @@ func TestHeadBlock(t *testing.T) {
 	err = json.Unmarshal(dynData, &headBlock)
 	assert.NoError(t, err)
 
-	headBlockNum := int(headBlock["head_block_number"].(float64))
+	headBlockNum := uint64(headBlock["head_block_number"].(float64))
 
 	s := streamer.NewStreamer(mockClient, mockHiveBlocks, nil, nil, nil)
 
@@ -816,13 +668,15 @@ func TestHeadBlock(t *testing.T) {
 
 	time.Sleep(3 * time.Second)
 
-	assert.Equal(t, headBlockNum, s.HeadHeight())
+	actual := s.HeadHeight()
+	assert.GreaterOrEqual(t, actual, headBlockNum, "head height should be at least the dummy block head")
+	assert.LessOrEqual(t, actual, headBlockNum+1, "head height may be head+1 due to 3s ticker increment in trackHeadHeight")
 }
 
 func TestDbStoredBlockIntegrity(t *testing.T) {
 
 	// hive blocks
-	mockHiveBlocks := &MockHiveBlockDb{}
+	mockHiveBlocks := &test_utils.MockHiveBlockDb{}
 
 	test_utils.RunPlugin(t, mockHiveBlocks)
 
@@ -865,7 +719,7 @@ func TestDbStoredBlockIntegrity(t *testing.T) {
 
 func TestNestedArrayStructure(t *testing.T) {
 
-	mockHiveBlocks := &MockHiveBlockDb{}
+	mockHiveBlocks := &test_utils.MockHiveBlockDb{}
 
 	// clear existing data
 	assert.NoError(t, mockHiveBlocks.ClearBlocks())

--- a/modules/ledger-system/invariant_test.go
+++ b/modules/ledger-system/invariant_test.go
@@ -85,9 +85,8 @@ type mockLedgerSystem struct {
 func (m *mockLedgerSystem) GetBalance(account string, blockHeight uint64, asset string) int64 {
 	return m.state.SnapshotForAccount(account, blockHeight, asset)
 }
-func (m *mockLedgerSystem) ClaimHBDInterest(lastClaim uint64, blockHeight uint64, amount int64, txId string) {
-}
-func (m *mockLedgerSystem) IndexActions(actionUpdate map[string]interface{}, extraInfo ledgerSystem.ExtraInfo) {
+func (m *mockLedgerSystem) ClaimHBDInterest(lastClaim uint64, blockHeight uint64, amount int64, txId string) {}
+func (m *mockLedgerSystem) IndexActions(actionUpdate ledgerSystem.ActionUpdate, extraInfo ledgerSystem.ExtraInfo) {
 }
 func (m *mockLedgerSystem) Deposit(deposit ledgerSystem.Deposit) string { return "" }
 func (m *mockLedgerSystem) IngestOplog(oplog []ledgerSystem.OpLogEvent, options ledgerSystem.OplogInjestOptions) {

--- a/modules/ledger-system/ledger_system.go
+++ b/modules/ledger-system/ledger_system.go
@@ -873,23 +873,13 @@ func (ls *ledgerSystem) ClaimHBDInterest(lastClaim uint64, blockHeight uint64, a
 	//DONE
 }
 
-func (ls *ledgerSystem) IndexActions(actionUpdate map[string]interface{}, extraInfo ExtraInfo) {
+func (ls *ledgerSystem) IndexActions(actionUpdate ActionUpdate, extraInfo ExtraInfo) {
 	log.Debug("IndexActions", "actionUpdate", actionUpdate)
 
-	// review2 MED #86/#88 (sweep): actionUpdate is json.Unmarshal'd
-	// from an L1 custom_json payload. Bare assertions on ops /
-	// cleared_ops panicked block processing on a malformed (or
-	// future-divergent) vsc.actions op. Comma-ok and skip indexing
-	// this op deterministically instead.
-	opsRaw, opsOk := actionUpdate["ops"].([]interface{})
-	completeOps, clearedOk := actionUpdate["cleared_ops"].(string)
-	if !opsOk || !clearedOk {
-		log.Warn("skipping malformed vsc.actions op (ops/cleared_ops wrong type)",
-			"actionId", extraInfo.ActionId, "blockHeight", extraInfo.BlockHeight)
-		return
-	}
+	actionIds := actionUpdate.Ops
 
-	actionIds := common.ArrayToStringArray(opsRaw)
+	//All stake related ops
+	completeOps := actionUpdate.ClearedOps
 
 	b64, _ := base64.RawURLEncoding.DecodeString(completeOps)
 

--- a/modules/ledger-system/types.go
+++ b/modules/ledger-system/types.go
@@ -181,6 +181,12 @@ type ExtraInfo struct {
 	ActionId    string
 }
 
+// ActionUpdate represents the JSON payload for vsc.actions consensus operations.
+type ActionUpdate struct {
+	Ops        []string `json:"ops"`
+	ClearedOps string   `json:"cleared_ops"`
+}
+
 type LedgerSession interface {
 	GetBalance(account string, blockHeight uint64, asset string) int64
 	ExecuteTransfer(OpLogEvent OpLogEvent, options ...TransferOptions) LedgerResult
@@ -200,7 +206,7 @@ type LedgerSession interface {
 type LedgerSystem interface {
 	GetBalance(account string, blockHeight uint64, asset string) int64
 	ClaimHBDInterest(lastClaim uint64, blockHeight uint64, amount int64, txId string)
-	IndexActions(actionUpdate map[string]interface{}, extraInfo ExtraInfo)
+	IndexActions(actionUpdate ActionUpdate, extraInfo ExtraInfo)
 	Deposit(deposit Deposit) string
 	IngestOplog(oplog []OpLogEvent, options OplogInjestOptions)
 	// PendulumDistribute drains the pendulum:nodes:hbd bucket into a recipient

--- a/modules/ledger-system/utils.go
+++ b/modules/ledger-system/utils.go
@@ -195,26 +195,6 @@ func ExecuteOplog(oplog []OpLogEvent, startHeight uint64, endBlock uint64) struc
 			})
 		}
 	}
-	// assets := []string{"hbd", "hive", "hbd_savings"}
-
-	// fmt.Println("Affected Accounts", affectedAccounts)
-	// //Cleanup!
-	// for k := range affectedAccounts {
-	// 	ledgerBalances := map[string]int64{}
-	// 	for _, asset := range assets {
-	// 		//As of block X or below
-	// 		bal := ls.GetBalance(k, endBlock, asset)
-	// 		fmt.Println("bal", bal)
-	// 		ledgerBalances[asset] = bal
-
-	// 		// LedgerUpdates, _ := ls.LedgerDb.GetLedgerRange(k, startHeight, endBlock, asset)
-
-	// 		// for _, v := range *LedgerUpdates {
-	// 		// 	ledgerBalances[asset] += v.Amount
-	// 		// }
-	// 	}
-	// 	ls.BalanceDb.UpdateBalanceRecord(k, endBlock, ledgerBalances)
-	// }
 
 	accounts := make([]string, 0)
 	for k := range affectedAccounts {

--- a/modules/rc-system/rc_system_test.go
+++ b/modules/rc-system/rc_system_test.go
@@ -61,9 +61,8 @@ type mockLedgerSystem struct {
 func (m *mockLedgerSystem) GetBalance(account string, blockHeight uint64, asset string) int64 {
 	return m.balances[account+":"+asset]
 }
-func (m *mockLedgerSystem) ClaimHBDInterest(lastClaim uint64, blockHeight uint64, amount int64, txId string) {
-}
-func (m *mockLedgerSystem) IndexActions(actionUpdate map[string]interface{}, extraInfo ledgerSystem.ExtraInfo) {
+func (m *mockLedgerSystem) ClaimHBDInterest(lastClaim uint64, blockHeight uint64, amount int64, txId string) {}
+func (m *mockLedgerSystem) IndexActions(actionUpdate ledgerSystem.ActionUpdate, extraInfo ledgerSystem.ExtraInfo) {
 }
 func (m *mockLedgerSystem) Deposit(deposit ledgerSystem.Deposit) string { return "" }
 func (m *mockLedgerSystem) IngestOplog(oplog []ledgerSystem.OpLogEvent, options ledgerSystem.OplogInjestOptions) {

--- a/modules/state-processing/audit_c7a_savings_transfer_test.go
+++ b/modules/state-processing/audit_c7a_savings_transfer_test.go
@@ -19,15 +19,19 @@ import (
 )
 
 func TestAuditReview7_C7a_DetectsGatewaySavingsTransfer(t *testing.T) {
-	// transfer_to_savings to the gateway is the stranding case — must be detected.
-	require.True(t, isUnsupportedGatewaySavingsDeposit("transfer_to_savings", params.GATEWAY_WALLET),
-		"transfer_to_savings to the gateway must be flagged (was silently dropped)")
+	// External user sends transfer_to_savings to the gateway — stranding case.
+	require.True(t, isUnsupportedGatewaySavingsDeposit("transfer_to_savings", "user123", params.GATEWAY_WALLET),
+		"transfer_to_savings to the gateway from an external user must be flagged")
+
+	// Gateway sends transfer_to_savings to itself — normal operation, not flagged.
+	require.False(t, isUnsupportedGatewaySavingsDeposit("transfer_to_savings", params.GATEWAY_WALLET, params.GATEWAY_WALLET),
+		"gateway doing its own transfer_to_savings must not be flagged")
 
 	// A plain transfer to the gateway is the supported deposit path — not flagged.
-	require.False(t, isUnsupportedGatewaySavingsDeposit("transfer", params.GATEWAY_WALLET),
-		"a normal gateway deposit must not be flagged")
+	require.False(t, isUnsupportedGatewaySavingsDeposit("transfer", "user123", params.GATEWAY_WALLET),
+		"a normal transfer to the gateway must not be flagged")
 
 	// transfer_to_savings to some other account is unrelated to the gateway.
-	require.False(t, isUnsupportedGatewaySavingsDeposit("transfer_to_savings", "someuser"),
+	require.False(t, isUnsupportedGatewaySavingsDeposit("transfer_to_savings", "user123", "someuser"),
 		"transfer_to_savings to a non-gateway account is not our concern")
 }

--- a/modules/state-processing/safety_evidence_internal_test.go
+++ b/modules/state-processing/safety_evidence_internal_test.go
@@ -35,7 +35,7 @@ func (s *stubLedgerSystem) GetBalance(account string, blockHeight uint64, asset 
 }
 func (s *stubLedgerSystem) ClaimHBDInterest(lastClaim uint64, blockHeight uint64, amount int64, txId string) {
 }
-func (s *stubLedgerSystem) IndexActions(actionUpdate map[string]interface{}, extraInfo ledgerSystem.ExtraInfo) {
+func (s *stubLedgerSystem) IndexActions(actionUpdate ledgerSystem.ActionUpdate, extraInfo ledgerSystem.ExtraInfo) {
 }
 func (s *stubLedgerSystem) Deposit(deposit ledgerSystem.Deposit) string { return "" }
 func (s *stubLedgerSystem) IngestOplog(oplog []ledgerSystem.OpLogEvent, options ledgerSystem.OplogInjestOptions) {

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -1537,15 +1537,16 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 	//Detects new slot and executes batch if so
 	if se.slotStatus.SlotHeight != slotInfo.StartHeight {
 		//Updates balances index before next batch can execute
-		vscBlock, err := se.vscBlocks.GetBlockByHeight(se.slotStatus.SlotHeight - 1)
-		if err != nil && err != mongo.ErrNoDocuments {
-			log.Error("GetBlockByHeight failed, falling back to full-range balance scan",
-				"slotHeight", se.slotStatus.SlotHeight, "err", err)
-		}
-
 		startBlock := uint64(0)
-		if vscBlock != nil {
-			startBlock = uint64(vscBlock.EndBlock)
+		if se.slotStatus.SlotHeight > 0 {
+			vscBlock, err := se.vscBlocks.GetBlockByHeight(se.slotStatus.SlotHeight - 1)
+			if err != nil && err != mongo.ErrNoDocuments {
+				log.Error("GetBlockByHeight failed, falling back to full-range balance scan",
+					"slotHeight", se.slotStatus.SlotHeight, "err", err)
+			}
+			if vscBlock != nil {
+				startBlock = uint64(vscBlock.EndBlock)
+			}
 		}
 
 		se.UpdateBalances(startBlock, se.slotStatus.SlotHeight)

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -528,7 +528,7 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 
 				if Id == "vsc.actions" && RequiredAuths[0] == se.sconf.GatewayWallet() &&
 					!se.chainProcessingSuspended() {
-					actionUpdate := map[string]interface{}{}
+					var actionUpdate ledgerSystem.ActionUpdate
 					err := json.Unmarshal(cj.Json, &actionUpdate)
 
 					if err == nil {
@@ -595,10 +595,7 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 			jsonMeta, jsonMetaOk := opValue["json_metadata"].(string)
 			acct, acctOk := singleOp.Value["account"].(string)
 			if jsonMetaOk && acctOk {
-				untypedJson := make(map[string]interface{})
-
 				bbytes := []byte(jsonMeta)
-				json.Unmarshal(bbytes, &untypedJson)
 
 				rawJson := witnesses.PostingJsonMetadata{}
 				json.Unmarshal(bbytes, &rawJson)
@@ -677,13 +674,6 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 				//Start parsing block
 				if cj.Id == "vsc.produce_block" {
 					//Process block production
-					rawJson := map[string]interface{}{}
-					json.Unmarshal(cj.Json, &rawJson)
-					// parsedTx := TxProposeBlock{}
-					// json.Unmarshal(cj.Json, &parsedTx)
-
-					// parsedTx.ExecuteTx(se)
-
 					schedule := se.GetSchedule(slotInfo.StartHeight)
 
 					var scheduleSlot WitnessSlot
@@ -696,9 +686,6 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 					}
 
 					if cj.RequiredAuths[0] == scheduleSlot.Account {
-						rawJson := map[string]interface{}{}
-						json.Unmarshal(cj.Json, &rawJson)
-
 						parsedBlock := TxProposeBlock{
 							Self: txSelf,
 							SignedBlock: SignedBlockHeader{

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -963,8 +963,9 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 			// savings). Flag it loudly for manual refund instead of silently
 			// stranding it — the prior handler was dead code (see
 			// isUnsupportedGatewaySavingsDeposit).
-			if toStr, _ := op.Value["to"].(string); isUnsupportedGatewaySavingsDeposit(op.Type, op.Value["from"].(string), toStr) {
-				fromStr, _ := op.Value["from"].(string)
+			fromStr, _ := op.Value["from"].(string)
+			toStr, _ := op.Value["to"].(string)
+			if isUnsupportedGatewaySavingsDeposit(op.Type, fromStr, toStr) {
 				log.Warn(
 					"review7 C7-a: transfer_to_savings to gateway is not a supported deposit path — NOT credited, manual refund required",
 					"tx",

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -963,7 +963,7 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 			// savings). Flag it loudly for manual refund instead of silently
 			// stranding it — the prior handler was dead code (see
 			// isUnsupportedGatewaySavingsDeposit).
-			if toStr, _ := op.Value["to"].(string); isUnsupportedGatewaySavingsDeposit(op.Type, toStr) {
+			if toStr, _ := op.Value["to"].(string); isUnsupportedGatewaySavingsDeposit(op.Type, op.Value["from"].(string), toStr) {
 				fromStr, _ := op.Value["from"].(string)
 				log.Warn(
 					"review7 C7-a: transfer_to_savings to gateway is not a supported deposit path — NOT credited, manual refund required",
@@ -1640,8 +1640,8 @@ func witnessAnnounceHasRogueBlsKey(meta witnesses.PostingJsonMetadata, account s
 // branch, so unreachable for a transfer_to_savings op), which silently stranded
 // the funds with no L2 credit and no audit trail. The caller flags these for
 // manual refund instead of dropping them silently.
-func isUnsupportedGatewaySavingsDeposit(opType, to string) bool {
-	return opType == "transfer_to_savings" && to == params.GATEWAY_WALLET
+func isUnsupportedGatewaySavingsDeposit(opType, from, to string) bool {
+	return opType == "transfer_to_savings" && from != params.GATEWAY_WALLET && to == params.GATEWAY_WALLET
 }
 
 // executeTxSafely runs a transaction handler with panic recovery so that a

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -617,16 +617,23 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 					// DA payload — never the witness DB — so a divergent witness record
 					// cannot split state ingestion; the only residual effect is on what a
 					// node would propose/sign.
-					if witnessAnnounceHasRogueBlsKey(rawJson, acct) {
-						se.warnSync(
-							blockInfo.BlockHeight,
-							"witness announce REJECTED: consensus BLS key failed proof-of-possession (rogue-key guard)",
-							"account",
-							acct,
-							"txId",
-							tx.TransactionID,
-						)
-						continue
+					//
+					// PoP is only enforced once the chain-active consensus version
+					// reaches 0.2.0. Before that line, witnesses were not required to
+					// include PoPs — retroactively rejecting pre-0.2.0 announces during
+					// reindex would drop valid historical witnesses from the set.
+					if consensusversion.Version0_2_0Active(se.ActiveConsensusVersion(blockInfo.BlockHeight)) {
+						if witnessAnnounceHasRogueBlsKey(rawJson, acct) {
+							se.warnSync(
+								blockInfo.BlockHeight,
+								"witness announce REJECTED: consensus BLS key failed proof-of-possession (rogue-key guard)",
+								"account",
+								acct,
+								"txId",
+								tx.TransactionID,
+							)
+							continue
+						}
 					}
 					inputData := witnesses.SetWitnessUpdateType{
 						Account:  acct,

--- a/modules/state-processing/system_txs.go
+++ b/modules/state-processing/system_txs.go
@@ -660,7 +660,8 @@ func (tx *TxElectionResult) ExecuteTx(se *StateEngine) {
 			}
 		}
 
-		minimums := elections.MinimalRequiredElectionVotes(totalWeight)
+		blocksLastElection := tx.Self.BlockHeight - prevElection.BlockHeight
+		minimums := elections.MinimalRequiredElectionVotes(blocksLastElection, totalWeight, elections.ResultVersion(*prevElection))
 
 		realWeight := uint64(0)
 		bv := blsCircuit.RawBitVector()

--- a/modules/state-processing/utils.go
+++ b/modules/state-processing/utils.go
@@ -518,14 +518,6 @@ func HashAuths(auths []string) *cid.Cid {
 	return &cid
 }
 
-func copyJsonToType(src map[string]interface{}, dest interface{}) error {
-	bytes, err := json.Marshal(src)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(bytes, dest)
-}
-
 type Buffer struct {
 	c chan byte
 }

--- a/modules/state-processing/utils.go
+++ b/modules/state-processing/utils.go
@@ -463,9 +463,7 @@ func (mc *MockCreator) ingestTx(tx hive_blocks.Tx, txId ...string) TxConfirmatio
 }
 
 func (mc *MockCreator) ingestVp(v hivego.VirtualOp) {
-	// mc.Mr.mutex.Lock()
 	mc.Mr.VMempool = append(mc.Mr.VMempool, v)
-	// mc.Mr.mutex.Unlock()
 }
 
 func (mc *MockCreator) hashTx(bbytes []byte) string {
@@ -530,16 +528,12 @@ func copyJsonToType(src map[string]interface{}, dest interface{}) error {
 
 type Buffer struct {
 	c chan byte
-	// *io.PipeReader
-	// *io.PipeWriter
 }
 
 func NewBuffer() *Buffer {
 	return &Buffer{
 		c: make(chan byte, 8*1024*1024),
 	} // TODO by making the buffer size very large, the test will no longer be flaky. Does this indicate a likely problem in production?
-	// r, w := io.Pipe()
-	// return &Buffer{r, w}
 }
 
 func (b *Buffer) Read(p []byte) (n int, err error) {


### PR DESCRIPTION
## fixes a number of changes that caused state divergence during a reindex
1. uint64 underflow at reindex start — [389f40f2]
2. PoP/rogue-key check gated on 0.2.0 — [7c65595c]
3. Decaying election threshold gated on 0.2.0 — [bf4e3ac2]
4. Typed ActionUpdate + drop redundant unmarshals — [fac3ac62]
5. C7-a type-assertion panic fix — [bd6a73bb]
6. Don't warn for normal gateway ops — [eea2b848]
7. Disable participation plugins when no key — [9439fb43]
8. Test consolidation — [3e5c1c9d], [6b2ec60d] — test-only