### PR TITLE
Restore and reserve spend vote system

### DIFF
--- a/cmd/vsc-node/main.go
+++ b/cmd/vsc-node/main.go
@@ -289,6 +289,7 @@ func main() {
 		TssKeys:        tssKeys,
 		TssCommitments: tssCommitments,
 		TssRequests:    tssRequests,
+		Governance:     governanceDb,
 		InterestClaims: interestClaims,
 		ChainOracle:    oracle.ChainOracle(),
 	}}), gqlConf)

--- a/cmd/vsc-node/main.go
+++ b/cmd/vsc-node/main.go
@@ -21,6 +21,7 @@ import (
 	"vsc-node/modules/db/vsc/consensus_state"
 	"vsc-node/modules/db/vsc/contracts"
 	"vsc-node/modules/db/vsc/elections"
+	governance_db "vsc-node/modules/db/vsc/governance"
 	"vsc-node/modules/db/vsc/hive_blocks"
 	ledgerDb "vsc-node/modules/db/vsc/ledger"
 	"vsc-node/modules/db/vsc/nonces"
@@ -96,6 +97,7 @@ func main() {
 	tssKeys := tss_db.NewKeys(vscDb)
 	tssCommitments := tss_db.NewCommitments(vscDb)
 	tssRequests := tss_db.NewRequests(vscDb)
+	governanceDb := governance_db.New(vscDb)
 	pendulumSettlementsDb := pendulum_settlements.New(vscDb)
 	consensusStateDb := consensus_state.New(vscDb)
 	sysConfig := systemconfig.FromNetwork(args.network)
@@ -200,6 +202,7 @@ func main() {
 		tssKeys,
 		tssCommitments,
 		tssRequests,
+		governanceDb,
 		pendulumSettlementsDb,
 		consensusStateDb,
 		wasm,
@@ -322,6 +325,7 @@ func main() {
 		tssKeys,
 		tssCommitments,
 		tssRequests,
+		governanceDb,
 		pendulumSettlementsDb,
 		consensusStateDb,
 

--- a/lib/test_utils/contract_test_utils.go
+++ b/lib/test_utils/contract_test_utils.go
@@ -130,6 +130,7 @@ func NewContractTest() ContractTest {
 		&tssKeys,
 		&tssCommitments,
 		&tssRequests,
+		nil, // governanceDb
 		nil, // pendulumSettlementsDb
 		nil, // consensusStateDb
 		nil, // wasm

--- a/modules/common/consensusversion/feature_gates.go
+++ b/modules/common/consensusversion/feature_gates.go
@@ -82,3 +82,40 @@ func ContractUpdateTimelockActive(active Version) bool {
 func GatewayDecentralizationActive(active Version) bool {
 	return Version0_2_0Active(active)
 }
+
+// V0_3_0 is the consensus version line at which the v0.3.0 witness-vote
+// GOVERNANCE batch activates. Every consensus-affecting change in v0.3.0 keys off
+// this single version so the network has ONE coordinated activation, driven by
+// the election floor reaching 0.3.0.
+var V0_3_0 = Version{Major: 0, Consensus: 3, NonConsensus: 0}
+
+// Version0_3_0Active reports whether the v0.3.0 batch is in force given the
+// chain-active consensus version. `active` is resolved by the caller from the
+// on-chain election (deterministic, replay-correct). Below the line every v0.3.0
+// rule is inert and behavior stays byte-identical to 0.2.0, so old and new
+// binaries interoperate until the floor reaches 0.3.0.
+func Version0_3_0Active(active Version) bool {
+	return active.MeetsConsensusMin(V0_3_0)
+}
+
+// GovernanceActionsActive reports whether the witness-vote governance ops
+// (vsc.slash_restore, vsc.reserve_payout, vsc.reserve_vote) are in force given
+// the chain-active consensus version. Resolve `active` from the version active at
+// the op's block height (StateEngine.ActiveConsensusVersion(blockHeight)); below
+// the line the ops are ignored on every node, so a full reindex reproduces
+// historical state and a laggard is excluded from the committee rather than
+// applying the ops over a chain that didn't.
+func GovernanceActionsActive(active Version) bool {
+	return Version0_3_0Active(active)
+}
+
+// SafetySlashBurnDelay7dActive reports whether a new safety slash uses the
+// extended 7-day pending-burn window (vs the original 3 days), given the chain-
+// active consensus version. Resolve `active` from the version active at the
+// SLASH's own height (StateEngine.ActiveConsensusVersion(slashHeight)) so the
+// stored maturity (slashHeight + delay) recomputes identically on replay; below
+// the line the window stays 3 days. It shares the v0.3.0 line with the governance
+// ops it backs, so both flip together.
+func SafetySlashBurnDelay7dActive(active Version) bool {
+	return Version0_3_0Active(active)
+}

--- a/modules/common/consensusversion/feature_gates_test.go
+++ b/modules/common/consensusversion/feature_gates_test.go
@@ -1,0 +1,53 @@
+package consensusversion
+
+import "testing"
+
+// TestV0_3_0Gates pins the v0.3.0 governance batch activation: every v0.3.0
+// feature is inert at/below 0.2.0 and active at/above 0.3.0, all keyed off the
+// single V0_3_0 line so the governance ops and the 7-day pending window flip
+// together. non_consensus is ignored (coordination is on major.consensus only).
+func TestV0_3_0Gates(t *testing.T) {
+	below := []Version{
+		{Major: 0, Consensus: 0},
+		{Major: 0, Consensus: 1},
+		{Major: 0, Consensus: 2, NonConsensus: 9}, // 0.2.x is still below the line
+	}
+	// Coordination is componentwise on major.consensus (MeetsConsensusMin), so
+	// "above" means same major with consensus >= 3 (a major bump resets consensus
+	// and is a separate coordination — not exercised here).
+	atOrAbove := []Version{
+		{Major: 0, Consensus: 3},
+		{Major: 0, Consensus: 3, NonConsensus: 7}, // non_consensus ignored
+		{Major: 0, Consensus: 4},
+		{Major: 0, Consensus: 9},
+	}
+
+	for _, v := range below {
+		if Version0_3_0Active(v) {
+			t.Errorf("Version0_3_0Active(%s) = true, want false (below the line)", v.Format())
+		}
+		if GovernanceActionsActive(v) {
+			t.Errorf("GovernanceActionsActive(%s) = true, want false", v.Format())
+		}
+		if SafetySlashBurnDelay7dActive(v) {
+			t.Errorf("SafetySlashBurnDelay7dActive(%s) = true, want false", v.Format())
+		}
+	}
+	for _, v := range atOrAbove {
+		if !Version0_3_0Active(v) {
+			t.Errorf("Version0_3_0Active(%s) = false, want true (at/above the line)", v.Format())
+		}
+		if !GovernanceActionsActive(v) {
+			t.Errorf("GovernanceActionsActive(%s) = false, want true", v.Format())
+		}
+		if !SafetySlashBurnDelay7dActive(v) {
+			t.Errorf("SafetySlashBurnDelay7dActive(%s) = false, want true", v.Format())
+		}
+	}
+
+	// The shipped binary must run the version it implements, so the floor can rise.
+	if RunningVersion().Cmp(V0_3_0) != 0 {
+		t.Errorf("RunningVersion() = %s, want %s (bump in the same commit as the v0.3.0 gates)",
+			RunningVersion().Format(), V0_3_0.Format())
+	}
+}

--- a/modules/common/consensusversion/version.go
+++ b/modules/common/consensusversion/version.go
@@ -37,9 +37,17 @@ import (
 //     pendulum.LPFloorActivation.
 //     Until 0.2.0 is chain-active both behaviors are inert and splits/call semantics stay
 //     byte-identical to 0.1.0, so old and new binaries interoperate until activation.
+//   - 0.3.0 — the Consensus 2→3 bump gates the witness-vote GOVERNANCE batch, all
+//     activated together when the election floor reaches 0.3.0 (consensusversion.V0_3_0):
+//     (a) the vsc.slash_restore / vsc.reserve_payout / vsc.reserve_vote ops
+//     (GovernanceActionsActive) — below the line the ops are inert on every node;
+//     (b) the extended 7-day safety-slash pending window (SafetySlashBurnDelay7dActive),
+//     which backs (a) by giving witnesses time to gather a slash_restore quorum before
+//     the residual matures. Until 0.3.0 is chain-active the ops are ignored and the
+//     pending window stays 3 days, so old and new binaries interoperate until activation.
 const (
 	currentMajor        uint64 = 0
-	currentConsensus    uint64 = 2
+	currentConsensus    uint64 = 3
 	currentNonConsensus uint64 = 0
 )
 

--- a/modules/common/consensusversion/version_test.go
+++ b/modules/common/consensusversion/version_test.go
@@ -44,7 +44,7 @@ func TestMaxComponentwise(t *testing.T) {
 // pinned current triple. Update this pin in the SAME commit that bumps the constants in
 // version.go.
 func TestRunningVersionIsSourcePinned(t *testing.T) {
-	want := Version{Major: 0, Consensus: 2, NonConsensus: 0}
+	want := Version{Major: 0, Consensus: 3, NonConsensus: 0}
 	if got := RunningVersion(); got != want {
 		t.Fatalf("running version = %+v, want %+v (source constants in version.go)", got, want)
 	}

--- a/modules/common/params/burn_delay_test.go
+++ b/modules/common/params/burn_delay_test.go
@@ -2,36 +2,17 @@ package params
 
 import "testing"
 
-// TestSafetySlashBurnDelayBlocks pins the forward-only 3d→7d gate. The window is
-// a function of the SLASH's own height so maturity (slashHeight+delay) recomputes
-// identically on replay and raising the window can't retroactively shift history.
-func TestSafetySlashBurnDelayBlocks(t *testing.T) {
-	const h = uint64(108_000_000)
-
-	// Not scheduled (0): always the 3-day window.
-	unset := ConsensusParams{SafetySlashBurnDelay7dHeight: 0}
-	for _, height := range []uint64{0, h, h + 1_000_000} {
-		if got := unset.SafetySlashBurnDelayBlocks(height); got != SafetySlashBurnDelay3dBlocks {
-			t.Errorf("unset gate at height %d = %d, want 3d (%d)", height, got, SafetySlashBurnDelay3dBlocks)
-		}
+// TestSafetySlashBurnDelayConstants pins the 3d/7d pending-window constants. The
+// 3d↔7d CHOICE is no longer a params method — it moved to a version gate
+// (consensusversion.SafetySlashBurnDelay7dActive, resolved in state-processing
+// from the chain-active version at the slash's own height), so the gate's
+// behavior is covered there and in the consensusversion package. This guards only
+// that the window magnitudes themselves don't drift.
+func TestSafetySlashBurnDelayConstants(t *testing.T) {
+	if SafetySlashBurnDelay3dBlocks != 3*28800 {
+		t.Errorf("SafetySlashBurnDelay3dBlocks drifted: got %d, want %d", SafetySlashBurnDelay3dBlocks, 3*28800)
 	}
-
-	// Scheduled at h: 3d strictly before, 7d at/after.
-	cp := ConsensusParams{SafetySlashBurnDelay7dHeight: h}
-	cases := map[uint64]uint64{
-		h - 1: SafetySlashBurnDelay3dBlocks,
-		h:     SafetySlashBurnDelay7dBlocks,
-		h + 1: SafetySlashBurnDelay7dBlocks,
-		0:     SafetySlashBurnDelay3dBlocks,
-	}
-	for height, want := range cases {
-		if got := cp.SafetySlashBurnDelayBlocks(height); got != want {
-			t.Errorf("SafetySlashBurnDelayBlocks(%d) = %d, want %d", height, got, want)
-		}
-	}
-
-	// Sanity on the constants.
-	if SafetySlashBurnDelay3dBlocks != 3*28800 || SafetySlashBurnDelay7dBlocks != 7*28800 {
-		t.Fatalf("unexpected window constants: 3d=%d 7d=%d", SafetySlashBurnDelay3dBlocks, SafetySlashBurnDelay7dBlocks)
+	if SafetySlashBurnDelay7dBlocks != 7*28800 {
+		t.Errorf("SafetySlashBurnDelay7dBlocks drifted: got %d, want %d", SafetySlashBurnDelay7dBlocks, 7*28800)
 	}
 }

--- a/modules/common/params/burn_delay_test.go
+++ b/modules/common/params/burn_delay_test.go
@@ -1,0 +1,37 @@
+package params
+
+import "testing"
+
+// TestSafetySlashBurnDelayBlocks pins the forward-only 3d→7d gate. The window is
+// a function of the SLASH's own height so maturity (slashHeight+delay) recomputes
+// identically on replay and raising the window can't retroactively shift history.
+func TestSafetySlashBurnDelayBlocks(t *testing.T) {
+	const h = uint64(108_000_000)
+
+	// Not scheduled (0): always the 3-day window.
+	unset := ConsensusParams{SafetySlashBurnDelay7dHeight: 0}
+	for _, height := range []uint64{0, h, h + 1_000_000} {
+		if got := unset.SafetySlashBurnDelayBlocks(height); got != SafetySlashBurnDelay3dBlocks {
+			t.Errorf("unset gate at height %d = %d, want 3d (%d)", height, got, SafetySlashBurnDelay3dBlocks)
+		}
+	}
+
+	// Scheduled at h: 3d strictly before, 7d at/after.
+	cp := ConsensusParams{SafetySlashBurnDelay7dHeight: h}
+	cases := map[uint64]uint64{
+		h - 1: SafetySlashBurnDelay3dBlocks,
+		h:     SafetySlashBurnDelay7dBlocks,
+		h + 1: SafetySlashBurnDelay7dBlocks,
+		0:     SafetySlashBurnDelay3dBlocks,
+	}
+	for height, want := range cases {
+		if got := cp.SafetySlashBurnDelayBlocks(height); got != want {
+			t.Errorf("SafetySlashBurnDelayBlocks(%d) = %d, want %d", height, got, want)
+		}
+	}
+
+	// Sanity on the constants.
+	if SafetySlashBurnDelay3dBlocks != 3*28800 || SafetySlashBurnDelay7dBlocks != 7*28800 {
+		t.Fatalf("unexpected window constants: 3d=%d 7d=%d", SafetySlashBurnDelay3dBlocks, SafetySlashBurnDelay7dBlocks)
+	}
+}

--- a/modules/common/params/params.go
+++ b/modules/common/params/params.go
@@ -335,22 +335,6 @@ type ConsensusParams struct {
 	// decision changes ledger state, so this is a fixed network-wide constant
 	// every node shares. 0 falls back to DefaultGovernanceProposalExpiryBlocks.
 	GovernanceProposalExpiryBlocks uint64 `json:"governanceProposalExpiryBlocks,omitempty"`
-
-	// SafetySlashBurnDelay7dHeight is the FORWARD-ONLY activation height for the
-	// extended 7-day safety-slash pending window (vs the original 3 days). A slash
-	// occurring at slashHeight uses the 7-day window iff slashHeight >= this value
-	// (and this != 0); earlier slashes keep the 3-day window. The longer window
-	// gives witnesses more time to notice a wrongful slash and gather a
-	// slash_restore quorum before the residual matures into the reserve.
-	//
-	// CONSENSUS-CRITICAL: the window length is read at slash-application time and
-	// folded into the STORED maturity (slashHeight + delay). Because the gate keys
-	// off the slash's OWN height it is recomputed identically on replay, so raising
-	// the window can NEVER retroactively shift a historical maturity (which would
-	// diverge a resync — the same footgun as SafetySlashWindows). Pin it STRICTLY
-	// ABOVE chain head with every witness upgraded first. 0 = not yet scheduled
-	// (stays 3 days), the safe default.
-	SafetySlashBurnDelay7dHeight uint64 `json:"safetySlashBurnDelay7dHeight,omitempty"`
 }
 
 // DefaultGovernanceProposalExpiryBlocks is the fallback proposal voting window
@@ -360,22 +344,16 @@ const DefaultGovernanceProposalExpiryBlocks uint64 = 3 * 28800
 const (
 	// SafetySlashBurnDelay3dBlocks is the original ~3-day pending-burn window
 	// (mirrors safetyslash.DefaultSafetySlashBurnDelayBlocks; kept here to avoid a
-	// params→safety_slash import just for the gate).
+	// params→safety_slash import just for the gate). Used below the v0.3.0 line.
 	SafetySlashBurnDelay3dBlocks uint64 = 3 * 28800
-	// SafetySlashBurnDelay7dBlocks is the extended ~7-day pending-burn window.
+	// SafetySlashBurnDelay7dBlocks is the extended ~7-day pending-burn window, in
+	// force once the chain-active consensus version reaches 0.3.0 (the v0.3.0
+	// governance batch — see consensusversion.SafetySlashBurnDelay7dActive). The
+	// 7d/3d choice is resolved in state-processing from the version active at the
+	// slash's own height, NOT a raw activation height, so it flips in lockstep with
+	// the governance slash_restore op it backs.
 	SafetySlashBurnDelay7dBlocks uint64 = 7 * 28800
 )
-
-// SafetySlashBurnDelayBlocks returns the pending-burn challenge-window length (in
-// L1 blocks) for a slash occurring at slashHeight: the 7-day window at/after
-// SafetySlashBurnDelay7dHeight, the 3-day window before it. Keying off the slash's
-// own height keeps maturity deterministic across replay (see the field comment).
-func (cp ConsensusParams) SafetySlashBurnDelayBlocks(slashHeight uint64) uint64 {
-	if cp.SafetySlashBurnDelay7dHeight != 0 && slashHeight >= cp.SafetySlashBurnDelay7dHeight {
-		return SafetySlashBurnDelay7dBlocks
-	}
-	return SafetySlashBurnDelay3dBlocks
-}
 
 // HeightWindow is a half-open [Start, End) range of L1 block heights. End == 0
 // means open-ended (no upper bound). Used by SafetySlashWindows to schedule

--- a/modules/common/params/params.go
+++ b/modules/common/params/params.go
@@ -324,6 +324,57 @@ type ConsensusParams struct {
 	// order, or mid-list open-ended) is rejected by ValidSafetySlashWindows, which
 	// is asserted against every shipped config in tests.
 	SafetySlashWindows []HeightWindow `json:"safetySlashWindows,omitempty"`
+
+	// GovernanceProposalExpiryBlocks is how long a witness-vote governance
+	// proposal (vsc.slash_restore / vsc.reserve_payout) stays open to collect
+	// approvals, in L1 blocks. A proposal that has not crossed the 2/3 threshold
+	// by creationBlock+this is closed. For a slash_restore the effective window
+	// is additionally capped to the slash's remaining pending time
+	// (min(expiry, maturity−creation) — see governance.EffectiveExpiry); it never
+	// extends the slash's fixed maturity. CONSENSUS-CRITICAL: the tally/expiry
+	// decision changes ledger state, so this is a fixed network-wide constant
+	// every node shares. 0 falls back to DefaultGovernanceProposalExpiryBlocks.
+	GovernanceProposalExpiryBlocks uint64 `json:"governanceProposalExpiryBlocks,omitempty"`
+
+	// SafetySlashBurnDelay7dHeight is the FORWARD-ONLY activation height for the
+	// extended 7-day safety-slash pending window (vs the original 3 days). A slash
+	// occurring at slashHeight uses the 7-day window iff slashHeight >= this value
+	// (and this != 0); earlier slashes keep the 3-day window. The longer window
+	// gives witnesses more time to notice a wrongful slash and gather a
+	// slash_restore quorum before the residual matures into the reserve.
+	//
+	// CONSENSUS-CRITICAL: the window length is read at slash-application time and
+	// folded into the STORED maturity (slashHeight + delay). Because the gate keys
+	// off the slash's OWN height it is recomputed identically on replay, so raising
+	// the window can NEVER retroactively shift a historical maturity (which would
+	// diverge a resync — the same footgun as SafetySlashWindows). Pin it STRICTLY
+	// ABOVE chain head with every witness upgraded first. 0 = not yet scheduled
+	// (stays 3 days), the safe default.
+	SafetySlashBurnDelay7dHeight uint64 `json:"safetySlashBurnDelay7dHeight,omitempty"`
+}
+
+// DefaultGovernanceProposalExpiryBlocks is the fallback proposal voting window
+// (~3 days at 3s/block) used when a network pins no explicit value.
+const DefaultGovernanceProposalExpiryBlocks uint64 = 3 * 28800
+
+const (
+	// SafetySlashBurnDelay3dBlocks is the original ~3-day pending-burn window
+	// (mirrors safetyslash.DefaultSafetySlashBurnDelayBlocks; kept here to avoid a
+	// params→safety_slash import just for the gate).
+	SafetySlashBurnDelay3dBlocks uint64 = 3 * 28800
+	// SafetySlashBurnDelay7dBlocks is the extended ~7-day pending-burn window.
+	SafetySlashBurnDelay7dBlocks uint64 = 7 * 28800
+)
+
+// SafetySlashBurnDelayBlocks returns the pending-burn challenge-window length (in
+// L1 blocks) for a slash occurring at slashHeight: the 7-day window at/after
+// SafetySlashBurnDelay7dHeight, the 3-day window before it. Keying off the slash's
+// own height keeps maturity deterministic across replay (see the field comment).
+func (cp ConsensusParams) SafetySlashBurnDelayBlocks(slashHeight uint64) uint64 {
+	if cp.SafetySlashBurnDelay7dHeight != 0 && slashHeight >= cp.SafetySlashBurnDelay7dHeight {
+		return SafetySlashBurnDelay7dBlocks
+	}
+	return SafetySlashBurnDelay3dBlocks
 }
 
 // HeightWindow is a half-open [Start, End) range of L1 block heights. End == 0
@@ -400,6 +451,15 @@ func (cp ConsensusParams) ValidSafetySlashWindows() error {
 		}
 	}
 	return nil
+}
+
+// GovernanceProposalExpiry returns the configured proposal voting window in L1
+// blocks, falling back to DefaultGovernanceProposalExpiryBlocks when unset (0).
+func (cp ConsensusParams) GovernanceProposalExpiry() uint64 {
+	if cp.GovernanceProposalExpiryBlocks == 0 {
+		return DefaultGovernanceProposalExpiryBlocks
+	}
+	return cp.GovernanceProposalExpiryBlocks
 }
 
 // BondInclusionActive reports whether the bond inclusion-window maturity gate

--- a/modules/common/system-config/system-config.go
+++ b/modules/common/system-config/system-config.go
@@ -204,19 +204,11 @@ func MainnetConfig() SystemConfig {
 			TssIndexHeight:                 params.TSS_INDEX_HEIGHT,
 			ElectionInterval:               params.ELECTION_INTERVAL,
 			ElectionDupeFixEpoch:           1406,
-			ConsensusVersionFloorEpoch:     1698,
+			ConsensusVersionFloorEpoch:     1712,
 			ConsensusVersionFloorMajor:     0,
 			ConsensusVersionFloorConsensus: 2,
 			PendulumSeedEpoch:              1622,
 			EvmAddressChecksumHeight:       106_907_500,
-			// v0.2.0 release activation: the contract-update timelock, gateway-key
-			// strict admission, gateway dao-removal, try/catch ICC and the pendulum
-			// LP-floor all gate on the CHAIN-ACTIVE CONSENSUS VERSION reaching 0.2.0
-			// (consensusversion.V0_2_0), driven by the floor below — NOT a dedicated
-			// height. The floor is currently 0.1.0 (epoch 1623), so the whole v0.2.0
-			// batch is inert. To roll out: raise ConsensusVersionFloorConsensus to 2
-			// at a future epoch boundary (CP-1 devnet-proven first — see the gateway
-			// dao-removal note in modules/gateway/multisig.go).
 			// Bond inclusion window (CP-2): 86,400 Hive blocks = 3 days @ 3s.
 			// Activation height 0 = INERT (no behavior change) until an operator
 			// pins a future epoch-boundary height (>=3d lead) for rollout.
@@ -380,15 +372,15 @@ func DevnetConfig() SystemConfig {
 			ConsensusVersionActivationNum: 4,
 			ConsensusVersionActivationDen: 5,
 			// Ephemeral network (fresh per run): pin the consensus-version floor to
-			// 0.2.0 from epoch 1 so the whole v0.2.0 batch is active from genesis and
-			// exercised by devnet/regression tests. Replaces the old
-			// Version0_2_0Height=1; this is the same floor pin the try/catch and
-			// LP-floor devnet tests already use (and pass with). No reindex concern —
-			// devnet is fresh per run and every node runs the current 0.2.0 binary,
-			// so the floor never excludes a witness.
+			// 0.3.0 from epoch 1 so the whole v0.2.0 AND v0.3.0 batches are active
+			// from genesis and exercised by devnet/regression tests (the governance
+			// slash_restore / reserve_payout / reserve_vote ops and the 7-day
+			// pending window all gate on 0.3.0). No reindex concern — devnet is fresh
+			// per run and every node runs the current 0.3.0 binary, so the floor
+			// never excludes a witness.
 			ConsensusVersionFloorEpoch:     1,
 			ConsensusVersionFloorMajor:     0,
-			ConsensusVersionFloorConsensus: 2,
+			ConsensusVersionFloorConsensus: 3,
 			// Bond inclusion window (CP-2): tiny 80-block window for fast devnet
 			// tests. Activation 0 = inert; devnet test harness pins a low height
 			// to exercise the gate.

--- a/modules/common/system-config/system-config.go
+++ b/modules/common/system-config/system-config.go
@@ -204,9 +204,9 @@ func MainnetConfig() SystemConfig {
 			TssIndexHeight:                 params.TSS_INDEX_HEIGHT,
 			ElectionInterval:               params.ELECTION_INTERVAL,
 			ElectionDupeFixEpoch:           1406,
-			ConsensusVersionFloorEpoch:     1712,
+			ConsensusVersionFloorEpoch:     1713,
 			ConsensusVersionFloorMajor:     0,
-			ConsensusVersionFloorConsensus: 2,
+			ConsensusVersionFloorConsensus: 3,
 			PendulumSeedEpoch:              1622,
 			EvmAddressChecksumHeight:       106_907_500,
 			// Bond inclusion window (CP-2): 86,400 Hive blocks = 3 days @ 3s.

--- a/modules/db/vsc/governance/governance.go
+++ b/modules/db/vsc/governance/governance.go
@@ -65,6 +65,11 @@ type Governance interface {
 	RecordVote(v ProposalVote) error
 	// GetVotes returns every vote row for a proposal (excludes the proposal row).
 	GetVotes(proposalId string) ([]ProposalVote, error)
+	// ListProposals returns proposal rows (voter="") matching the optional
+	// proposalId/type/status filters, newest creation_block first, paginated by
+	// offset/limit. Read-only — backs the GraphQL governance query, never the
+	// consensus path.
+	ListProposals(byProposalId, byType, byStatus *string, offset, limit int) ([]Proposal, error)
 }
 
 type governance struct {
@@ -152,6 +157,44 @@ func (g *governance) GetVotes(proposalId string) ([]ProposalVote, error) {
 			return nil, err
 		}
 		out = append(out, v)
+	}
+	return out, nil
+}
+
+func (g *governance) ListProposals(byProposalId, byType, byStatus *string, offset, limit int) ([]Proposal, error) {
+	filter := bson.M{"voter": ""} // proposal rows only
+	if byProposalId != nil && *byProposalId != "" {
+		filter["proposal_id"] = *byProposalId
+	}
+	if byType != nil && *byType != "" {
+		filter["type"] = *byType
+	}
+	if byStatus != nil && *byStatus != "" {
+		filter["status"] = *byStatus
+	}
+	// Newest creation first, proposal_id as a stable tiebreak for paging.
+	opts := options.Find().SetSort(bson.D{
+		{Key: "creation_block", Value: -1},
+		{Key: "proposal_id", Value: 1},
+	})
+	if offset > 0 {
+		opts.SetSkip(int64(offset))
+	}
+	if limit > 0 {
+		opts.SetLimit(int64(limit))
+	}
+	cursor, err := g.Find(context.Background(), filter, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(context.Background())
+	out := make([]Proposal, 0)
+	for cursor.Next(context.Background()) {
+		var p Proposal
+		if err := cursor.Decode(&p); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
 	}
 	return out, nil
 }

--- a/modules/db/vsc/governance/governance.go
+++ b/modules/db/vsc/governance/governance.go
@@ -1,0 +1,172 @@
+// Package governance_db is the deterministic persistence layer for the
+// witness-vote governance engine (see modules/governance for the pure tally
+// logic). It stores proposals and per-witness votes in a single Mongo
+// collection keyed by (proposal_id, voter): the proposal row is the one with an
+// empty voter, votes are the rows with a witness account. Writes are
+// idempotent upserts so block replay converges (mirrors tss_db.SetCommitmentData).
+package governance_db
+
+import (
+	"context"
+
+	a "vsc-node/modules/aggregate"
+	"vsc-node/modules/db"
+	"vsc-node/modules/db/vsc"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// Proposal is the persisted governance-proposal row (the (proposal_id, voter="")
+// row). One per proposal_id. CreationBlock anchors both the expiry window and
+// the electorate snapshot, so it must be the block of the FIRST vote — which is
+// identical on every node because votes are applied in L1 order.
+type Proposal struct {
+	ProposalId    string `bson:"proposal_id"`
+	Voter         string `bson:"voter"` // always "" for the proposal row
+	Type          string `bson:"type"`
+	Status        string `bson:"status"`
+	CreationBlock uint64 `bson:"creation_block"`
+	Beneficiary   string `bson:"beneficiary"` // normalized; excluded from the vote
+	AppliedBlock  uint64 `bson:"applied_block,omitempty"`
+	AppliedTxId   string `bson:"applied_tx_id,omitempty"`
+
+	// slash_restore payload (resolved from the on-chain slash row at creation).
+	SlashTxId      string `bson:"slash_tx_id,omitempty"`
+	EvidenceKind   string `bson:"evidence_kind,omitempty"`
+	SlashedAccount string `bson:"slashed_account,omitempty"`
+
+	// reserve_payout payload.
+	Recipient string `bson:"recipient,omitempty"`
+	Reason    string `bson:"reason,omitempty"`
+
+	// shared
+	Amount int64 `bson:"amount,omitempty"` // sats
+}
+
+// ProposalVote is one witness's approve vote (a (proposal_id, voter=account)
+// row). One per voter; re-votes upsert the same row.
+type ProposalVote struct {
+	ProposalId  string `bson:"proposal_id"`
+	Voter       string `bson:"voter"` // normalized account
+	BlockHeight uint64 `bson:"block_height"`
+	TxId        string `bson:"tx_id"`
+}
+
+// Governance is the store interface consumed by the state engine.
+type Governance interface {
+	a.Plugin
+	// GetProposal returns the proposal row for an id; ok=false if none exists yet.
+	GetProposal(proposalId string) (Proposal, bool, error)
+	// SaveProposal upserts the proposal row (voter="").
+	SaveProposal(p Proposal) error
+	// RecordVote upserts a single witness vote, deduped on (proposal_id, voter).
+	RecordVote(v ProposalVote) error
+	// GetVotes returns every vote row for a proposal (excludes the proposal row).
+	GetVotes(proposalId string) ([]ProposalVote, error)
+}
+
+type governance struct {
+	*db.Collection
+}
+
+var _ Governance = &governance{}
+
+func New(d *vsc.VscDb) Governance {
+	return &governance{db.NewCollection(d.DbInstance, "governance_proposals")}
+}
+
+func (g *governance) GetProposal(proposalId string) (Proposal, bool, error) {
+	res := g.FindOne(context.Background(), bson.M{"proposal_id": proposalId, "voter": ""})
+	if err := res.Err(); err != nil {
+		if err == mongo.ErrNoDocuments {
+			return Proposal{}, false, nil
+		}
+		return Proposal{}, false, err
+	}
+	var p Proposal
+	if err := res.Decode(&p); err != nil {
+		return Proposal{}, false, err
+	}
+	return p, true, nil
+}
+
+func (g *governance) SaveProposal(p Proposal) error {
+	p.Voter = "" // the proposal row is always voter=""
+	opts := options.FindOneAndUpdate().SetUpsert(true)
+	res := g.FindOneAndUpdate(context.Background(),
+		bson.M{"proposal_id": p.ProposalId, "voter": ""},
+		bson.M{"$set": bson.M{
+			"type":            p.Type,
+			"status":          p.Status,
+			"creation_block":  p.CreationBlock,
+			"beneficiary":     p.Beneficiary,
+			"applied_block":   p.AppliedBlock,
+			"applied_tx_id":   p.AppliedTxId,
+			"slash_tx_id":     p.SlashTxId,
+			"evidence_kind":   p.EvidenceKind,
+			"slashed_account": p.SlashedAccount,
+			"recipient":       p.Recipient,
+			"reason":          p.Reason,
+			"amount":          p.Amount,
+		}},
+		opts)
+	if err := res.Err(); err != nil && err != mongo.ErrNoDocuments {
+		return err
+	}
+	return nil
+}
+
+func (g *governance) RecordVote(v ProposalVote) error {
+	if v.Voter == "" {
+		return nil // a blank voter would collide with the proposal row; ignore
+	}
+	opts := options.FindOneAndUpdate().SetUpsert(true)
+	res := g.FindOneAndUpdate(context.Background(),
+		bson.M{"proposal_id": v.ProposalId, "voter": v.Voter},
+		bson.M{"$set": bson.M{
+			"block_height": v.BlockHeight,
+			"tx_id":        v.TxId,
+		}},
+		opts)
+	if err := res.Err(); err != nil && err != mongo.ErrNoDocuments {
+		return err
+	}
+	return nil
+}
+
+func (g *governance) GetVotes(proposalId string) ([]ProposalVote, error) {
+	cursor, err := g.Find(context.Background(), bson.M{
+		"proposal_id": proposalId,
+		"voter":       bson.M{"$ne": ""},
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(context.Background())
+	out := make([]ProposalVote, 0)
+	for cursor.Next(context.Background()) {
+		var v ProposalVote
+		if err := cursor.Decode(&v); err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+func (g *governance) Init() error {
+	if err := g.Collection.Init(); err != nil {
+		return err
+	}
+	// Unique (proposal_id, voter): one proposal row (voter="") + one row per
+	// voter. Enforces vote dedup at the storage layer.
+	return g.CreateIndexIfNotExist(mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "proposal_id", Value: 1},
+			{Key: "voter", Value: 1},
+		},
+		Options: options.Index().SetUnique(true),
+	})
+}

--- a/modules/e2e/node.go
+++ b/modules/e2e/node.go
@@ -17,6 +17,7 @@ import (
 	"vsc-node/modules/db/vsc/consensus_state"
 	"vsc-node/modules/db/vsc/contracts"
 	"vsc-node/modules/db/vsc/elections"
+	governance_db "vsc-node/modules/db/vsc/governance"
 	ledger_db "vsc-node/modules/db/vsc/ledger"
 	"vsc-node/modules/db/vsc/nonces"
 	"vsc-node/modules/db/vsc/pendulum_settlements"
@@ -133,6 +134,7 @@ func MakeNode(input MakeNodeInput) *Node {
 	tssRequests := tss_db.NewRequests(vscDb)
 	tssCommitments := tss_db.NewCommitments(vscDb)
 	tssKeys := tss_db.NewKeys(vscDb)
+	governanceDb := governance_db.New(vscDb)
 	pendulumSettlementsDb := pendulum_settlements.New(vscDb)
 	consensusStateDb := consensus_state.New(vscDb)
 
@@ -181,6 +183,7 @@ func MakeNode(input MakeNodeInput) *Node {
 		tssKeys,
 		tssCommitments,
 		tssRequests,
+		governanceDb,
 		pendulumSettlementsDb,
 		consensusStateDb,
 		wasm,
@@ -285,6 +288,7 @@ func MakeNode(input MakeNodeInput) *Node {
 		tssCommitments,
 		tssKeys,
 		tssRequests,
+		governanceDb,
 		pendulumSettlementsDb,
 		consensusStateDb,
 		dataAvailability,

--- a/modules/e2e/node.go
+++ b/modules/e2e/node.go
@@ -322,6 +322,7 @@ func MakeNode(input MakeNodeInput) *Node {
 			TssKeys:        tssKeys,
 			TssCommitments: tssCommitments,
 			TssRequests:    tssRequests,
+			Governance:     governanceDb,
 			InterestClaims: interestClaims,
 		}}), gqlConfig)
 		plugins = append(plugins, gqlManager)

--- a/modules/governance/governance.go
+++ b/modules/governance/governance.go
@@ -1,0 +1,169 @@
+// Package governance holds the deterministic, dependency-free core of the
+// witness-vote governance engine: vote tallying, the supermajority threshold,
+// beneficiary exclusion, and proposal expiry math.
+//
+// The whole point of this package is that it is PURE — given the same inputs it
+// returns the same outputs on every node, with no DB, clock, or network access.
+// That is what lets the state engine tally L1-broadcast votes during block
+// replay and reach an identical approve/expire decision everywhere (the same
+// determinism property the slash itself relies on). The persistence layer
+// (modules/db/vsc/governance) and the L1 op handlers (state-processing) wrap
+// this; they never re-implement the math.
+package governance
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"strings"
+)
+
+// ProposalType enumerates the governance actions tallied through the shared
+// witness-vote engine. The string values are persisted and appear in derived
+// proposal ids, so they are part of the on-chain contract — do not rename.
+type ProposalType string
+
+const (
+	// ProposalSlashRestore is the light path: cancel a pending safety-slash and
+	// re-credit the HIVE_CONSENSUS bond while the slash is still in its pending
+	// window (see applySafetySlashReverse, action "both").
+	ProposalSlashRestore ProposalType = "slash_restore"
+	// ProposalReservePayout is the heavy path: debit the keyless insurance
+	// reserve and credit a named recipient. The general make-whole mechanism for
+	// matured slashes and theft victims.
+	ProposalReservePayout ProposalType = "reserve_payout"
+)
+
+// ProposalStatus is the lifecycle state of a proposal row.
+type ProposalStatus string
+
+const (
+	// StatusOpen: accepting votes, not yet approved or expired.
+	StatusOpen ProposalStatus = "open"
+	// StatusApplied: crossed the threshold and the ledger effect was applied.
+	// Terminal and idempotent — further votes are no-ops.
+	StatusApplied ProposalStatus = "applied"
+	// StatusExpired: reached its effective expiry without approval. Terminal.
+	StatusExpired ProposalStatus = "expired"
+)
+
+// Member is one electorate entry: a witness account and its voting weight
+// (election stake weight). Built by the caller from an ElectionResult snapshot.
+type Member struct {
+	Account string
+	Weight  uint64
+}
+
+// NormalizeAccount canonicalizes a Hive account name for comparison: trims
+// surrounding space, lowercases, and strips a leading "hive:" prefix, so a vote
+// op's RequiredAuths account, an election member, and a beneficiary all compare
+// on the same key regardless of which surface produced them.
+func NormalizeAccount(a string) string {
+	a = strings.ToLower(strings.TrimSpace(a))
+	a = strings.TrimPrefix(a, "hive:")
+	return a
+}
+
+// EffectiveWeight sums the weights of the electorate EXCLUDING the beneficiary.
+// This is the denominator basis for the threshold: the beneficiary of a payout
+// never counts toward — or against — its own approval (no self-dealing). The
+// exclusion is deterministic (derived from the on-chain election + the resolved
+// beneficiary), so every node computes the same basis.
+func EffectiveWeight(electorate []Member, beneficiary string) uint64 {
+	ben := NormalizeAccount(beneficiary)
+	var total uint64
+	for _, m := range electorate {
+		if NormalizeAccount(m.Account) == ben {
+			continue
+		}
+		total += m.Weight
+	}
+	return total
+}
+
+// RequiredWeight is the minimal voted weight to approve: a BFT-safe 2/3+
+// supermajority of the beneficiary-excluded electorate weight, computed as
+// ceil(2W/3) = (2W+2)/3. This matches the election helper
+// (MinimalRequiredElectionVotes on 0.2.0) so governance and block consensus
+// share one threshold shape. Returns 0 only when the effective electorate is
+// empty; IsApproved treats that as never-approved rather than auto-approve.
+func RequiredWeight(electorate []Member, beneficiary string) uint64 {
+	w := EffectiveWeight(electorate, beneficiary)
+	if w == 0 {
+		return 0
+	}
+	return (2*w + 2) / 3
+}
+
+// Tally sums the weights of electorate members who have cast an approve vote,
+// EXCLUDING the beneficiary. voters is the set of NORMALIZED accounts that voted
+// (the caller dedups and normalizes); a voter not in the electorate snapshot
+// contributes nothing.
+func Tally(electorate []Member, beneficiary string, voters map[string]bool) uint64 {
+	ben := NormalizeAccount(beneficiary)
+	var total uint64
+	for _, m := range electorate {
+		acct := NormalizeAccount(m.Account)
+		if acct == ben {
+			continue
+		}
+		if voters[acct] {
+			total += m.Weight
+		}
+	}
+	return total
+}
+
+// IsApproved reports whether the voted weight meets the approval threshold over
+// the beneficiary-excluded electorate. It requires a strictly positive required
+// weight, so a degenerate all-beneficiary (or empty) electorate can never
+// auto-approve a payout to the beneficiary.
+func IsApproved(electorate []Member, beneficiary string, voters map[string]bool) bool {
+	req := RequiredWeight(electorate, beneficiary)
+	if req == 0 {
+		return false
+	}
+	return Tally(electorate, beneficiary, voters) >= req
+}
+
+// EffectiveExpiry returns the block height at which a proposal closes: the
+// EARLIER of (creationBlock + expiryBlocks) and, when maturity != 0, the slash's
+// maturity height. This is the locked "simple-cap" rule — a slash_restore window
+// is min(expiry, remaining pending time) and NEVER extends the slash's fixed
+// maturity. maturity == 0 means "no maturity cap" (reserve_payout, which is not
+// bounded by a pending window). Overflow of creationBlock+expiryBlocks is not a
+// concern at real Hive heights.
+func EffectiveExpiry(creationBlock, expiryBlocks, maturity uint64) uint64 {
+	exp := creationBlock + expiryBlocks
+	if maturity != 0 && maturity < exp {
+		return maturity
+	}
+	return exp
+}
+
+// IsExpired reports whether currentBlock has reached or passed the proposal's
+// effective expiry. Expiry is inclusive (a proposal at exactly the expiry height
+// is closed) so the boundary is unambiguous across nodes.
+func IsExpired(currentBlock, creationBlock, expiryBlocks, maturity uint64) bool {
+	return currentBlock >= EffectiveExpiry(creationBlock, expiryBlocks, maturity)
+}
+
+// ReservePayoutProposalID derives the deterministic id for a reserve-payout
+// proposal from its content (normalized recipient, amount, reason) PLUS the
+// create op's tx id. Folding in createTxID means two distinct create ops are two
+// distinct proposals — voters reference this id rather than reproducing the
+// content, and a one-satoshi difference can't silently merge votes across
+// unrelated payouts. Fields are null-delimited (a byte that can't appear in a
+// Hive account or an integer) so the reason text can't be crafted to collide
+// with a different (recipient, amount).
+func ReservePayoutProposalID(recipient string, amount int64, reason, createTxID string) string {
+	h := sha256.New()
+	h.Write([]byte(NormalizeAccount(recipient)))
+	h.Write([]byte{0})
+	h.Write([]byte(strconv.FormatInt(amount, 10)))
+	h.Write([]byte{0})
+	h.Write([]byte(reason))
+	h.Write([]byte{0})
+	h.Write([]byte(strings.TrimSpace(createTxID)))
+	return string(ProposalReservePayout) + ":" + hex.EncodeToString(h.Sum(nil))
+}

--- a/modules/governance/governance_test.go
+++ b/modules/governance/governance_test.go
@@ -1,0 +1,130 @@
+package governance
+
+import "testing"
+
+func members(pairs ...any) []Member {
+	out := make([]Member, 0, len(pairs)/2)
+	for i := 0; i+1 < len(pairs); i += 2 {
+		out = append(out, Member{Account: pairs[i].(string), Weight: uint64(pairs[i+1].(int))})
+	}
+	return out
+}
+
+func voterSet(accts ...string) map[string]bool {
+	m := make(map[string]bool, len(accts))
+	for _, a := range accts {
+		m[NormalizeAccount(a)] = true
+	}
+	return m
+}
+
+func TestNormalizeAccount(t *testing.T) {
+	cases := map[string]string{
+		"hive:Mengao.VSC": "mengao.vsc",
+		"  milo.vsc  ":    "milo.vsc",
+		"BOB":             "bob",
+		"hive:alice":      "alice",
+	}
+	for in, want := range cases {
+		if got := NormalizeAccount(in); got != want {
+			t.Errorf("NormalizeAccount(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestThresholdAndTally pins the supermajority math and beneficiary exclusion.
+// Electorate of 4 equal-weight members; the beneficiary is excluded from both
+// numerator and denominator, so the effective electorate is 3 and the threshold
+// is ceil(2*3/3)=2.
+func TestThresholdAndTally(t *testing.T) {
+	e := members("a", 1, "b", 1, "c", 1, "victim", 1)
+	ben := "victim"
+
+	if got := EffectiveWeight(e, ben); got != 3 {
+		t.Fatalf("EffectiveWeight = %d, want 3 (beneficiary excluded)", got)
+	}
+	if got := RequiredWeight(e, ben); got != 2 {
+		t.Fatalf("RequiredWeight = %d, want 2 (ceil(2*3/3))", got)
+	}
+
+	// One non-beneficiary vote: below threshold.
+	if IsApproved(e, ben, voterSet("a")) {
+		t.Error("1 of 3 should not approve")
+	}
+	// Two non-beneficiary votes: meets threshold.
+	if !IsApproved(e, ben, voterSet("a", "b")) {
+		t.Error("2 of 3 should approve")
+	}
+	// The beneficiary's own vote must not count toward the tally.
+	if Tally(e, ben, voterSet("victim")) != 0 {
+		t.Error("beneficiary self-vote must contribute 0")
+	}
+	if IsApproved(e, ben, voterSet("victim", "a")) {
+		t.Error("beneficiary + 1 other (=1 counting vote) should not approve")
+	}
+}
+
+// TestWeightedThreshold checks weights, not just counts, drive the tally.
+func TestWeightedThreshold(t *testing.T) {
+	// Total non-beneficiary weight = 10+5+3 = 18; required = ceil(36/3)=12.
+	e := members("big", 10, "mid", 5, "small", 3, "victim", 100)
+	ben := "victim"
+	if got := RequiredWeight(e, ben); got != 12 {
+		t.Fatalf("RequiredWeight = %d, want 12", got)
+	}
+	if !IsApproved(e, ben, voterSet("big", "mid")) { // 15 >= 12
+		t.Error("big+mid (15) should approve")
+	}
+	if IsApproved(e, ben, voterSet("big", "small")) { // 13 >= 12 -> approve
+		// 13 >= 12 actually approves; assert that
+	} else {
+		t.Error("big+small (13) should approve")
+	}
+	if IsApproved(e, ben, voterSet("mid", "small")) { // 8 < 12
+		t.Error("mid+small (8) should not approve")
+	}
+	// The huge-weight beneficiary cannot tip its own payout.
+	if IsApproved(e, ben, voterSet("victim")) {
+		t.Error("beneficiary weight must be excluded entirely")
+	}
+}
+
+// TestDegenerateElectorate guards against auto-approval when the effective
+// (beneficiary-excluded) electorate is empty.
+func TestDegenerateElectorate(t *testing.T) {
+	if RequiredWeight(members("victim", 5), "victim") != 0 {
+		t.Error("all-beneficiary electorate should have 0 required weight")
+	}
+	if IsApproved(members("victim", 5), "victim", voterSet("victim")) {
+		t.Error("empty effective electorate must never auto-approve")
+	}
+	if IsApproved(nil, "victim", voterSet()) {
+		t.Error("nil electorate must never auto-approve")
+	}
+}
+
+// TestEffectiveExpiry pins the simple-cap rule: min(creation+expiry, maturity),
+// with maturity==0 meaning no cap.
+func TestEffectiveExpiry(t *testing.T) {
+	const expiry = 86400 // 3d
+	// No maturity cap (reserve_payout): pure creation+expiry.
+	if got := EffectiveExpiry(1000, expiry, 0); got != 1000+expiry {
+		t.Errorf("no-cap expiry = %d, want %d", got, 1000+expiry)
+	}
+	// Maturity far in the future: expiry wins.
+	if got := EffectiveExpiry(1000, expiry, 10_000_000); got != 1000+expiry {
+		t.Errorf("distant-maturity expiry = %d, want %d", got, 1000+expiry)
+	}
+	// Maturity sooner than expiry: maturity caps the window.
+	if got := EffectiveExpiry(1000, expiry, 5000); got != 5000 {
+		t.Errorf("near-maturity expiry = %d, want 5000", got)
+	}
+
+	// IsExpired boundary is inclusive.
+	if !IsExpired(5000, 1000, expiry, 5000) {
+		t.Error("at maturity height the proposal must be expired")
+	}
+	if IsExpired(4999, 1000, expiry, 5000) {
+		t.Error("just before maturity the proposal must be live")
+	}
+}

--- a/modules/gql/gqlgen/governance_test.go
+++ b/modules/gql/gqlgen/governance_test.go
@@ -1,0 +1,117 @@
+package gqlgen
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vsc-node/modules/aggregate"
+	governance_db "vsc-node/modules/db/vsc/governance"
+)
+
+// mockGovDb is an in-memory governance_db.Governance for resolver tests. The
+// embedded aggregate.Plugin (left nil) supplies the Init/Start/Stop methods the
+// resolver never calls.
+type mockGovDb struct {
+	aggregate.Plugin
+	proposals []governance_db.Proposal
+	votes     map[string][]governance_db.ProposalVote
+}
+
+func (m *mockGovDb) GetProposal(id string) (governance_db.Proposal, bool, error) {
+	for _, p := range m.proposals {
+		if p.ProposalId == id {
+			return p, true, nil
+		}
+	}
+	return governance_db.Proposal{}, false, nil
+}
+func (m *mockGovDb) SaveProposal(p governance_db.Proposal) error {
+	return nil
+}
+func (m *mockGovDb) RecordVote(v governance_db.ProposalVote) error {
+	return nil
+}
+func (m *mockGovDb) GetVotes(id string) ([]governance_db.ProposalVote, error) {
+	return m.votes[id], nil
+}
+func (m *mockGovDb) ListProposals(byProposalId, byType, byStatus *string, offset, limit int) ([]governance_db.Proposal, error) {
+	out := make([]governance_db.Proposal, 0, len(m.proposals))
+	for _, p := range m.proposals {
+		if byProposalId != nil && *byProposalId != "" && p.ProposalId != *byProposalId {
+			continue
+		}
+		if byType != nil && *byType != "" && p.Type != *byType {
+			continue
+		}
+		if byStatus != nil && *byStatus != "" && p.Status != *byStatus {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// TestFindGovernanceProposals_MapsBothKindsAndVotes verifies the resolver maps
+// both proposal kinds (slash_restore + reserve_payout) and their votes into the
+// GraphQL model, honors the type filter, and is nil-safe when governance is
+// unwired.
+func TestFindGovernanceProposals_MapsBothKindsAndVotes(t *testing.T) {
+	gov := &mockGovDb{
+		proposals: []governance_db.Proposal{
+			{
+				ProposalId: "slash_restore:tx1:alice", Type: "slash_restore", Status: "applied",
+				CreationBlock: 100, Beneficiary: "alice", Amount: 100_000,
+				SlashTxId: "tx1", EvidenceKind: "vsc_double_block_sign", SlashedAccount: "alice",
+				AppliedBlock: 101, AppliedTxId: "v-carol",
+			},
+			{
+				ProposalId: "reserve_payout:abc", Type: "reserve_payout", Status: "open",
+				CreationBlock: 200, Beneficiary: "victim", Amount: 60_000,
+				Recipient: "victim", Reason: "theft-incident",
+			},
+		},
+		votes: map[string][]governance_db.ProposalVote{
+			"slash_restore:tx1:alice": {
+				{Voter: "bob", BlockHeight: 100, TxId: "v-bob"},
+				{Voter: "carol", BlockHeight: 101, TxId: "v-carol"},
+			},
+		},
+	}
+	r := &queryResolver{Resolver: &Resolver{Governance: gov}}
+
+	// No filter: both proposals, with votes mapped on the slash_restore row.
+	all, err := r.FindGovernanceProposals(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+
+	var restore *GovernanceProposal
+	for i := range all {
+		if all[i].Type == "slash_restore" {
+			restore = &all[i]
+		}
+	}
+	require.NotNil(t, restore)
+	require.EqualValues(t, 100_000, int64(restore.Amount))
+	require.EqualValues(t, 100, uint64(restore.CreationBlock))
+	require.Equal(t, "tx1", restore.SlashTxID)
+	require.Equal(t, "alice", restore.SlashedAccount)
+	require.Len(t, restore.Votes, 2)
+	require.EqualValues(t, 101, uint64(restore.Votes[1].BlockHeight))
+
+	// Filter by type returns only the reserve payout, with no votes.
+	typ := "reserve_payout"
+	rp, err := r.FindGovernanceProposals(context.Background(), &GovernanceProposalFilter{ByType: &typ})
+	require.NoError(t, err)
+	require.Len(t, rp, 1)
+	require.Equal(t, "victim", rp[0].Recipient)
+	require.Equal(t, "theft-incident", rp[0].Reason)
+	require.Empty(t, rp[0].Votes)
+
+	// Unwired governance → empty result, never a panic or error.
+	rNil := &queryResolver{Resolver: &Resolver{}}
+	empty, err := rNil.FindGovernanceProposals(context.Background(), nil)
+	require.NoError(t, err)
+	require.Empty(t, empty)
+}

--- a/modules/gql/gqlgen/resolver.go
+++ b/modules/gql/gqlgen/resolver.go
@@ -6,6 +6,7 @@ import (
 	"vsc-node/lib/datalayer"
 	"vsc-node/modules/db/vsc/contracts"
 	"vsc-node/modules/db/vsc/elections"
+	governance_db "vsc-node/modules/db/vsc/governance"
 	"vsc-node/modules/db/vsc/hive_blocks"
 	ledgerDb "vsc-node/modules/db/vsc/ledger"
 	"vsc-node/modules/db/vsc/nonces"
@@ -44,6 +45,7 @@ type Resolver struct {
 	TssKeys        tss_db.TssKeys
 	TssCommitments tss_db.TssCommitments
 	TssRequests    tss_db.TssRequests
+	Governance     governance_db.Governance
 	ChainOracle    *chain.ChainOracle
 }
 

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -958,6 +958,58 @@ func (r *queryResolver) SimulateContractCalls(ctx context.Context, input Simulat
 	return results, nil
 }
 
+// FindGovernanceProposals is the resolver for the findGovernanceProposals field.
+func (r *queryResolver) FindGovernanceProposals(ctx context.Context, filterOptions *GovernanceProposalFilter) ([]GovernanceProposal, error) {
+	if filterOptions == nil {
+		filterOptions = &GovernanceProposalFilter{}
+	}
+	offset, limit, err := Paginate(filterOptions.Offset, filterOptions.Limit)
+	if err != nil {
+		return nil, err
+	}
+	// Governance is unwired on indexer/test surfaces — return an empty set
+	// rather than erroring so the query is always answerable.
+	if r.Governance == nil {
+		return []GovernanceProposal{}, nil
+	}
+	rows, err := r.Governance.ListProposals(filterOptions.ByProposalID, filterOptions.ByType, filterOptions.ByStatus, offset, limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]GovernanceProposal, 0, len(rows))
+	for _, p := range rows {
+		votes, err := r.Governance.GetVotes(p.ProposalId)
+		if err != nil {
+			return nil, err
+		}
+		gv := make([]GovernanceVote, 0, len(votes))
+		for _, v := range votes {
+			gv = append(gv, GovernanceVote{
+				Voter:       v.Voter,
+				BlockHeight: model.Uint64(v.BlockHeight),
+				TxID:        v.TxId,
+			})
+		}
+		out = append(out, GovernanceProposal{
+			ProposalID:     p.ProposalId,
+			Type:           p.Type,
+			Status:         p.Status,
+			CreationBlock:  model.Uint64(p.CreationBlock),
+			Beneficiary:    p.Beneficiary,
+			Amount:         model.Int64(p.Amount),
+			AppliedBlock:   model.Uint64(p.AppliedBlock),
+			AppliedTxID:    p.AppliedTxId,
+			SlashTxID:      p.SlashTxId,
+			EvidenceKind:   p.EvidenceKind,
+			SlashedAccount: p.SlashedAccount,
+			Recipient:      p.Recipient,
+			Reason:         p.Reason,
+			Votes:          gv,
+		})
+	}
+	return out, nil
+}
+
 // Amount is the resolver for the amount field.
 func (r *rcRecordResolver) Amount(ctx context.Context, obj *rcDb.RcRecord) (model.Int64, error) {
 	return model.Int64(obj.Amount), nil

--- a/modules/gql/schema.graphql
+++ b/modules/gql/schema.graphql
@@ -855,6 +855,72 @@ type SimulateContractCallResult {
   state_diff: Map
 }
 
+"""
+A single witness approval vote recorded against a governance proposal.
+"""
+type GovernanceVote {
+  """Normalized Hive account of the witness that voted."""
+  voter: String!
+  """L1 block height at which the vote was recorded."""
+  blockHeight: Uint64!
+  """Hive transaction id of the vote op."""
+  txId: String!
+}
+
+"""
+A witness-vote governance proposal. Encapsulates BOTH governance actions: a
+safety-slash restoration (type 'slash_restore' — re-credit a wrongfully slashed
+bond while it is still pending) and a reserve spend (type 'reserve_payout' —
+disburse from the keyless insurance reserve to a recipient). Kind-specific
+fields are populated according to `type`; the shared fields apply to both.
+"""
+type GovernanceProposal {
+  """Deterministic proposal id (the unit witnesses reference when voting)."""
+  proposalId: String!
+  """Proposal kind: 'slash_restore' or 'reserve_payout'."""
+  type: String!
+  """Lifecycle status: 'open', 'applied', or 'expired'."""
+  status: String!
+  """Block height of the first vote; anchors expiry window + electorate snapshot."""
+  creationBlock: Uint64!
+  """Account excluded from the tally (slashed account / payout recipient — no self-dealing)."""
+  beneficiary: String!
+  """Amount in satoshis (restored bond / disbursed reserve value)."""
+  amount: Int64!
+  """Block height at which the proposal was applied (0 if not yet applied)."""
+  appliedBlock: Uint64!
+  """Hive tx id of the vote that crossed the threshold (empty if not applied)."""
+  appliedTxId: String!
+  """slash_restore: Hive tx id of the original slash being restored."""
+  slashTxId: String!
+  """slash_restore: evidence kind of the original slash."""
+  evidenceKind: String!
+  """slash_restore: the slashed account whose bond is restored."""
+  slashedAccount: String!
+  """reserve_payout: the account credited by the disbursement."""
+  recipient: String!
+  """reserve_payout: human-readable reason logged for explorers."""
+  reason: String!
+  """Recorded approval votes (excludes the proposal row itself)."""
+  votes: [GovernanceVote!]!
+}
+
+"""
+Filter options for querying governance proposals.
+"""
+input GovernanceProposalFilter {
+  """Restrict to a single proposal by exact id."""
+  byProposalId: String
+  """Filter by proposal type ('slash_restore' or 'reserve_payout')."""
+  byType: String
+  """Filter by lifecycle status ('open', 'applied', 'expired')."""
+  byStatus: String
+  """Number of records to skip (for pagination)."""
+  offset: Int
+  """Maximum number of records to return (for pagination)."""
+  limit: Int
+}
+
 type Query {
   """
   Retrieve contract state values by their keys. Returns a map of key-value pairs from the contract's state merkle tree.
@@ -1064,5 +1130,15 @@ type Query {
     """Simulation input containing the batch of contract calls to execute."""
     input: SimulateContractCallsInput!
   ): [SimulateContractCallResult!]!
+
+  """
+  Search witness-vote governance proposals — both safety-slash restorations
+  ('slash_restore') and reserve spends ('reserve_payout') — and their recorded
+  approval votes. Returns newest-created first.
+  """
+  findGovernanceProposals(
+    """Filter criteria for the governance proposal search."""
+    filterOptions: GovernanceProposalFilter
+  ): [GovernanceProposal!]!
 }
 

--- a/modules/ledger-system/invariant_test.go
+++ b/modules/ledger-system/invariant_test.go
@@ -121,6 +121,11 @@ func (m *mockLedgerSystem) ReverseSafetySlashConsensusDebit(p ledgerSystem.Rever
 	return ledgerSystem.LedgerResult{Ok: false, Msg: "mock ledger: reverse consensus debit not implemented"}
 }
 
+func (m *mockLedgerSystem) ReservePayout(p ledgerSystem.ReservePayoutParams) ledgerSystem.LedgerResult {
+	_ = p
+	return ledgerSystem.LedgerResult{Ok: false, Msg: "mock ledger: reserve payout not implemented"}
+}
+
 // ---------------------------------------------------------------------------
 // Invariant 1: Balance Conservation
 //

--- a/modules/ledger-system/invariant_test.go
+++ b/modules/ledger-system/invariant_test.go
@@ -126,6 +126,8 @@ func (m *mockLedgerSystem) ReservePayout(p ledgerSystem.ReservePayoutParams) led
 	return ledgerSystem.LedgerResult{Ok: false, Msg: "mock ledger: reserve payout not implemented"}
 }
 
+func (m *mockLedgerSystem) ReserveAvailable() int64 { return 0 }
+
 // ---------------------------------------------------------------------------
 // Invariant 1: Balance Conservation
 //

--- a/modules/ledger-system/ledger_system.go
+++ b/modules/ledger-system/ledger_system.go
@@ -714,13 +714,24 @@ func (ls *ledgerSystem) reserveAvailable(excludeDebitID string) int64 {
 	return total
 }
 
+// ReserveAvailable returns the keyless reserve's currently-available hive (sum
+// of every reserve credit minus every prior payout debit). It excludes no debit
+// (the create-time over-ask gate wants the live headroom), so it is the
+// public counterpart of reserveAvailable("").
+func (ls *ledgerSystem) ReserveAvailable() int64 {
+	return ls.reserveAvailable("")
+}
+
 // ReservePayout disburses governance-approved value out of the keyless insurance
 // reserve. It writes a supply-conserving PAIR: a meta debit on the reserve
 // account and a spendable credit on the recipient, both keyed by ProposalID so a
-// replay/double-apply upserts the same rows (never double-pays). The amount is
-// capped at the reserve's available balance, so a payout can neither mint nor
-// overdraw — the only authority that lets value leave the reserve is the 2/3
-// witness vote that drove this call.
+// replay/double-apply upserts the same rows (never double-pays). It is
+// all-or-nothing: rejected when the requested amount exceeds the reserve's
+// available balance (never a partial pay that would close the proposal having
+// disbursed less than approved), so a payout can neither mint nor overdraw — the
+// only authority that lets value leave the reserve is the 2/3 witness vote that
+// drove this call. The caller leaves the proposal open on rejection so a later
+// vote can retry once the reserve is refunded.
 func (ls *ledgerSystem) ReservePayout(p ReservePayoutParams) LedgerResult {
 	proposalID := strings.TrimSpace(p.ProposalID)
 	recipient := normalizeHiveConsensusAccount(p.Recipient) // generic "hive:" normalizer
@@ -737,14 +748,18 @@ func (ls *ledgerSystem) ReservePayout(p ReservePayoutParams) LedgerResult {
 	debitID := proposalID + "#reserve_payout#debit"
 	creditID := proposalID + "#reserve_payout#credit#" + recipient
 
+	// Exclude this proposal's own debit so a re-apply recomputes the SAME
+	// available and the same (full) amount — idempotent on replay.
 	available := ls.reserveAvailable(debitID)
 	if available <= 0 {
 		return LedgerResult{Ok: false, Msg: "reserve has no available balance"}
 	}
-	amount := p.Amount
-	if amount > available {
-		amount = available
+	if p.Amount > available {
+		// All-or-nothing: do NOT partial-pay-and-close. The caller keeps the
+		// proposal open so a later vote can retry once the reserve is funded.
+		return LedgerResult{Ok: false, Msg: "reserve payout exceeds available balance"}
 	}
+	amount := p.Amount
 
 	ls.LedgerDb.StoreLedger(
 		ledger_db.LedgerRecord{

--- a/modules/ledger-system/ledger_system.go
+++ b/modules/ledger-system/ledger_system.go
@@ -157,6 +157,21 @@ const (
 	// safetySlashFinalizeCursorRowID is the deterministic Id used for the
 	// single cursor row. Repeating writes upsert the same row.
 	safetySlashFinalizeCursorRowID = "safety_slash_burn_finalize_cursor"
+
+	// LedgerTypeReservePayoutDebit is the FIRST-EVER debit of the keyless
+	// insurance reserve. A governance-approved payout (vsc.reserve_payout, ratified
+	// by a 2/3 witness vote) removes value FROM ProtocolSlashReserveAccount as a
+	// negative `hive` row. It is a protocol-meta row (excluded from spendable
+	// balance, like the reserve credit it draws down) and is paired 1:1 with a
+	// LedgerTypeReservePayoutCredit on the recipient so total `hive` supply is
+	// conserved: held reserve value becomes spendable on the recipient, never
+	// minted. The reserve is no longer a one-way sink — but the ONLY way out is a
+	// supermajority-voted payout, capped at the reserve's available balance.
+	LedgerTypeReservePayoutDebit = "reserve_payout_debit"
+	// LedgerTypeReservePayoutCredit credits the payout recipient with SPENDABLE
+	// `hive` (the make-whole disbursement). NOT a meta type — GetBalance must count
+	// it so the recipient can use the funds.
+	LedgerTypeReservePayoutCredit = "reserve_payout_credit"
 )
 
 // IsProtocolMetaLedgerType reports whether a ledger record type is a
@@ -187,7 +202,11 @@ func IsProtocolMetaLedgerType(t string) bool {
 		LedgerTypeSafetySlashHiveBurnPendingRelease,
 		LedgerTypeSafetySlashHiveBurnPendingFinalized,
 		LedgerTypeSafetySlashHiveBurnPendingCancelled,
-		LedgerTypeSafetySlashBurnFinalizeCursor:
+		LedgerTypeSafetySlashBurnFinalizeCursor,
+		// The reserve-payout DEBIT is held bookkeeping on the keyless reserve
+		// account — never spendable there. (The paired CREDIT on the recipient is
+		// deliberately NOT here: it is the spendable disbursement.)
+		LedgerTypeReservePayoutDebit:
 		return true
 	default:
 		return false
@@ -654,6 +673,100 @@ func (ls *ledgerSystem) ReverseSafetySlashConsensusDebit(p ReverseSafetySlashCon
 		Type:        LedgerTypeSafetySlashConsensusReverse,
 	})
 	return LedgerResult{Ok: true, Msg: "reverse credit recorded"}
+}
+
+// maxReserveScanHeight bounds the reserve-balance scan. Like maxLedgerScanHeight
+// in state-processing it MUST be math.MaxInt64, not math.MaxUint64 — a uint64
+// above MaxInt64 BSON-wraps to -1 and matches zero rows on a real Mongo node.
+const maxReserveScanHeight uint64 = math.MaxInt64
+
+// reserveAvailable returns the keyless reserve's currently-available hive: the
+// sum of every reserve credit (LedgerTypeSafetySlashReserve) plus every prior
+// payout debit (LedgerTypeReservePayoutDebit, negative), EXCLUDING the debit row
+// for excludeDebitID. Excluding this proposal's own debit is what makes
+// ReservePayout idempotent: a re-apply recomputes the SAME available and the same
+// capped amount, so the upsert reproduces identical rows instead of shrinking the
+// payout. Block-on-error (fail-stop): a transient 0 would let a payout overdraw
+// the reserve and could fork.
+func (ls *ledgerSystem) reserveAvailable(excludeDebitID string) int64 {
+	if ls.LedgerDb == nil {
+		return 0
+	}
+	var recs *[]ledger_db.LedgerRecord
+	blockingRetry("reserveAvailable", func() error {
+		var err error
+		recs, err = ls.LedgerDb.GetLedgerRange(
+			params.ProtocolSlashReserveAccount, 0, maxReserveScanHeight, "hive",
+			ledger_db.LedgerOptions{OpType: []string{LedgerTypeSafetySlashReserve, LedgerTypeReservePayoutDebit}},
+		)
+		return err
+	})
+	if recs == nil {
+		return 0
+	}
+	total := int64(0)
+	for _, r := range *recs {
+		if r.Id == excludeDebitID {
+			continue
+		}
+		total += r.Amount
+	}
+	return total
+}
+
+// ReservePayout disburses governance-approved value out of the keyless insurance
+// reserve. It writes a supply-conserving PAIR: a meta debit on the reserve
+// account and a spendable credit on the recipient, both keyed by ProposalID so a
+// replay/double-apply upserts the same rows (never double-pays). The amount is
+// capped at the reserve's available balance, so a payout can neither mint nor
+// overdraw — the only authority that lets value leave the reserve is the 2/3
+// witness vote that drove this call.
+func (ls *ledgerSystem) ReservePayout(p ReservePayoutParams) LedgerResult {
+	proposalID := strings.TrimSpace(p.ProposalID)
+	recipient := normalizeHiveConsensusAccount(p.Recipient) // generic "hive:" normalizer
+	if proposalID == "" || recipient == "" {
+		return LedgerResult{Ok: false, Msg: "invalid reserve payout params"}
+	}
+	if p.Amount <= 0 {
+		return LedgerResult{Ok: false, Msg: "reserve payout amount must be positive"}
+	}
+	if ls.LedgerDb == nil {
+		return LedgerResult{Ok: false, Msg: "ledger not configured"}
+	}
+
+	debitID := proposalID + "#reserve_payout#debit"
+	creditID := proposalID + "#reserve_payout#credit#" + recipient
+
+	available := ls.reserveAvailable(debitID)
+	if available <= 0 {
+		return LedgerResult{Ok: false, Msg: "reserve has no available balance"}
+	}
+	amount := p.Amount
+	if amount > available {
+		amount = available
+	}
+
+	ls.LedgerDb.StoreLedger(
+		ledger_db.LedgerRecord{
+			Id:          debitID,
+			TxId:        proposalID,
+			BlockHeight: p.BlockHeight,
+			Amount:      -amount,
+			Asset:       "hive",
+			Owner:       params.ProtocolSlashReserveAccount,
+			Type:        LedgerTypeReservePayoutDebit,
+		},
+		ledger_db.LedgerRecord{
+			Id:          creditID,
+			TxId:        proposalID,
+			BlockHeight: p.BlockHeight,
+			Amount:      amount,
+			Asset:       "hive",
+			Owner:       recipient,
+			Type:        LedgerTypeReservePayoutCredit,
+		},
+	)
+	return LedgerResult{Ok: true, Msg: "reserve payout recorded"}
 }
 
 // PendulumBucketBalance sums every ledger record whose Owner == bucket and

--- a/modules/ledger-system/types.go
+++ b/modules/ledger-system/types.go
@@ -146,7 +146,9 @@ type ReservePayoutParams struct {
 	ProposalID string
 	// Recipient is the account credited with spendable hive (the make-whole).
 	Recipient string
-	// Amount in satoshis requested; capped at the reserve's available balance.
+	// Amount in satoshis requested. ReservePayout is all-or-nothing: it pays
+	// exactly this or rejects (never a partial pay) when it exceeds the reserve's
+	// available balance.
 	Amount int64
 	// BlockHeight at which the payout rows are recorded.
 	BlockHeight uint64
@@ -250,9 +252,16 @@ type LedgerSystem interface {
 	ReverseSafetySlashConsensusDebit(p ReverseSafetySlashConsensusDebitParams) LedgerResult
 	// ReservePayout disburses governance-approved value OUT of the keyless
 	// insurance reserve to a recipient (the first and only path that debits the
-	// reserve). Idempotent per ProposalID; the amount is capped at the reserve's
-	// available balance so it can never mint or overdraw.
+	// reserve). Idempotent per ProposalID; rejected (all-or-nothing, never a
+	// partial pay) when the requested amount exceeds the reserve's available
+	// balance so it can never mint or overdraw.
 	ReservePayout(p ReservePayoutParams) LedgerResult
+	// ReserveAvailable returns the keyless reserve's currently-available hive:
+	// the sum of every reserve credit minus every prior payout debit. Used by the
+	// governance create handler to reject a vsc.reserve_payout that proposes
+	// spending more than the reserve holds. Deterministic (on-chain ledger scan,
+	// fail-stop), so every node gates proposal creation identically.
+	ReserveAvailable() int64
 	PendulumBucketBalance(bucket string, blockHeight uint64) int64
 	NewEmptySession(state *LedgerState, startHeight uint64) LedgerSession
 	NewEmptyState() *LedgerState

--- a/modules/ledger-system/types.go
+++ b/modules/ledger-system/types.go
@@ -133,6 +133,27 @@ type ReverseSafetySlashConsensusDebitParams struct {
 	OpInstanceID string
 }
 
+// ReservePayoutParams drives a governance-approved disbursement OUT of the
+// keyless insurance reserve to a recipient. Authorized by a 2/3 witness vote
+// (see the vsc.reserve_payout governance op); the ledger primitive caps the
+// amount at the reserve's available balance so a payout can never mint or
+// overdraw the reserve.
+type ReservePayoutParams struct {
+	// ProposalID is the deterministic governance proposal id. It keys the
+	// idempotent ledger rows so re-applying the same approved proposal upserts
+	// (never double-pays) and is the unit the available-balance cap excludes
+	// when recomputing headroom on replay.
+	ProposalID string
+	// Recipient is the account credited with spendable hive (the make-whole).
+	Recipient string
+	// Amount in satoshis requested; capped at the reserve's available balance.
+	Amount int64
+	// BlockHeight at which the payout rows are recorded.
+	BlockHeight uint64
+	// Reason is logged for explorers.
+	Reason string
+}
+
 type LedgerResult struct {
 	Ok  bool
 	Msg string
@@ -227,6 +248,11 @@ type LedgerSystem interface {
 	// by a previous SafetySlashConsensusBond call. Idempotent per
 	// (TxID, EvidenceKind, Account) tuple.
 	ReverseSafetySlashConsensusDebit(p ReverseSafetySlashConsensusDebitParams) LedgerResult
+	// ReservePayout disburses governance-approved value OUT of the keyless
+	// insurance reserve to a recipient (the first and only path that debits the
+	// reserve). Idempotent per ProposalID; the amount is capped at the reserve's
+	// available balance so it can never mint or overdraw.
+	ReservePayout(p ReservePayoutParams) LedgerResult
 	PendulumBucketBalance(bucket string, blockHeight uint64) int64
 	NewEmptySession(state *LedgerState, startHeight uint64) LedgerSession
 	NewEmptyState() *LedgerState

--- a/modules/rc-system/rc_system_test.go
+++ b/modules/rc-system/rc_system_test.go
@@ -117,6 +117,11 @@ func (m *mockLedgerSystem) ReverseSafetySlashConsensusDebit(
 	return ledgerSystem.LedgerResult{Ok: false}
 }
 
+func (m *mockLedgerSystem) ReservePayout(p ledgerSystem.ReservePayoutParams) ledgerSystem.LedgerResult {
+	_ = p
+	return ledgerSystem.LedgerResult{Ok: false}
+}
+
 // ── CalculateFrozenBal tests ──
 
 func TestCalculateFrozenBal_NoDecay(t *testing.T) {

--- a/modules/rc-system/rc_system_test.go
+++ b/modules/rc-system/rc_system_test.go
@@ -122,6 +122,8 @@ func (m *mockLedgerSystem) ReservePayout(p ledgerSystem.ReservePayoutParams) led
 	return ledgerSystem.LedgerResult{Ok: false}
 }
 
+func (m *mockLedgerSystem) ReserveAvailable() int64 { return 0 }
+
 // ── CalculateFrozenBal tests ──
 
 func TestCalculateFrozenBal_NoDecay(t *testing.T) {

--- a/modules/state-processing/audit_fix_c4_gvl12_test.go
+++ b/modules/state-processing/audit_fix_c4_gvl12_test.go
@@ -94,6 +94,7 @@ func newGVL12Env() *gvl12Env {
 		txDb, ledgerDbImpl, balanceDb, nil,
 		interestClaims, vscBlocksDb, actionsDb, mockRcDb, nonceDb,
 		tssKeys, tssCommitments, tssRequests,
+		nil, // governanceDb
 		nil, // pendulumSettlementsDb
 		nil, // consensusStateDb
 		nil, // wasm

--- a/modules/state-processing/governance_reserve_payout.go
+++ b/modules/state-processing/governance_reserve_payout.go
@@ -1,0 +1,177 @@
+package state_engine
+
+import (
+	"encoding/json"
+	"strings"
+
+	governance_db "vsc-node/modules/db/vsc/governance"
+	governance "vsc-node/modules/governance"
+	ledgerSystem "vsc-node/modules/ledger-system"
+)
+
+// handleReservePayoutCreate processes a vsc.reserve_payout L1 custom_json: a
+// witness PROPOSES a disbursement from the keyless insurance reserve. Payload:
+//
+//	{"recipient": "<account>", "amount": <sats>, "reason": "<text>"}
+//
+// Unlike slash_restore (whose parameters are resolved from an on-chain slash),
+// a reserve payout's parameters are CHOSEN, so the create op introduces them and
+// the proposal id is derived from the content + this op's tx id. Two distinct
+// creates are two distinct proposals; other witnesses approve by referencing the
+// id via vsc.reserve_vote. The creator's create op counts as their first vote.
+// On crossing 2/3 of the recipient-excluded electorate the payout is disbursed,
+// capped at the reserve balance (it can never mint or overdraw — see ReservePayout).
+func (se *StateEngine) handleReservePayoutCreate(payload []byte, creatorAccount, txID string, blockHeight uint64) {
+	if se == nil || se.governanceDb == nil {
+		return
+	}
+	var req struct {
+		Recipient string `json:"recipient"`
+		Amount    int64  `json:"amount"`
+		Reason    string `json:"reason"`
+	}
+	if err := json.Unmarshal(payload, &req); err != nil {
+		log.Warn("vsc.reserve_payout: malformed payload; ignoring", "tx", txID, "err", err)
+		return
+	}
+	recipient := governance.NormalizeAccount(req.Recipient)
+	if recipient == "" || req.Amount <= 0 {
+		log.Warn("vsc.reserve_payout: missing recipient or non-positive amount; ignoring", "tx", txID)
+		return
+	}
+	creator := governance.NormalizeAccount(creatorAccount)
+
+	// Creation eligibility: only a current electorate member may propose a reserve
+	// payout (it disburses to an arbitrary account, so creation is witness-gated).
+	// The snapshot is THIS block — it also becomes the proposal's stable snapshot.
+	electorate, ok := se.governanceElectorate(blockHeight)
+	if !ok {
+		log.Warn("vsc.reserve_payout: no electorate snapshot; ignoring", "tx", txID)
+		return
+	}
+	if !governanceIsMember(electorate, creator) {
+		log.Debug("vsc.reserve_payout: creator not a witness; ignoring", "tx", txID, "creator", creator)
+		return
+	}
+
+	proposalID := governance.ReservePayoutProposalID(recipient, req.Amount, req.Reason, txID)
+
+	// Create the proposal if it doesn't already exist (replay of the same create
+	// op is idempotent: same txID → same id → same row). Don't clobber an existing
+	// proposal's status (a re-observed create must not reopen an applied payout).
+	if _, exists := se.getGovernanceProposalOrBlock(proposalID); !exists {
+		se.saveGovernanceProposalOrBlock(governance_db.Proposal{
+			ProposalId:    proposalID,
+			Type:          string(governance.ProposalReservePayout),
+			Status:        string(governance.StatusOpen),
+			CreationBlock: blockHeight,
+			Beneficiary:   recipient,
+			Recipient:     recipient,
+			Reason:        req.Reason,
+			Amount:        req.Amount,
+		})
+	}
+
+	// The creator's op is their first vote. If the creator IS the recipient it is
+	// excluded from the tally (no self-dealing) but the proposal still stands.
+	se.castReservePayoutVote(proposalID, creator, txID, blockHeight)
+}
+
+// handleReservePayoutVote processes a vsc.reserve_vote L1 custom_json: a witness
+// approves an existing reserve-payout proposal by id. Payload: {"id": "<id>"}.
+func (se *StateEngine) handleReservePayoutVote(payload []byte, voterAccount, txID string, blockHeight uint64) {
+	if se == nil || se.governanceDb == nil {
+		return
+	}
+	var req struct {
+		Id string `json:"id"`
+	}
+	if err := json.Unmarshal(payload, &req); err != nil {
+		log.Warn("vsc.reserve_vote: malformed payload; ignoring", "tx", txID, "err", err)
+		return
+	}
+	proposalID := strings.TrimSpace(req.Id)
+	if proposalID == "" {
+		return
+	}
+	se.castReservePayoutVote(proposalID, governance.NormalizeAccount(voterAccount), txID, blockHeight)
+}
+
+// castReservePayoutVote records one approval on an existing reserve-payout
+// proposal and disburses when the 2/3 threshold is crossed. Shared by the create
+// op (creator's first vote) and the vote op. Deterministic: all inputs are
+// L1-ordered + on-chain, so every node reaches the same apply decision.
+func (se *StateEngine) castReservePayoutVote(proposalID, voter, txID string, blockHeight uint64) {
+	prop, exists := se.getGovernanceProposalOrBlock(proposalID)
+	if !exists {
+		// Vote for an unknown proposal (e.g. it arrived before its create op).
+		// Ignored deterministically — the voter re-votes once the create lands.
+		log.Debug("vsc.reserve_vote: unknown proposal; ignoring", "proposal", proposalID, "voter", voter)
+		return
+	}
+	if prop.Type != string(governance.ProposalReservePayout) {
+		return
+	}
+	if prop.Status != string(governance.StatusOpen) {
+		return // terminal (applied or expired)
+	}
+
+	// Reserve payouts are not bounded by a slash pending window → no maturity cap;
+	// the effective expiry is simply creation+expiry.
+	expiryBlocks := se.sconf.ConsensusParams().GovernanceProposalExpiry()
+	if governance.IsExpired(blockHeight, prop.CreationBlock, expiryBlocks, 0) {
+		prop.Status = string(governance.StatusExpired)
+		se.saveGovernanceProposalOrBlock(prop)
+		log.Info("vsc.reserve_payout: proposal expired without quorum", "proposal", proposalID)
+		return
+	}
+
+	electorate, ok := se.governanceElectorate(prop.CreationBlock)
+	if !ok {
+		return
+	}
+	if !governanceIsMember(electorate, voter) {
+		log.Debug("vsc.reserve_payout: voter not in electorate snapshot; ignoring",
+			"proposal", proposalID, "voter", voter)
+		return
+	}
+
+	se.recordGovernanceVoteOrBlock(governance_db.ProposalVote{
+		ProposalId: proposalID, Voter: voter, BlockHeight: blockHeight, TxId: txID,
+	})
+
+	voters := se.governanceVoterSetOrBlock(proposalID)
+	if !governance.IsApproved(electorate, prop.Beneficiary, voters) {
+		return
+	}
+
+	res := se.LedgerSystem.ReservePayout(ledgerSystem.ReservePayoutParams{
+		ProposalID:  proposalID,
+		Recipient:   prop.Recipient,
+		Amount:      prop.Amount,
+		BlockHeight: blockHeight,
+		Reason:      prop.Reason,
+	})
+	if !res.Ok {
+		// e.g. reserve empty — leave the proposal open so a later vote can retry if
+		// the reserve is funded before expiry.
+		log.Warn("vsc.reserve_payout: ledger payout rejected; proposal stays open",
+			"proposal", proposalID, "msg", res.Msg)
+		return
+	}
+	prop.Status = string(governance.StatusApplied)
+	prop.AppliedBlock = blockHeight
+	prop.AppliedTxId = txID
+	se.saveGovernanceProposalOrBlock(prop)
+	log.Info("vsc.reserve_payout: threshold crossed; reserve payout applied",
+		"proposal", proposalID, "recipient", prop.Recipient, "amount", prop.Amount, "height", blockHeight)
+}
+
+// HandleReservePayoutCreateForTest / HandleReservePayoutVoteForTest expose the
+// reserve-payout handlers to the external state_engine_test package.
+func (se *StateEngine) HandleReservePayoutCreateForTest(payload []byte, creator, txID string, blockHeight uint64) {
+	se.handleReservePayoutCreate(payload, creator, txID, blockHeight)
+}
+func (se *StateEngine) HandleReservePayoutVoteForTest(payload []byte, voter, txID string, blockHeight uint64) {
+	se.handleReservePayoutVote(payload, voter, txID, blockHeight)
+}

--- a/modules/state-processing/governance_reserve_payout.go
+++ b/modules/state-processing/governance_reserve_payout.go
@@ -54,6 +54,23 @@ func (se *StateEngine) handleReservePayoutCreate(payload []byte, creatorAccount,
 		return
 	}
 
+	// Over-ask gate: fail the op outright if it proposes spending more than the
+	// reserve currently holds. This keeps the reserve all-or-nothing — a proposal
+	// never disburses less than it asked and then closes (the partial-pay wart) —
+	// and avoids gathering a quorum for a payout that could only ever be capped.
+	// Deterministic: ReserveAvailable is an on-chain ledger scan evaluated at this
+	// (L1-ordered) creation block, so every node makes the same create/skip
+	// decision. The apply path (ReservePayout) re-checks all-or-nothing in case
+	// the reserve drains between creation and approval.
+	if se.LedgerSystem == nil {
+		return
+	}
+	if available := se.LedgerSystem.ReserveAvailable(); req.Amount > available {
+		log.Warn("vsc.reserve_payout: amount exceeds reserve available; ignoring",
+			"tx", txID, "amount", req.Amount, "available", available)
+		return
+	}
+
 	proposalID := governance.ReservePayoutProposalID(recipient, req.Amount, req.Reason, txID)
 
 	// Create the proposal if it doesn't already exist (replay of the same create

--- a/modules/state-processing/governance_reserve_payout_test.go
+++ b/modules/state-processing/governance_reserve_payout_test.go
@@ -1,0 +1,144 @@
+package state_engine_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vsc-node/lib/test_utils"
+	"vsc-node/modules/common/params"
+	governance "vsc-node/modules/governance"
+	ledgerSystem "vsc-node/modules/ledger-system"
+)
+
+func recipientCredit(db *test_utils.MockLedgerDb, recipient string) int64 {
+	var total int64
+	for _, r := range db.LedgerRecords[recipient] {
+		if r.Type == ledgerSystem.LedgerTypeReservePayoutCredit {
+			total += r.Amount
+		}
+	}
+	return total
+}
+
+func reserveCreditsTotal(db *test_utils.MockLedgerDb) int64 {
+	var total int64
+	for _, r := range db.LedgerRecords[params.ProtocolSlashReserveAccount] {
+		if r.Type == ledgerSystem.LedgerTypeSafetySlashReserve {
+			total += r.Amount
+		}
+	}
+	return total
+}
+
+// reserveAvailable = reserve credits + payout debits (debits negative).
+func reserveAvailable(db *test_utils.MockLedgerDb) int64 {
+	var total int64
+	for _, r := range db.LedgerRecords[params.ProtocolSlashReserveAccount] {
+		if r.Type == ledgerSystem.LedgerTypeSafetySlashReserve ||
+			r.Type == ledgerSystem.LedgerTypeReservePayoutDebit {
+			total += r.Amount
+		}
+	}
+	return total
+}
+
+// TestReservePayout_PrimitiveCapAndIdempotency exercises the ledger primitive
+// directly: supply-conserving disbursement, idempotency on re-apply, the
+// balance cap, and rejection once the reserve is empty.
+func TestReservePayout_PrimitiveCapAndIdempotency(t *testing.T) {
+	f := newChainOpFixture(t)
+	f.fireSlash(t, "fund-1", 100, 0) // burnDelay 0 → 100_000 lands straight in the reserve
+	require.EqualValues(t, 100_000, reserveCreditsTotal(f.db))
+
+	// Pay 60k to victim.
+	r := f.ls.ReservePayout(ledgerSystem.ReservePayoutParams{
+		ProposalID: "p1", Recipient: "victim", Amount: 60_000, BlockHeight: 120,
+	})
+	require.True(t, r.Ok, r.Msg)
+	require.EqualValues(t, 60_000, recipientCredit(f.db, "hive:victim"), "recipient credited spendable hive")
+	require.EqualValues(t, 40_000, reserveAvailable(f.db), "reserve drawn down by the payout")
+
+	// Idempotent: re-applying the same proposal does not double-pay.
+	f.ls.ReservePayout(ledgerSystem.ReservePayoutParams{
+		ProposalID: "p1", Recipient: "victim", Amount: 60_000, BlockHeight: 121,
+	})
+	require.EqualValues(t, 60_000, recipientCredit(f.db, "hive:victim"), "idempotent on proposal id")
+	require.EqualValues(t, 40_000, reserveAvailable(f.db))
+
+	// Cap: a second proposal requesting more than remaining is capped at 40k.
+	r2 := f.ls.ReservePayout(ledgerSystem.ReservePayoutParams{
+		ProposalID: "p2", Recipient: "victim", Amount: 999_999, BlockHeight: 122,
+	})
+	require.True(t, r2.Ok, r2.Msg)
+	require.EqualValues(t, 100_000, recipientCredit(f.db, "hive:victim"), "second payout capped to remaining reserve")
+	require.EqualValues(t, 0, reserveAvailable(f.db), "reserve fully drawn")
+
+	// Empty: a further payout is rejected (cannot overdraw / mint).
+	r3 := f.ls.ReservePayout(ledgerSystem.ReservePayoutParams{
+		ProposalID: "p3", Recipient: "victim", Amount: 1, BlockHeight: 123,
+	})
+	require.False(t, r3.Ok, "payout from an empty reserve must be rejected")
+}
+
+// TestReservePayout_CreateVoteDisburses is the governance path: a witness
+// proposes a payout (create == first vote), others approve by id, and on crossing
+// 2/3 of the electorate (recipient excluded — victim is not a member, so the
+// effective electorate is all 4 → threshold 3) the reserve disburses.
+func TestReservePayout_CreateVoteDisburses(t *testing.T) {
+	f, gov := wireRestoreFixture(t)
+	f.fireSlash(t, "fund-1", 100, 0) // fund the reserve with 100_000
+	require.EqualValues(t, 100_000, reserveCreditsTotal(f.db))
+
+	amount := int64(60_000)
+	reason := "theft-incident-x"
+	createPayload := fmt.Sprintf(`{"recipient":"victim","amount":%d,"reason":%q}`, amount, reason)
+	propID := governance.ReservePayoutProposalID("victim", amount, reason, "create-tx")
+	votePayload := `{"id":"` + propID + `"}`
+
+	// Create (alice's first vote) — 1 of 3.
+	f.se.HandleReservePayoutCreateForTest([]byte(createPayload), "alice", "create-tx", 110)
+	require.EqualValues(t, 0, recipientCredit(f.db, "hive:victim"), "no payout below threshold")
+
+	// bob votes — 2 of 3.
+	f.se.HandleReservePayoutVoteForTest([]byte(votePayload), "bob", "v-bob", 111)
+	require.EqualValues(t, 0, recipientCredit(f.db, "hive:victim"))
+
+	// carol votes — 3 of 3 → payout disburses.
+	f.se.HandleReservePayoutVoteForTest([]byte(votePayload), "carol", "v-carol", 112)
+	require.EqualValues(t, 60_000, recipientCredit(f.db, "hive:victim"), "threshold crossed → reserve payout")
+	require.EqualValues(t, 40_000, reserveAvailable(f.db))
+
+	p, ok, _ := gov.GetProposal(propID)
+	require.True(t, ok)
+	require.Equal(t, "applied", p.Status)
+
+	// A late vote after apply is a no-op.
+	f.se.HandleReservePayoutVoteForTest([]byte(votePayload), "dave", "v-dave", 113)
+	require.EqualValues(t, 60_000, recipientCredit(f.db, "hive:victim"), "no double payout after applied")
+}
+
+// TestReservePayout_NonWitnessCreateIgnored: only electorate members may propose.
+func TestReservePayout_NonWitnessCreateIgnored(t *testing.T) {
+	f, gov := wireRestoreFixture(t)
+	f.fireSlash(t, "fund-1", 100, 0)
+
+	amount := int64(10_000)
+	createPayload := fmt.Sprintf(`{"recipient":"victim","amount":%d,"reason":"x"}`, amount)
+	propID := governance.ReservePayoutProposalID("victim", amount, "x", "create-tx")
+
+	f.se.HandleReservePayoutCreateForTest([]byte(createPayload), "eve", "create-tx", 110)
+	_, ok, _ := gov.GetProposal(propID)
+	require.False(t, ok, "non-witness must not create a reserve payout proposal")
+	require.EqualValues(t, 0, recipientCredit(f.db, "hive:victim"))
+}
+
+// TestReservePayout_VoteBeforeCreateIgnored: a vote for an unknown proposal id
+// is dropped deterministically (no proposal, no payout).
+func TestReservePayout_VoteBeforeCreateIgnored(t *testing.T) {
+	f, _ := wireRestoreFixture(t)
+	f.fireSlash(t, "fund-1", 100, 0)
+	f.se.HandleReservePayoutVoteForTest([]byte(`{"id":"reserve_payout:deadbeef"}`), "bob", "v-bob", 110)
+	require.EqualValues(t, 0, recipientCredit(f.db, "hive:victim"))
+}

--- a/modules/state-processing/governance_reserve_payout_test.go
+++ b/modules/state-processing/governance_reserve_payout_test.go
@@ -44,10 +44,11 @@ func reserveAvailable(db *test_utils.MockLedgerDb) int64 {
 	return total
 }
 
-// TestReservePayout_PrimitiveCapAndIdempotency exercises the ledger primitive
-// directly: supply-conserving disbursement, idempotency on re-apply, the
-// balance cap, and rejection once the reserve is empty.
-func TestReservePayout_PrimitiveCapAndIdempotency(t *testing.T) {
+// TestReservePayout_PrimitiveAllOrNothingAndIdempotency exercises the ledger
+// primitive directly: supply-conserving disbursement, idempotency on re-apply,
+// all-or-nothing rejection of an over-available request (never a partial pay),
+// an exact-balance payout, and rejection once the reserve is empty.
+func TestReservePayout_PrimitiveAllOrNothingAndIdempotency(t *testing.T) {
 	f := newChainOpFixture(t)
 	f.fireSlash(t, "fund-1", 100, 0) // burnDelay 0 → 100_000 lands straight in the reserve
 	require.EqualValues(t, 100_000, reserveCreditsTotal(f.db))
@@ -67,12 +68,22 @@ func TestReservePayout_PrimitiveCapAndIdempotency(t *testing.T) {
 	require.EqualValues(t, 60_000, recipientCredit(f.db, "hive:victim"), "idempotent on proposal id")
 	require.EqualValues(t, 40_000, reserveAvailable(f.db))
 
-	// Cap: a second proposal requesting more than remaining is capped at 40k.
+	// All-or-nothing: a second proposal requesting more than remaining (40k) is
+	// REJECTED, not partial-paid — the reserve is untouched so the proposal can
+	// retry once refunded.
 	r2 := f.ls.ReservePayout(ledgerSystem.ReservePayoutParams{
 		ProposalID: "p2", Recipient: "victim", Amount: 999_999, BlockHeight: 122,
 	})
-	require.True(t, r2.Ok, r2.Msg)
-	require.EqualValues(t, 100_000, recipientCredit(f.db, "hive:victim"), "second payout capped to remaining reserve")
+	require.False(t, r2.Ok, "over-available payout must be rejected, not capped")
+	require.EqualValues(t, 60_000, recipientCredit(f.db, "hive:victim"), "no partial payout")
+	require.EqualValues(t, 40_000, reserveAvailable(f.db), "reserve unchanged by a rejected payout")
+
+	// An exact-available payout succeeds and fully draws the reserve.
+	r2b := f.ls.ReservePayout(ledgerSystem.ReservePayoutParams{
+		ProposalID: "p2b", Recipient: "victim", Amount: 40_000, BlockHeight: 122,
+	})
+	require.True(t, r2b.Ok, r2b.Msg)
+	require.EqualValues(t, 100_000, recipientCredit(f.db, "hive:victim"), "exact-balance payout disburses in full")
 	require.EqualValues(t, 0, reserveAvailable(f.db), "reserve fully drawn")
 
 	// Empty: a further payout is rejected (cannot overdraw / mint).
@@ -117,6 +128,30 @@ func TestReservePayout_CreateVoteDisburses(t *testing.T) {
 	// A late vote after apply is a no-op.
 	f.se.HandleReservePayoutVoteForTest([]byte(votePayload), "dave", "v-dave", 113)
 	require.EqualValues(t, 60_000, recipientCredit(f.db, "hive:victim"), "no double payout after applied")
+}
+
+// TestReservePayout_OverAskCreateRejected: a create op proposing more than the
+// reserve currently holds is failed outright — no proposal row is written — so a
+// payout can never gather a quorum only to disburse less than approved and close.
+func TestReservePayout_OverAskCreateRejected(t *testing.T) {
+	f, gov := wireRestoreFixture(t)
+	f.fireSlash(t, "fund-1", 100, 0) // reserve holds 100_000
+
+	overAmount := int64(150_000) // more than available
+	overPayload := fmt.Sprintf(`{"recipient":"victim","amount":%d,"reason":"too-big"}`, overAmount)
+	overID := governance.ReservePayoutProposalID("victim", overAmount, "too-big", "create-over")
+
+	f.se.HandleReservePayoutCreateForTest([]byte(overPayload), "alice", "create-over", 110)
+	_, ok, _ := gov.GetProposal(overID)
+	require.False(t, ok, "over-ask create must not create a proposal")
+	require.EqualValues(t, 0, recipientCredit(f.db, "hive:victim"))
+
+	// An exact-available create (100_000) is accepted.
+	okPayload := fmt.Sprintf(`{"recipient":"victim","amount":%d,"reason":"ok"}`, 100_000)
+	okID := governance.ReservePayoutProposalID("victim", 100_000, "ok", "create-ok")
+	f.se.HandleReservePayoutCreateForTest([]byte(okPayload), "alice", "create-ok", 111)
+	_, ok2, _ := gov.GetProposal(okID)
+	require.True(t, ok2, "exact-available create must succeed")
 }
 
 // TestReservePayout_NonWitnessCreateIgnored: only electorate members may propose.

--- a/modules/state-processing/governance_slash_restore.go
+++ b/modules/state-processing/governance_slash_restore.go
@@ -306,13 +306,32 @@ func (se *StateEngine) slashPendingMaturity(slashTxID, evidenceKind, normalizedA
 	if recs == nil {
 		return 0
 	}
+	// One pending-burn row exists per (slashTxID, evidenceKind, account), so in
+	// practice a single row matches the prefix. Guard the rare case anyway:
+	// pick the lexicographically-smallest matching Id so the maturity is
+	// resolved deterministically across nodes regardless of the DB's (unsorted)
+	// return order — mirroring resolveSlashConsensusRowByTx above. A divergent
+	// maturity would shift the slash_restore window and could fork.
 	prefix := slashTxID + "#safety_slash#" + evidenceKind + "#"
+	var bestID string
+	var bestMaturity uint64
+	found := false
 	for _, r := range *recs {
-		if strings.HasPrefix(r.Id, prefix) {
-			if m, err := strconv.ParseUint(strings.TrimSpace(r.From), 10, 64); err == nil {
-				return m
-			}
+		if !strings.HasPrefix(r.Id, prefix) {
+			continue
+		}
+		m, err := strconv.ParseUint(strings.TrimSpace(r.From), 10, 64)
+		if err != nil {
+			continue
+		}
+		if !found || r.Id < bestID {
+			bestID = r.Id
+			bestMaturity = m
+			found = true
 		}
 	}
-	return 0
+	if !found {
+		return 0
+	}
+	return bestMaturity
 }

--- a/modules/state-processing/governance_slash_restore.go
+++ b/modules/state-processing/governance_slash_restore.go
@@ -258,12 +258,23 @@ func (se *StateEngine) resolveSlashConsensusRowByTx(slashTxID, normalizedAcct st
 	if recs == nil {
 		return ledgerDb.LedgerRecord{}, false
 	}
+	// In practice one safety_slash_consensus row exists per slash tx (the two
+	// detectors that fire on a double-sign use different triggering txs, so they
+	// have different tx ids). Guard the rare case anyway: pick the lexicographically
+	// smallest Id so the resolution is deterministic across nodes regardless of the
+	// DB's (unsorted) return order.
+	var best ledgerDb.LedgerRecord
+	found := false
 	for _, r := range *recs {
-		if r.TxId == slashTxID {
-			return r, true
+		if r.TxId != slashTxID {
+			continue
+		}
+		if !found || r.Id < best.Id {
+			best = r
+			found = true
 		}
 	}
-	return ledgerDb.LedgerRecord{}, false
+	return best, found
 }
 
 // parseEvidenceKindFromSlashRowID extracts <kind> from a principal-debit row id

--- a/modules/state-processing/governance_slash_restore.go
+++ b/modules/state-processing/governance_slash_restore.go
@@ -1,0 +1,307 @@
+package state_engine
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"vsc-node/modules/common/params"
+	systemconfig "vsc-node/modules/common/system-config"
+	"vsc-node/modules/db/vsc/elections"
+	governance_db "vsc-node/modules/db/vsc/governance"
+	ledgerDb "vsc-node/modules/db/vsc/ledger"
+	governance "vsc-node/modules/governance"
+	safetyslash "vsc-node/modules/incentive-pendulum/safety_slash"
+	ledgerSystem "vsc-node/modules/ledger-system"
+)
+
+// WireGovernanceForTest injects the governance store, election db, and system
+// config into a test StateEngine so the external state_engine_test package can
+// drive the vote handlers without the full plugin constellation. Production
+// wires these via the constructor.
+func (se *StateEngine) WireGovernanceForTest(gov governance_db.Governance, elec elections.Elections, sconf systemconfig.SystemConfig) {
+	se.governanceDb = gov
+	se.electionDb = elec
+	se.sconf = sconf
+}
+
+// HandleSlashRestoreVoteForTest exposes handleSlashRestoreVote to external tests.
+func (se *StateEngine) HandleSlashRestoreVoteForTest(payload []byte, voter, txID string, blockHeight uint64) {
+	se.handleSlashRestoreVote(payload, voter, txID, blockHeight)
+}
+
+// handleSlashRestoreVote processes a vsc.slash_restore L1 custom_json: a witness
+// approving the restoration of a wrongful safety slash while it is still in its
+// pending window. The op is propose==vote — the first valid vote creates the
+// proposal, each later distinct witness adds weight, and on crossing 2/3 of the
+// (beneficiary-excluded) electorate the bond is restored via
+// applySafetySlashReverse(action "both"). Payload:
+//
+//	{"id": "<slash_tx_id>", "account": "<slashed_account>"}
+//
+// The slash's evidence kind and amount are RESOLVED from the on-chain slash row
+// (voters never supply them, so there is nothing to disagree on). Everything
+// here is a deterministic function of L1-ordered votes + on-chain state, so
+// every node reaches the same apply/expire decision (votes are tallied during
+// block replay, exactly like the slash itself).
+//
+// Phase A is intentionally one-shot per slash: the proposal is terminal once
+// applied or expired, and a failed attempt falls through to the reserve-payout
+// path at maturity (the general backstop). The simple-cap window never extends
+// the slash's fixed maturity.
+func (se *StateEngine) handleSlashRestoreVote(payload []byte, voterAccount, txID string, blockHeight uint64) {
+	if se == nil || se.governanceDb == nil {
+		return
+	}
+	var req struct {
+		Id      string `json:"id"`      // slash Hive tx id
+		Account string `json:"account"` // slashed account
+	}
+	if err := json.Unmarshal(payload, &req); err != nil {
+		log.Warn("vsc.slash_restore: malformed payload; ignoring", "tx", txID, "err", err)
+		return
+	}
+	slashTxID := strings.TrimSpace(req.Id)
+	slashedAcct := governance.NormalizeAccount(req.Account)
+	if slashTxID == "" || slashedAcct == "" {
+		log.Warn("vsc.slash_restore: missing id/account; ignoring", "tx", txID)
+		return
+	}
+	voter := governance.NormalizeAccount(voterAccount)
+
+	// Deterministic proposal id binds the slash tx and slashed account.
+	proposalID := string(governance.ProposalSlashRestore) + ":" + slashTxID + ":" + slashedAcct
+
+	prop, exists := se.getGovernanceProposalOrBlock(proposalID)
+
+	// Eligibility is checked BEFORE creation so a non-member cannot anchor a
+	// proposal's creation block (which would fix the expiry window + electorate
+	// snapshot). The snapshot height is the creation block: this block for a new
+	// proposal, the stored one for an existing proposal — stable across nodes.
+	snapshotBlock := blockHeight
+	if exists {
+		snapshotBlock = prop.CreationBlock
+	}
+	electorate, ok := se.governanceElectorate(snapshotBlock)
+	if !ok {
+		log.Warn("vsc.slash_restore: no electorate snapshot; skipping vote", "proposal", proposalID)
+		return
+	}
+	if !governanceIsMember(electorate, voter) {
+		log.Debug("vsc.slash_restore: voter not in electorate snapshot; ignoring",
+			"proposal", proposalID, "voter", voter)
+		return
+	}
+
+	if !exists {
+		// First eligible vote creates the proposal. Resolve the slash row to
+		// learn the evidence kind and amount (beneficiary = slashed account).
+		row, found := se.resolveSlashConsensusRowByTx(slashTxID, slashedAcct)
+		if !found {
+			log.Warn("vsc.slash_restore: no matching safety_slash_consensus row; ignoring",
+				"tx", txID, "slash_tx_id", slashTxID, "account", slashedAcct)
+			return
+		}
+		amount := -row.Amount
+		if amount <= 0 {
+			log.Warn("vsc.slash_restore: slash row has non-positive amount; ignoring",
+				"tx", txID, "slash_tx_id", slashTxID)
+			return
+		}
+		prop = governance_db.Proposal{
+			ProposalId:     proposalID,
+			Type:           string(governance.ProposalSlashRestore),
+			Status:         string(governance.StatusOpen),
+			CreationBlock:  blockHeight,
+			Beneficiary:    slashedAcct,
+			SlashTxId:      slashTxID,
+			EvidenceKind:   parseEvidenceKindFromSlashRowID(row.Id),
+			SlashedAccount: slashedAcct,
+			Amount:         amount,
+		}
+		se.saveGovernanceProposalOrBlock(prop)
+	}
+
+	if prop.Status != string(governance.StatusOpen) {
+		// Already applied or expired — votes are no-ops (terminal, one-shot).
+		return
+	}
+
+	// Effective expiry = min(creation+expiry, slash maturity). The maturity cap
+	// keeps the light path inside the pending window; it NEVER moves maturity.
+	maturity := se.slashPendingMaturity(prop.SlashTxId, prop.EvidenceKind, prop.SlashedAccount)
+	expiryBlocks := se.sconf.ConsensusParams().GovernanceProposalExpiry()
+	if governance.IsExpired(blockHeight, prop.CreationBlock, expiryBlocks, maturity) {
+		prop.Status = string(governance.StatusExpired)
+		se.saveGovernanceProposalOrBlock(prop)
+		log.Info("vsc.slash_restore: proposal expired without quorum",
+			"proposal", proposalID, "creation", prop.CreationBlock, "height", blockHeight)
+		return
+	}
+
+	se.recordGovernanceVoteOrBlock(governance_db.ProposalVote{
+		ProposalId: proposalID, Voter: voter, BlockHeight: blockHeight, TxId: txID,
+	})
+
+	// Recompute the weighted tally over every recorded vote and apply on crossing.
+	voters := se.governanceVoterSetOrBlock(proposalID)
+	if !governance.IsApproved(electorate, prop.Beneficiary, voters) {
+		return
+	}
+
+	rec := safetyslash.SafetySlashReverseRecord{
+		SlashTxID:      prop.SlashTxId,
+		EvidenceKind:   prop.EvidenceKind,
+		SlashedAccount: prop.SlashedAccount,
+		Action:         safetyslash.ReverseActionBoth,
+		Amount:         prop.Amount,
+		Reason:         "governance slash_restore " + proposalID,
+	}
+	se.applySafetySlashReverse(rec.Normalize(), txID, blockHeight)
+
+	prop.Status = string(governance.StatusApplied)
+	prop.AppliedBlock = blockHeight
+	prop.AppliedTxId = txID
+	se.saveGovernanceProposalOrBlock(prop)
+	log.Info("vsc.slash_restore: threshold crossed; bond restoration applied",
+		"proposal", proposalID, "slashed", prop.SlashedAccount, "amount", prop.Amount, "height", blockHeight)
+}
+
+// ── deterministic store helpers (fail-stop on infra error, like blockingRetry) ──
+
+func (se *StateEngine) getGovernanceProposalOrBlock(proposalID string) (governance_db.Proposal, bool) {
+	var p governance_db.Proposal
+	var found bool
+	blockingRetry("GetGovernanceProposal", func() error {
+		var err error
+		p, found, err = se.governanceDb.GetProposal(proposalID)
+		return err
+	})
+	return p, found
+}
+
+func (se *StateEngine) saveGovernanceProposalOrBlock(p governance_db.Proposal) {
+	blockingRetry("SaveGovernanceProposal", func() error {
+		return se.governanceDb.SaveProposal(p)
+	})
+}
+
+func (se *StateEngine) recordGovernanceVoteOrBlock(v governance_db.ProposalVote) {
+	blockingRetry("RecordGovernanceVote", func() error {
+		return se.governanceDb.RecordVote(v)
+	})
+}
+
+func (se *StateEngine) governanceVoterSetOrBlock(proposalID string) map[string]bool {
+	var votes []governance_db.ProposalVote
+	blockingRetry("GetGovernanceVotes", func() error {
+		var err error
+		votes, err = se.governanceDb.GetVotes(proposalID)
+		return err
+	})
+	out := make(map[string]bool, len(votes))
+	for _, v := range votes {
+		out[v.Voter] = true
+	}
+	return out
+}
+
+// governanceElectorate builds the weighted member set from the election snapshot
+// at height. found=false when no election covers the height (handled as
+// "skip", not retried forever — see GetElectionInfoOrBlock).
+func (se *StateEngine) governanceElectorate(height uint64) ([]governance.Member, bool) {
+	if se.electionDb == nil {
+		return nil, false
+	}
+	elec, ok := se.GetElectionInfoOrBlock(height)
+	if !ok {
+		return nil, false
+	}
+	members := make([]governance.Member, 0, len(elec.Members))
+	for i, m := range elec.Members {
+		w := uint64(1)
+		if len(elec.Weights) == len(elec.Members) {
+			w = elec.Weights[i]
+		}
+		members = append(members, governance.Member{Account: m.Account, Weight: w})
+	}
+	return members, true
+}
+
+func governanceIsMember(electorate []governance.Member, normalizedAcct string) bool {
+	for _, m := range electorate {
+		if governance.NormalizeAccount(m.Account) == normalizedAcct {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveSlashConsensusRowByTx finds the principal-debit row for a slash given
+// only its Hive tx id and the slashed account (the evidence kind is parsed from
+// the row id afterwards). The ledger is account-indexed, so the account is
+// required; one safety_slash_consensus row exists per slash tx.
+func (se *StateEngine) resolveSlashConsensusRowByTx(slashTxID, normalizedAcct string) (ledgerDb.LedgerRecord, bool) {
+	if se == nil || se.LedgerState == nil || se.LedgerState.LedgerDb == nil {
+		return ledgerDb.LedgerRecord{}, false
+	}
+	owner := normalizeHiveAccount(normalizedAcct)
+	var recs *[]ledgerDb.LedgerRecord
+	blockingRetry("resolveSlashConsensusRowByTx", func() error {
+		var err error
+		recs, err = se.LedgerState.LedgerDb.GetLedgerRange(
+			owner, 0, maxLedgerScanHeight, "hive_consensus",
+			ledgerDb.LedgerOptions{OpType: []string{ledgerSystem.LedgerTypeSafetySlashConsensus}},
+		)
+		return err
+	})
+	if recs == nil {
+		return ledgerDb.LedgerRecord{}, false
+	}
+	for _, r := range *recs {
+		if r.TxId == slashTxID {
+			return r, true
+		}
+	}
+	return ledgerDb.LedgerRecord{}, false
+}
+
+// parseEvidenceKindFromSlashRowID extracts <kind> from a principal-debit row id
+// of the form "<txID>#safety_slash#<kind>#consensus_debit#<acct>".
+func parseEvidenceKindFromSlashRowID(id string) string {
+	parts := strings.Split(id, "#")
+	if len(parts) >= 3 && parts[1] == "safety_slash" {
+		return parts[2]
+	}
+	return ""
+}
+
+// slashPendingMaturity returns the stored maturity height of this slash's pending
+// burn row (its From field). 0 if no pending row exists (already matured to the
+// reserve, cancelled, or slashed with no delay) — meaning no maturity cap.
+func (se *StateEngine) slashPendingMaturity(slashTxID, evidenceKind, normalizedAcct string) uint64 {
+	if se == nil || se.LedgerState == nil || se.LedgerState.LedgerDb == nil {
+		return 0
+	}
+	var recs *[]ledgerDb.LedgerRecord
+	blockingRetry("slashPendingMaturity", func() error {
+		var err error
+		recs, err = se.LedgerState.LedgerDb.GetLedgerRange(
+			params.ProtocolSlashPendingBurnAccount, 0, maxLedgerScanHeight, "hive",
+			ledgerDb.LedgerOptions{OpType: []string{ledgerSystem.LedgerTypeSafetySlashHiveBurnPending}},
+		)
+		return err
+	})
+	if recs == nil {
+		return 0
+	}
+	prefix := slashTxID + "#safety_slash#" + evidenceKind + "#"
+	for _, r := range *recs {
+		if strings.HasPrefix(r.Id, prefix) {
+			if m, err := strconv.ParseUint(strings.TrimSpace(r.From), 10, 64); err == nil {
+				return m
+			}
+		}
+	}
+	return 0
+}

--- a/modules/state-processing/governance_slash_restore_test.go
+++ b/modules/state-processing/governance_slash_restore_test.go
@@ -53,6 +53,22 @@ func (m *memGovDb) RecordVote(v governance_db.ProposalVote) error {
 func (m *memGovDb) GetVotes(id string) ([]governance_db.ProposalVote, error) {
 	return m.votes[id], nil
 }
+func (m *memGovDb) ListProposals(byProposalId, byType, byStatus *string, offset, limit int) ([]governance_db.Proposal, error) {
+	out := make([]governance_db.Proposal, 0, len(m.proposals))
+	for _, p := range m.proposals {
+		if byProposalId != nil && *byProposalId != "" && p.ProposalId != *byProposalId {
+			continue
+		}
+		if byType != nil && *byType != "" && p.Type != *byType {
+			continue
+		}
+		if byStatus != nil && *byStatus != "" && p.Status != *byStatus {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
 
 // fourMemberElection: alice (the slashed beneficiary) + bob, carol, dave, equal
 // weight. Effective electorate excludes alice → 3; threshold = ceil(2*3/3) = 2.

--- a/modules/state-processing/governance_slash_restore_test.go
+++ b/modules/state-processing/governance_slash_restore_test.go
@@ -1,0 +1,169 @@
+package state_engine_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vsc-node/lib/test_utils"
+	"vsc-node/modules/aggregate"
+	systemconfig "vsc-node/modules/common/system-config"
+	"vsc-node/modules/db/vsc/elections"
+	governance_db "vsc-node/modules/db/vsc/governance"
+	governance "vsc-node/modules/governance"
+	ledgerSystem "vsc-node/modules/ledger-system"
+)
+
+// memGovDb is an in-memory governance_db.Governance for handler tests.
+type memGovDb struct {
+	aggregate.Plugin
+	proposals map[string]governance_db.Proposal
+	votes     map[string][]governance_db.ProposalVote
+}
+
+func newMemGovDb() *memGovDb {
+	return &memGovDb{
+		proposals: map[string]governance_db.Proposal{},
+		votes:     map[string][]governance_db.ProposalVote{},
+	}
+}
+
+func (m *memGovDb) GetProposal(id string) (governance_db.Proposal, bool, error) {
+	p, ok := m.proposals[id]
+	return p, ok, nil
+}
+func (m *memGovDb) SaveProposal(p governance_db.Proposal) error {
+	p.Voter = ""
+	m.proposals[p.ProposalId] = p
+	return nil
+}
+func (m *memGovDb) RecordVote(v governance_db.ProposalVote) error {
+	if v.Voter == "" {
+		return nil
+	}
+	for i, ex := range m.votes[v.ProposalId] {
+		if ex.Voter == v.Voter {
+			m.votes[v.ProposalId][i] = v // dedup: replace
+			return nil
+		}
+	}
+	m.votes[v.ProposalId] = append(m.votes[v.ProposalId], v)
+	return nil
+}
+func (m *memGovDb) GetVotes(id string) ([]governance_db.ProposalVote, error) {
+	return m.votes[id], nil
+}
+
+// fourMemberElection: alice (the slashed beneficiary) + bob, carol, dave, equal
+// weight. Effective electorate excludes alice → 3; threshold = ceil(2*3/3) = 2.
+func fourMemberElection() *test_utils.MockElectionDb {
+	elec := elections.ElectionResult{
+		ElectionCommonInfo: elections.ElectionCommonInfo{Epoch: 1},
+		ElectionDataInfo: elections.ElectionDataInfo{
+			Members: []elections.ElectionMember{
+				{Account: "alice"}, {Account: "bob"}, {Account: "carol"}, {Account: "dave"},
+			},
+			Weights: []uint64{1, 1, 1, 1},
+		},
+		TotalWeight: 4,
+	}
+	return &test_utils.MockElectionDb{ElectionsByHeight: map[uint64]elections.ElectionResult{0: elec}}
+}
+
+func wireRestoreFixture(t *testing.T) (*chainOpFixture, *memGovDb) {
+	t.Helper()
+	f := newChainOpFixture(t)
+	gov := newMemGovDb()
+	f.se.WireGovernanceForTest(gov, fourMemberElection(), systemconfig.MocknetConfig())
+	return f, gov
+}
+
+const restorePayload = `{"id":"slash-restore-1","account":"alice"}`
+
+func reverseCredit(db *test_utils.MockLedgerDb) int64 {
+	var total int64
+	for _, r := range db.LedgerRecords["hive:alice"] {
+		if r.Type == ledgerSystem.LedgerTypeSafetySlashConsensusReverse {
+			total += r.Amount
+		}
+	}
+	return total
+}
+
+// TestSlashRestore_ThresholdRestoresBond is the happy path: a real slash, then
+// witness votes; the bond is re-credited only once 2/3 of the
+// beneficiary-excluded electorate has voted. Also exercises vote dedup.
+func TestSlashRestore_ThresholdRestoresBond(t *testing.T) {
+	f, gov := wireRestoreFixture(t)
+	f.fireSlash(t, "slash-restore-1", 100, 100) // alice slashed 10% of 1_000_000 = 100_000; maturity 200
+
+	propID := "slash_restore:slash-restore-1:alice"
+
+	// First vote: proposal created, 1 of 3 — below threshold, no restore.
+	f.se.HandleSlashRestoreVoteForTest([]byte(restorePayload), "bob", "v-bob", 110)
+	require.EqualValues(t, 0, reverseCredit(f.db), "no restore below threshold")
+	require.Len(t, gov.votes[propID], 1)
+
+	// Duplicate vote from bob: still 1 counting vote, no restore.
+	f.se.HandleSlashRestoreVoteForTest([]byte(restorePayload), "bob", "v-bob-2", 110)
+	require.Len(t, gov.votes[propID], 1, "duplicate voter must not double-count")
+	require.EqualValues(t, 0, reverseCredit(f.db))
+
+	// Second distinct voter crosses 2/3 → bond restored.
+	f.se.HandleSlashRestoreVoteForTest([]byte(restorePayload), "carol", "v-carol", 111)
+	require.EqualValues(t, 100_000, reverseCredit(f.db), "threshold crossed → full bond re-credited")
+
+	p, ok, _ := gov.GetProposal(propID)
+	require.True(t, ok)
+	require.Equal(t, string(governance.StatusApplied), p.Status)
+
+	// A late vote after apply is a no-op (terminal).
+	f.se.HandleSlashRestoreVoteForTest([]byte(restorePayload), "dave", "v-dave", 112)
+	require.EqualValues(t, 100_000, reverseCredit(f.db), "no double restore after applied")
+}
+
+// TestSlashRestore_BeneficiaryVoteExcluded: the slashed account's own vote never
+// counts toward its restoration.
+func TestSlashRestore_BeneficiaryVoteExcluded(t *testing.T) {
+	f, _ := wireRestoreFixture(t)
+	f.fireSlash(t, "slash-restore-1", 100, 100)
+
+	// alice (beneficiary) + bob = only 1 counting vote (bob); below threshold 2.
+	f.se.HandleSlashRestoreVoteForTest([]byte(restorePayload), "alice", "v-alice", 110)
+	f.se.HandleSlashRestoreVoteForTest([]byte(restorePayload), "bob", "v-bob", 111)
+	require.EqualValues(t, 0, reverseCredit(f.db), "beneficiary self-vote must not count")
+}
+
+// TestSlashRestore_NonMemberIgnored: a vote from a non-electorate account is
+// ignored and does not even create the proposal.
+func TestSlashRestore_NonMemberIgnored(t *testing.T) {
+	f, gov := wireRestoreFixture(t)
+	f.fireSlash(t, "slash-restore-1", 100, 100)
+
+	f.se.HandleSlashRestoreVoteForTest([]byte(restorePayload), "eve", "v-eve", 110)
+	_, ok, _ := gov.GetProposal("slash_restore:slash-restore-1:alice")
+	require.False(t, ok, "non-member must not create a proposal")
+	require.EqualValues(t, 0, reverseCredit(f.db))
+}
+
+// TestSlashRestore_ExpiresWithoutQuorum: once past the effective window the
+// proposal is terminal-expired and a later quorum cannot restore.
+func TestSlashRestore_ExpiresWithoutQuorum(t *testing.T) {
+	f, gov := wireRestoreFixture(t)
+	f.fireSlash(t, "slash-restore-1", 100, 100) // maturity 200
+
+	// Create + 1 vote at block 110.
+	f.se.HandleSlashRestoreVoteForTest([]byte(restorePayload), "bob", "v-bob", 110)
+	// Maturity (200) caps the window well before the 3-day expiry, so a vote at
+	// block 250 is past expiry → terminal.
+	f.se.HandleSlashRestoreVoteForTest([]byte(restorePayload), "carol", "v-carol", 250)
+
+	p, ok, _ := gov.GetProposal("slash_restore:slash-restore-1:alice")
+	require.True(t, ok)
+	require.Equal(t, string(governance.StatusExpired), p.Status)
+	require.EqualValues(t, 0, reverseCredit(f.db), "expired proposal cannot restore")
+
+	// Even a fresh quorum after expiry does nothing (one-shot, terminal).
+	f.se.HandleSlashRestoreVoteForTest([]byte(restorePayload), "dave", "v-dave", 260)
+	require.EqualValues(t, 0, reverseCredit(f.db))
+}

--- a/modules/state-processing/safety_evidence_internal_test.go
+++ b/modules/state-processing/safety_evidence_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"testing"
 
+	"vsc-node/modules/aggregate"
 	"vsc-node/modules/common/params"
 	systemconfig "vsc-node/modules/common/system-config"
 	"vsc-node/modules/db/vsc/elections"
@@ -648,25 +649,52 @@ func TestSeedProposalsFromStoredBlock_RebuildsCurrentSlot(t *testing.T) {
 // ProcessBlock entry-point test (custom_json from the gateway → sink enqueue;
 // non-gateway → reject) is a devnet integration item.
 
-// TestSafetySlashBurnDelayHeightGate verifies the production slash path resolves
-// the pending-burn window through the height gate: 3 days for a slash below the
-// 7-day activation height, 7 days at/after it. Proves the sconf → helper → params
-// wiring end-to-end (the params gate math itself is covered in the params pkg).
-func TestSafetySlashBurnDelayHeightGate(t *testing.T) {
+// versionElectionDb is a minimal elections.Elections whose GetElectionByHeight
+// reports consensus version 0.3.0 at/after activationHeight and 0.2.0 below it,
+// so a test can drive the chain-active-version burn-delay gate. The embedded
+// aggregate.Plugin (nil) covers the Init/Start/Stop methods the slash path never
+// calls.
+type versionElectionDb struct {
+	aggregate.Plugin
+	activationHeight uint64
+}
+
+func (m *versionElectionDb) StoreElection(elecResult elections.ElectionResult) error { return nil }
+func (m *versionElectionDb) GetElection(epoch uint64) *elections.ElectionResult       { return nil }
+func (m *versionElectionDb) GetPreviousElections(beforeEpoch uint64, limit int) []elections.ElectionResult {
+	return nil
+}
+func (m *versionElectionDb) GetElectionByHeight(height uint64) (elections.ElectionResult, error) {
+	consensus := uint64(2)
+	if height >= m.activationHeight {
+		consensus = 3
+	}
+	return elections.ElectionResult{
+		ElectionDataInfo: elections.ElectionDataInfo{ProtocolVersion: consensus},
+	}, nil
+}
+
+// TestSafetySlashBurnDelayVersionGate verifies the production slash path resolves
+// the pending-burn window through the CONSENSUS-VERSION gate: 3 days while the
+// chain-active version is below 0.3.0, 7 days once it reaches 0.3.0. The version
+// is read at the slash's own height (deterministic, replay-correct). Proves the
+// sconf/electionDb → ActiveConsensusVersion → 7d/3d wiring end-to-end (the gate
+// predicate itself is covered in the consensusversion pkg).
+func TestSafetySlashBurnDelayVersionGate(t *testing.T) {
 	t.Setenv("VSC_SLASH_BURN_DELAY", "") // ensure the off-mainnet env override is inert
 
-	base := systemconfig.MocknetConfig()
-	cp := base.ConsensusParams()
-	cp.SafetySlashBurnDelay7dHeight = 1_000
-	se := &StateEngine{sconf: &safetySlashSconf{SystemConfig: base, cp: cp}}
+	se := &StateEngine{
+		sconf:      systemconfig.MocknetConfig(),
+		electionDb: &versionElectionDb{activationHeight: 1_000}, // 0.3.0 active at/after 1000
+	}
 
 	if got := se.safetySlashBurnDelayBlocks(999); got != params.SafetySlashBurnDelay3dBlocks {
-		t.Errorf("slash below 7d height: got %d, want 3d (%d)", got, params.SafetySlashBurnDelay3dBlocks)
+		t.Errorf("slash below 0.3.0: got %d, want 3d (%d)", got, params.SafetySlashBurnDelay3dBlocks)
 	}
 	if got := se.safetySlashBurnDelayBlocks(1_000); got != params.SafetySlashBurnDelay7dBlocks {
-		t.Errorf("slash at 7d height: got %d, want 7d (%d)", got, params.SafetySlashBurnDelay7dBlocks)
+		t.Errorf("slash at 0.3.0: got %d, want 7d (%d)", got, params.SafetySlashBurnDelay7dBlocks)
 	}
 	if got := se.safetySlashBurnDelayBlocks(2_000_000); got != params.SafetySlashBurnDelay7dBlocks {
-		t.Errorf("slash well after 7d height: got %d, want 7d", got)
+		t.Errorf("slash well after 0.3.0: got %d, want 7d", got)
 	}
 }

--- a/modules/state-processing/safety_evidence_internal_test.go
+++ b/modules/state-processing/safety_evidence_internal_test.go
@@ -53,6 +53,7 @@ func (s *stubLedgerSystem) ReverseSafetySlashConsensusDebit(p ledgerSystem.Rever
 func (s *stubLedgerSystem) ReservePayout(p ledgerSystem.ReservePayoutParams) ledgerSystem.LedgerResult {
 	return ledgerSystem.LedgerResult{Ok: false, Msg: "stub"}
 }
+func (s *stubLedgerSystem) ReserveAvailable() int64 { return 0 }
 func (s *stubLedgerSystem) PendulumBucketBalance(bucket string, blockHeight uint64) int64 { return 0 }
 func (s *stubLedgerSystem) NewEmptySession(state *ledgerSystem.LedgerState, startHeight uint64) ledgerSystem.LedgerSession {
 	return nil

--- a/modules/state-processing/safety_evidence_internal_test.go
+++ b/modules/state-processing/safety_evidence_internal_test.go
@@ -50,6 +50,9 @@ func (s *stubLedgerSystem) CancelPendingSafetySlashBurn(p ledgerSystem.CancelPen
 func (s *stubLedgerSystem) ReverseSafetySlashConsensusDebit(p ledgerSystem.ReverseSafetySlashConsensusDebitParams) ledgerSystem.LedgerResult {
 	return ledgerSystem.LedgerResult{Ok: false, Msg: "stub"}
 }
+func (s *stubLedgerSystem) ReservePayout(p ledgerSystem.ReservePayoutParams) ledgerSystem.LedgerResult {
+	return ledgerSystem.LedgerResult{Ok: false, Msg: "stub"}
+}
 func (s *stubLedgerSystem) PendulumBucketBalance(bucket string, blockHeight uint64) int64 { return 0 }
 func (s *stubLedgerSystem) NewEmptySession(state *ledgerSystem.LedgerState, startHeight uint64) ledgerSystem.LedgerSession {
 	return nil
@@ -643,3 +646,26 @@ func TestSeedProposalsFromStoredBlock_RebuildsCurrentSlot(t *testing.T) {
 // affected the earlier DAO_WALLET (prefixed) comparison cannot recur. A full
 // ProcessBlock entry-point test (custom_json from the gateway → sink enqueue;
 // non-gateway → reject) is a devnet integration item.
+
+// TestSafetySlashBurnDelayHeightGate verifies the production slash path resolves
+// the pending-burn window through the height gate: 3 days for a slash below the
+// 7-day activation height, 7 days at/after it. Proves the sconf → helper → params
+// wiring end-to-end (the params gate math itself is covered in the params pkg).
+func TestSafetySlashBurnDelayHeightGate(t *testing.T) {
+	t.Setenv("VSC_SLASH_BURN_DELAY", "") // ensure the off-mainnet env override is inert
+
+	base := systemconfig.MocknetConfig()
+	cp := base.ConsensusParams()
+	cp.SafetySlashBurnDelay7dHeight = 1_000
+	se := &StateEngine{sconf: &safetySlashSconf{SystemConfig: base, cp: cp}}
+
+	if got := se.safetySlashBurnDelayBlocks(999); got != params.SafetySlashBurnDelay3dBlocks {
+		t.Errorf("slash below 7d height: got %d, want 3d (%d)", got, params.SafetySlashBurnDelay3dBlocks)
+	}
+	if got := se.safetySlashBurnDelayBlocks(1_000); got != params.SafetySlashBurnDelay7dBlocks {
+		t.Errorf("slash at 7d height: got %d, want 7d (%d)", got, params.SafetySlashBurnDelay7dBlocks)
+	}
+	if got := se.safetySlashBurnDelayBlocks(2_000_000); got != params.SafetySlashBurnDelay7dBlocks {
+		t.Errorf("slash well after 7d height: got %d, want 7d", got)
+	}
+}

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -29,6 +29,7 @@ import (
 	"vsc-node/modules/db/vsc/consensus_state"
 	"vsc-node/modules/db/vsc/contracts"
 	"vsc-node/modules/db/vsc/elections"
+	governance_db "vsc-node/modules/db/vsc/governance"
 	"vsc-node/modules/db/vsc/hive_blocks"
 	ledgerDb "vsc-node/modules/db/vsc/ledger"
 	"vsc-node/modules/db/vsc/nonces"
@@ -82,6 +83,10 @@ type StateEngine struct {
 	tssRequests    tss_db.TssRequests
 	tssKeys        tss_db.TssKeys
 	tssCommitments tss_db.TssCommitments
+	// governanceDb persists witness-vote governance proposals + votes
+	// (vsc.slash_restore / vsc.reserve_payout). Nil on paths that don't process
+	// governance (the handlers no-op when nil).
+	governanceDb governance_db.Governance
 
 	consensusState      consensus_state.ConsensusState
 	chainConsensusCache consensus_state.ChainConsensusState
@@ -577,6 +582,31 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 							"tx", tx.TransactionID, "slash_tx_id", rec.SlashTxID,
 							"action", rec.Action, "slashed", rec.SlashedAccount)
 					}
+				}
+
+				// vsc.slash_restore: a witness votes (from its own witness
+				// account) to restore a wrongful safety slash while it is still in
+				// its pending window. Propose==vote; on crossing 2/3 of the
+				// beneficiary-excluded electorate the bond is restored. The
+				// authority is the deterministic on-chain vote tally — no gateway
+				// key is materialized (restoration is pure L2 ledger state).
+				if Id == "vsc.slash_restore" {
+					se.handleSlashRestoreVote(cj.Json, RequiredAuths[0], tx.TransactionID, blockInfo.BlockHeight)
+				}
+
+				// vsc.reserve_payout: a witness PROPOSES a disbursement from the
+				// keyless insurance reserve {recipient, amount, reason}. The proposal
+				// id is derived from the content + this tx id, and the create counts
+				// as the proposer's first vote.
+				if Id == "vsc.reserve_payout" {
+					se.handleReservePayoutCreate(cj.Json, RequiredAuths[0], tx.TransactionID, blockInfo.BlockHeight)
+				}
+
+				// vsc.reserve_vote: a witness approves an existing reserve-payout
+				// proposal by id {id}. On crossing 2/3 of the recipient-excluded
+				// electorate, the reserve disburses (capped at its balance).
+				if Id == "vsc.reserve_vote" {
+					se.handleReservePayoutVote(cj.Json, RequiredAuths[0], tx.TransactionID, blockInfo.BlockHeight)
 				}
 			}
 		}
@@ -2663,6 +2693,7 @@ func New(sconf systemconfig.SystemConfig, da *DataLayer.DataLayer,
 	tssKeys tss_db.TssKeys,
 	tssCommitments tss_db.TssCommitments,
 	tssRequests tss_db.TssRequests,
+	governanceDb governance_db.Governance,
 	pendulumSettlementsDb pendulum_settlements.PendulumSettlements,
 	consensusStateDb consensus_state.ConsensusState,
 	wasm *wasm_runtime.Wasm,
@@ -2717,6 +2748,7 @@ func New(sconf systemconfig.SystemConfig, da *DataLayer.DataLayer,
 		tssRequests:    tssRequests,
 		tssCommitments: tssCommitments,
 		tssKeys:        tssKeys,
+		governanceDb:   governanceDb,
 
 		consensusState:   consensusStateDb,
 		consensusRuntime: NewConsensusRuntime(),
@@ -2814,35 +2846,36 @@ func (se *StateEngine) applyPrincipalSlashForProvableEvidence(
 		TxID:            txID,
 		BlockHeight:     blockHeight,
 		EvidenceKind:    evidenceKind,
-		BurnDelayBlocks: se.safetySlashBurnDelayBlocks(),
+		BurnDelayBlocks: se.safetySlashBurnDelayBlocks(blockHeight),
 	})
 }
 
-// safetySlashBurnDelayBlocks returns the pending-burn challenge-window length
-// for a new safety slash. It is the production constant
-// (safetyslash.DefaultSafetySlashBurnDelayBlocks) on mainnet, and unconditionally
-// so — there is NO env override on mainnet. Off mainnet ONLY (devnet/testnet),
-// the integration-test harness may shorten or lengthen the window via the
-// VSC_SLASH_BURN_DELAY env var (parsed as a uint64 number of blocks), clamped to
-// params.MaxSafetySlashBurnDelayBlocks. This lets devnet tests either mature the
-// residual fast (reserve-destination proof) or hold it pending long enough to
-// post a wrongful-slash reversal (governance-reverse proof) without waiting the
-// production window. A missing/blank/unparseable value falls back to the
-// production default, so a misconfigured devnet node behaves exactly like
-// production rather than silently disabling the delay.
-func (se *StateEngine) safetySlashBurnDelayBlocks() uint64 {
-	delay := safetyslash.DefaultSafetySlashBurnDelayBlocks
+// safetySlashBurnDelayBlocks returns the pending-burn challenge-window length for
+// a new safety slash occurring at slashHeight. On mainnet it is the height-gated
+// production window (params.SafetySlashBurnDelayBlocks: 3 days, or 7 days at/after
+// SafetySlashBurnDelay7dHeight) — there is NO env override on mainnet. Off mainnet
+// ONLY (devnet/testnet), the integration-test harness may override the window via
+// the VSC_SLASH_BURN_DELAY env var (parsed as a uint64 number of blocks), clamped
+// to params.MaxSafetySlashBurnDelayBlocks, so tests can either mature the residual
+// fast (reserve-destination proof) or hold it pending long enough to post a
+// wrongful-slash reversal (governance-reverse proof). A missing/blank/unparseable
+// value falls back to the height-gated production window, so a misconfigured
+// devnet node behaves exactly like production rather than silently disabling it.
+func (se *StateEngine) safetySlashBurnDelayBlocks(slashHeight uint64) uint64 {
 	if se != nil && se.sconf != nil && !se.sconf.OnMainnet() {
 		if raw := strings.TrimSpace(os.Getenv("VSC_SLASH_BURN_DELAY")); raw != "" {
 			if parsed, err := strconv.ParseUint(raw, 10, 64); err == nil {
 				if parsed > params.MaxSafetySlashBurnDelayBlocks {
 					parsed = params.MaxSafetySlashBurnDelayBlocks
 				}
-				delay = parsed
+				return parsed
 			}
 		}
 	}
-	return delay
+	if se != nil && se.sconf != nil {
+		return se.sconf.ConsensusParams().SafetySlashBurnDelayBlocks(slashHeight)
+	}
+	return safetyslash.DefaultSafetySlashBurnDelayBlocks
 }
 
 func (se *StateEngine) evidenceKey(accountHive, kind string) string {

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -584,29 +584,38 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 					}
 				}
 
-				// vsc.slash_restore: a witness votes (from its own witness
-				// account) to restore a wrongful safety slash while it is still in
-				// its pending window. Propose==vote; on crossing 2/3 of the
-				// beneficiary-excluded electorate the bond is restored. The
-				// authority is the deterministic on-chain vote tally — no gateway
-				// key is materialized (restoration is pure L2 ledger state).
-				if Id == "vsc.slash_restore" {
-					se.handleSlashRestoreVote(cj.Json, RequiredAuths[0], tx.TransactionID, blockInfo.BlockHeight)
-				}
+				// The witness-vote governance batch (vsc.slash_restore /
+				// vsc.reserve_payout / vsc.reserve_vote) is gated on the CHAIN-ACTIVE
+				// consensus version reaching 0.3.0, resolved from the election active
+				// at this block (deterministic, replay-correct). Below the line the
+				// ops are inert on EVERY node, so old and new binaries interoperate
+				// and a laggard is excluded from the committee rather than applying
+				// these ledger effects over a chain that didn't (see feature_gates.go).
+				if consensusversion.GovernanceActionsActive(se.ActiveConsensusVersion(blockInfo.BlockHeight)) {
+					// vsc.slash_restore: a witness votes (from its own witness
+					// account) to restore a wrongful safety slash while it is still in
+					// its pending window. Propose==vote; on crossing 2/3 of the
+					// beneficiary-excluded electorate the bond is restored. The
+					// authority is the deterministic on-chain vote tally — no gateway
+					// key is materialized (restoration is pure L2 ledger state).
+					if Id == "vsc.slash_restore" {
+						se.handleSlashRestoreVote(cj.Json, RequiredAuths[0], tx.TransactionID, blockInfo.BlockHeight)
+					}
 
-				// vsc.reserve_payout: a witness PROPOSES a disbursement from the
-				// keyless insurance reserve {recipient, amount, reason}. The proposal
-				// id is derived from the content + this tx id, and the create counts
-				// as the proposer's first vote.
-				if Id == "vsc.reserve_payout" {
-					se.handleReservePayoutCreate(cj.Json, RequiredAuths[0], tx.TransactionID, blockInfo.BlockHeight)
-				}
+					// vsc.reserve_payout: a witness PROPOSES a disbursement from the
+					// keyless insurance reserve {recipient, amount, reason}. The proposal
+					// id is derived from the content + this tx id, and the create counts
+					// as the proposer's first vote.
+					if Id == "vsc.reserve_payout" {
+						se.handleReservePayoutCreate(cj.Json, RequiredAuths[0], tx.TransactionID, blockInfo.BlockHeight)
+					}
 
-				// vsc.reserve_vote: a witness approves an existing reserve-payout
-				// proposal by id {id}. On crossing 2/3 of the recipient-excluded
-				// electorate, the reserve disburses (capped at its balance).
-				if Id == "vsc.reserve_vote" {
-					se.handleReservePayoutVote(cj.Json, RequiredAuths[0], tx.TransactionID, blockInfo.BlockHeight)
+					// vsc.reserve_vote: a witness approves an existing reserve-payout
+					// proposal by id {id}. On crossing 2/3 of the recipient-excluded
+					// electorate, the reserve disburses (capped at its balance).
+					if Id == "vsc.reserve_vote" {
+						se.handleReservePayoutVote(cj.Json, RequiredAuths[0], tx.TransactionID, blockInfo.BlockHeight)
+					}
 				}
 			}
 		}
@@ -2851,16 +2860,22 @@ func (se *StateEngine) applyPrincipalSlashForProvableEvidence(
 }
 
 // safetySlashBurnDelayBlocks returns the pending-burn challenge-window length for
-// a new safety slash occurring at slashHeight. On mainnet it is the height-gated
-// production window (params.SafetySlashBurnDelayBlocks: 3 days, or 7 days at/after
-// SafetySlashBurnDelay7dHeight) — there is NO env override on mainnet. Off mainnet
-// ONLY (devnet/testnet), the integration-test harness may override the window via
-// the VSC_SLASH_BURN_DELAY env var (parsed as a uint64 number of blocks), clamped
-// to params.MaxSafetySlashBurnDelayBlocks, so tests can either mature the residual
-// fast (reserve-destination proof) or hold it pending long enough to post a
-// wrongful-slash reversal (governance-reverse proof). A missing/blank/unparseable
-// value falls back to the height-gated production window, so a misconfigured
-// devnet node behaves exactly like production rather than silently disabling it.
+// a new safety slash occurring at slashHeight. On mainnet it is the version-gated
+// production window: 3 days, or 7 days once the CHAIN-ACTIVE consensus version
+// reaches 0.3.0 (consensusversion.SafetySlashBurnDelay7dActive) — there is NO env
+// override on mainnet. Off mainnet ONLY (devnet/testnet), the integration-test
+// harness may override the window via the VSC_SLASH_BURN_DELAY env var (parsed as
+// a uint64 number of blocks), clamped to params.MaxSafetySlashBurnDelayBlocks, so
+// tests can either mature the residual fast (reserve-destination proof) or hold it
+// pending long enough to post a wrongful-slash reversal (governance-reverse
+// proof). A missing/blank/unparseable value falls back to the version-gated
+// production window.
+//
+// The 7-day window is gated on the consensus version (NOT a raw height) so it
+// flips in lockstep with the v0.3.0 governance slash_restore op it backs and a
+// laggard is excluded from the committee rather than forking across a height. The
+// version is resolved at the slash's OWN height so the stored maturity
+// (slashHeight + delay) recomputes identically on replay.
 func (se *StateEngine) safetySlashBurnDelayBlocks(slashHeight uint64) uint64 {
 	if se != nil && se.sconf != nil && !se.sconf.OnMainnet() {
 		if raw := strings.TrimSpace(os.Getenv("VSC_SLASH_BURN_DELAY")); raw != "" {
@@ -2872,8 +2887,13 @@ func (se *StateEngine) safetySlashBurnDelayBlocks(slashHeight uint64) uint64 {
 			}
 		}
 	}
-	if se != nil && se.sconf != nil {
-		return se.sconf.ConsensusParams().SafetySlashBurnDelayBlocks(slashHeight)
+	// electionDb is required to resolve the chain-active version; on the rare test
+	// paths without it, fall back to the 3-day default (safe, matches pre-0.3.0).
+	if se != nil && se.electionDb != nil {
+		if consensusversion.SafetySlashBurnDelay7dActive(se.ActiveConsensusVersion(slashHeight)) {
+			return params.SafetySlashBurnDelay7dBlocks
+		}
+		return params.SafetySlashBurnDelay3dBlocks
 	}
 	return safetyslash.DefaultSafetySlashBurnDelayBlocks
 }

--- a/modules/state-processing/state_engine_test.go
+++ b/modules/state-processing/state_engine_test.go
@@ -112,6 +112,7 @@ func newTestEnvWithConsensus(cs consensus_state.ConsensusState, sconf systemconf
 		txDb, ledgerDbImpl, balanceDb, nil,
 		interestClaims, vscBlocksDb, actionsDb, mockRcDb, nonceDb,
 		tssKeys, tssCommitments, tssRequests,
+		nil, // governanceDb
 		nil, // pendulumSettlementsDb
 		cs,  // consensusStateDb
 		nil, // wasm

--- a/tests/devnet/governance_reserve_payout_test.go
+++ b/tests/devnet/governance_reserve_payout_test.go
@@ -1,0 +1,206 @@
+package devnet
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"vsc-node/modules/common/params"
+	systemconfig "vsc-node/modules/common/system-config"
+	governance "vsc-node/modules/governance"
+)
+
+// sumReserveCredits sums the safety_slash_reserve credit rows on the keyless
+// insurance reserve account (the matured slash residual it now holds), read from
+// node 1.
+func sumReserveCredits(t *testing.T, d *Devnet) int64 {
+	t.Helper()
+	rows := findLedgerTXs(t, d.GQLEndpoint(1), params.ProtocolSlashReserveAccount, []string{"safety_slash_reserve"})
+	var total int64
+	for _, r := range rows {
+		if r.Amount > 0 && r.Asset == "hive" {
+			total += r.Amount
+		}
+	}
+	return total
+}
+
+// sumReservePayoutDebits sums the reserve_payout_debit rows on the reserve
+// account (negative; the amount drawn out by governance payouts), read from node 1.
+func sumReservePayoutDebits(t *testing.T, d *Devnet) int64 {
+	t.Helper()
+	rows := findLedgerTXs(t, d.GQLEndpoint(1), params.ProtocolSlashReserveAccount, []string{"reserve_payout_debit"})
+	var total int64
+	for _, r := range rows {
+		if r.Asset == "hive" {
+			total += r.Amount // negative
+		}
+	}
+	return total
+}
+
+// TestGovernanceReservePayoutVote proves the heavy make-whole path end-to-end on
+// a real multi-node devnet: after a slash residual MATURES into the keyless
+// insurance reserve, a quorum of witnesses disburses it back to the slashed
+// account via vsc.reserve_payout (the create == proposer's first vote) +
+// vsc.reserve_vote (votes by proposal id). This is the first-ever debit of the
+// reserve and the exact recovery path for an already-matured slash (the mengao
+// case).
+//
+// VSC_SLASH_BURN_DELAY=0 sends the residual STRAIGHT to the reserve (no pending
+// window), so the funds are immediately reserve-held and the only way out is this
+// vote. The recipient is the slashed witness (magi.test3), which is therefore the
+// excluded beneficiary — it cannot vote for its own payout, and the OTHER
+// witnesses decide.
+//
+// MINIMUM-QUORUM CHECK: the recipient (test3) is excluded, leaving 5 effective
+// witnesses (test1,2,4,5,6) and a threshold of ceil(2*5/3)=4. We sign with
+// EXACTLY 4 — the create from test1 plus votes from test2/test4/test5 — and leave
+// test6 abstaining, proving the payout lands on the minimum quorum, not all 5.
+//
+// Run manually (long-running, excluded from `make test`):
+//
+//	go test ./tests/devnet/ -run TestGovernanceReservePayoutVote -timeout 45m -v
+func TestGovernanceReservePayoutVote(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	const (
+		attacker = "magi.test3" // forced double-signer → slashed; its residual funds the reserve; the payout recipient (excluded)
+		honest   = "magi.test1"
+	)
+
+	cfg := DefaultConfig()
+	cfg.Nodes = 6
+	cfg.SkipFunding = true
+	cfg.LogLevel = "info"
+	cfg.MagiEnv = map[string]string{
+		"VSC_DOUBLE_SIGN_ACCOUNT":  attacker,
+		"VSC_DOUBLE_SIGN_ONCE":     "1",
+		"VSC_SLASH_BURN_DELAY":     "0", // residual goes straight to the keyless reserve (no pending window)
+		"DEVNET_DETERMINISTIC_BLS": "1", // deterministic witness keys so genesis-elector forms a valid committee
+	}
+	if os.Getenv("DEVNET_KEEP") != "" {
+		cfg.KeepRunning = true
+	}
+	cfg.SysConfigOverrides = &systemconfig.SysConfigOverrides{
+		ConsensusParams: &params.ConsensusParams{ElectionInterval: 20},
+	}
+
+	d, ctx := startDevnetNoKey(t, cfg, 45*time.Minute)
+
+	baseH := waitForStableBond(t, d, "hive:"+honest, 8*time.Minute)
+	head, _ := getHeadBlock(d.HiveRPCEndpoint())
+	t.Logf("[reserve-pay] head=%d baseline(stable honest)=%d", head, baseH)
+
+	// 1) Wait for the double-sign to slash node-3.
+	slashDeadline := time.Now().Add(10 * time.Minute)
+	var cur3 int64 = gqlConsensus(t, d.GQLEndpoint(1), "hive:"+attacker)
+	for time.Now().Before(slashDeadline) {
+		cur3 = gqlConsensus(t, d.GQLEndpoint(1), "hive:"+attacker)
+		if cur3 >= 0 && cur3 < baseH {
+			break
+		}
+		time.Sleep(3 * time.Second)
+	}
+	if !(cur3 >= 0 && cur3 < baseH) {
+		dumpNodeLogs(t, d, ctx, cfg.Nodes, 40)
+		t.Fatalf("[reserve-pay] node-3 bond never dropped below baseline (baseH=%d cur=%d) — slash did not fire", baseH, cur3)
+	}
+	t.Logf("[reserve-pay] node-3 slashed: bond now=%d (baseline=%d); slash-debit total=%d", cur3, baseH, sumSlashDebits(t, d, "hive:"+attacker))
+
+	// 2) Wait for the residual to land in the reserve and STABILIZE (a single
+	// incident can trip two detectors → two reserve credits arriving slightly
+	// apart). The stable total is the amount we will disburse in full.
+	var reserveAmt int64
+	reserveDeadline := time.Now().Add(5 * time.Minute)
+	var lastReserve int64 = -1
+	for time.Now().Before(reserveDeadline) {
+		v := sumReserveCredits(t, d)
+		if v > 0 && v == lastReserve {
+			reserveAmt = v
+			break
+		}
+		lastReserve = v
+		time.Sleep(3 * time.Second)
+	}
+	if reserveAmt <= 0 {
+		dumpNodeLogs(t, d, ctx, cfg.Nodes, 40)
+		t.Fatalf("[reserve-pay] reserve was never funded by the slash residual (last=%d)", lastReserve)
+	}
+	t.Logf("[reserve-pay] reserve funded and stable at %d (will disburse in full to %s)", reserveAmt, attacker)
+
+	preRecipient := gqlHiveSpendable(t, d.GQLEndpoint(1), "hive:"+attacker)
+	if preRecipient < 0 {
+		preRecipient = 0
+	}
+	wantHive := preRecipient + reserveAmt
+	t.Logf("[reserve-pay] recipient pre-payout spendable hive=%d; expect rise to %d", preRecipient, wantHive)
+
+	// 3) Propose the payout. The CREATE op (from test1) introduces {recipient,
+	// amount, reason} and counts as test1's first vote; the proposal id is derived
+	// from the content + this create tx id, exactly as the handler derives it.
+	reason := "reserve make-whole (devnet test)"
+	createPayload := map[string]interface{}{
+		"recipient": attacker,
+		"amount":    reserveAmt,
+		"reason":    reason,
+	}
+	createTx, err := d.BroadcastCustomJSON("vsc.reserve_payout", []string{honest}, createPayload, d.cfg.InitminerWIF)
+	if err != nil {
+		dumpNodeLogs(t, d, ctx, cfg.Nodes, 40)
+		t.Fatalf("[reserve-pay] broadcasting vsc.reserve_payout create: %v", err)
+	}
+	proposalID := governance.ReservePayoutProposalID(attacker, reserveAmt, reason, createTx)
+	t.Logf("[reserve-pay] create tx=%s proposal_id=%s (test1's create == vote 1/4)", createTx, proposalID)
+
+	// Let the create land + be processed so the proposal exists on every node
+	// before the votes reference it (a vote for an unknown proposal is dropped).
+	time.Sleep(18 * time.Second)
+
+	// 4) Sign with EXACTLY the threshold: 3 more votes (test2, test4, test5) →
+	// create + 3 = 4 = ceil(2*5/3). test6 ABSTAINS (recipient test3 is excluded).
+	votePayload := map[string]interface{}{"id": proposalID}
+	for _, voter := range []string{"magi.test2", "magi.test4", "magi.test5"} {
+		txID, err := d.BroadcastCustomJSON("vsc.reserve_vote", []string{voter}, votePayload, d.cfg.InitminerWIF)
+		if err != nil {
+			dumpNodeLogs(t, d, ctx, cfg.Nodes, 40)
+			t.Fatalf("[reserve-pay] broadcasting vsc.reserve_vote from %s: %v", voter, err)
+		}
+		t.Logf("[reserve-pay] vote from %s tx=%s", voter, txID)
+		time.Sleep(1 * time.Second)
+	}
+	t.Logf("[reserve-pay] 4 of 5 effective witnesses signed (test6 abstains) — minimum quorum")
+
+	// 5) Poll until the recipient's spendable hive rises by the disbursed amount.
+	payDeadline := time.Now().Add(8 * time.Minute)
+	paid := false
+	for time.Now().Before(payDeadline) {
+		if gqlHiveSpendable(t, d.GQLEndpoint(1), "hive:"+attacker) >= wantHive {
+			paid = true
+			break
+		}
+		time.Sleep(3 * time.Second)
+	}
+	if !paid {
+		dumpNodeLogs(t, d, ctx, cfg.Nodes, 40)
+		final := gqlHiveSpendable(t, d.GQLEndpoint(1), "hive:"+attacker)
+		t.Fatalf("[reserve-pay] recipient spendable hive never rose to %d (final=%d, pre=%d, amount=%d) — minimum quorum did not disburse",
+			wantHive, final, preRecipient, reserveAmt)
+	}
+
+	// 6) Cross-node consistency + reserve drawdown: every node must agree the
+	// recipient was paid, and the reserve must carry a debit of the disbursed amount.
+	for n := 1; n <= cfg.Nodes; n++ {
+		if v := gqlHiveSpendable(t, d.GQLEndpoint(n), "hive:"+attacker); v < wantHive {
+			dumpNodeLogs(t, d, ctx, cfg.Nodes, 40)
+			t.Fatalf("[reserve-pay] node-%d disagrees: recipient spendable hive=%d < want=%d", n, v, wantHive)
+		}
+	}
+	if debits := sumReservePayoutDebits(t, d); debits > -reserveAmt {
+		t.Fatalf("[reserve-pay] expected a reserve debit of <= %d, got %d", -reserveAmt, debits)
+	}
+	t.Logf("[reserve-pay] SUCCESS: %d disbursed from the reserve to %s on the minimum 4-of-5 quorum; consistent across all %d nodes",
+		reserveAmt, attacker, cfg.Nodes)
+}

--- a/tests/devnet/governance_reserve_payout_test.go
+++ b/tests/devnet/governance_reserve_payout_test.go
@@ -192,11 +192,27 @@ func TestGovernanceReservePayoutVote(t *testing.T) {
 
 	// 6) Cross-node consistency + reserve drawdown: every node must agree the
 	// recipient was paid, and the reserve must carry a debit of the disbursed amount.
-	for n := 1; n <= cfg.Nodes; n++ {
-		if v := gqlHiveSpendable(t, d.GQLEndpoint(n), "hive:"+attacker); v < wantHive {
-			dumpNodeLogs(t, d, ctx, cfg.Nodes, 40)
-			t.Fatalf("[reserve-pay] node-%d disagrees: recipient spendable hive=%d < want=%d", n, v, wantHive)
+	// All nodes apply the payout at the SAME L1 block (the vote tally is a
+	// deterministic function of L1-ordered votes), but a non-leader may process
+	// that block a beat after node-1, so poll each node to convergence rather than
+	// reading a single instant. A genuine divergence still fails at the deadline.
+	crossDeadline := time.Now().Add(2 * time.Minute)
+	for {
+		laggard, laggardV := 0, int64(0)
+		for n := 1; n <= cfg.Nodes; n++ {
+			if v := gqlHiveSpendable(t, d.GQLEndpoint(n), "hive:"+attacker); v < wantHive {
+				laggard, laggardV = n, v
+				break
+			}
 		}
+		if laggard == 0 {
+			break // every node agrees
+		}
+		if time.Now().After(crossDeadline) {
+			dumpNodeLogs(t, d, ctx, cfg.Nodes, 40)
+			t.Fatalf("[reserve-pay] node-%d disagrees: recipient spendable hive=%d < want=%d", laggard, laggardV, wantHive)
+		}
+		time.Sleep(3 * time.Second)
 	}
 	if debits := sumReservePayoutDebits(t, d); debits > -reserveAmt {
 		t.Fatalf("[reserve-pay] expected a reserve debit of <= %d, got %d", -reserveAmt, debits)

--- a/tests/devnet/governance_slash_restore_test.go
+++ b/tests/devnet/governance_slash_restore_test.go
@@ -174,15 +174,29 @@ func TestGovernanceSlashRestoreVote(t *testing.T) {
 			wantBond, final, preVote, rowSlashedAmt)
 	}
 
-	// 5) Cross-node consistency: every node must agree the bond was restored (the
-	// reverse landed in a 2/3-ratified block, so all nodes apply it identically),
-	// and a safety_slash_consensus_reverse credit row must exist for the account.
-	for n := 1; n <= cfg.Nodes; n++ {
-		b := gqlConsensus(t, d.GQLEndpoint(n), "hive:"+attacker)
-		if b < wantBond {
-			dumpNodeLogs(t, d, ctx, cfg.Nodes, 40)
-			t.Fatalf("[restore-vote] node-%d disagrees: bond=%d < want=%d (restoration not consistent across nodes)", n, b, wantBond)
+	// 5) Cross-node consistency: every node must agree the bond was restored. All
+	// nodes tally the L1 votes and apply the reverse at the same L1 block, but a
+	// non-leader may process that block a beat after node-1, so poll each node to
+	// convergence rather than reading a single instant. A genuine divergence still
+	// fails at the deadline. Then a safety_slash_consensus_reverse credit row must
+	// exist for the account.
+	crossDeadline := time.Now().Add(2 * time.Minute)
+	for {
+		laggard, laggardV := 0, int64(0)
+		for n := 1; n <= cfg.Nodes; n++ {
+			if b := gqlConsensus(t, d.GQLEndpoint(n), "hive:"+attacker); b < wantBond {
+				laggard, laggardV = n, b
+				break
+			}
 		}
+		if laggard == 0 {
+			break // every node agrees
+		}
+		if time.Now().After(crossDeadline) {
+			dumpNodeLogs(t, d, ctx, cfg.Nodes, 40)
+			t.Fatalf("[restore-vote] node-%d disagrees: bond=%d < want=%d (restoration not consistent across nodes)", laggard, laggardV, wantBond)
+		}
+		time.Sleep(3 * time.Second)
 	}
 	reverseRows := findLedgerTXs(t, d.GQLEndpoint(1), "hive:"+attacker, []string{"safety_slash_consensus_reverse"})
 	var reverseTotal int64

--- a/tests/devnet/governance_slash_restore_test.go
+++ b/tests/devnet/governance_slash_restore_test.go
@@ -1,0 +1,199 @@
+package devnet
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"vsc-node/modules/common/params"
+	systemconfig "vsc-node/modules/common/system-config"
+)
+
+// TestGovernanceSlashRestoreVote proves the witness-vote restoration path
+// end-to-end on a real multi-node devnet: a wrongful safety slash is undone NOT
+// by a gateway-multisig op but by a quorum of witnesses each broadcasting a cheap
+// vsc.slash_restore custom_json FROM THEIR OWN WITNESS ACCOUNT. The state engine
+// tallies those L1 votes deterministically and, on crossing 2/3 of the
+// beneficiary-excluded electorate, runs applySafetySlashReverse to RESTORE
+// node-3's slashed HIVE_CONSENSUS bond. No gateway key is ever materialized —
+// restoration is pure L2 ledger state driven by the on-chain vote tally.
+//
+// Setup mirrors TestSafetySlashGovernanceReverse: a single forced double-sign by
+// node-3 fires the slash, and a LONG burn delay (VSC_SLASH_BURN_DELAY=600) keeps
+// the residual pending so the light cancel+reverse path has full headroom.
+//
+// Run manually (long-running, excluded from `make test`):
+//
+//	go test ./tests/devnet/ -run TestGovernanceSlashRestoreVote -timeout 45m -v
+func TestGovernanceSlashRestoreVote(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	const (
+		attacker = "magi.test3" // forced double-signer → wrongfully slashed → the beneficiary (excluded from voting)
+		honest   = "magi.test1"
+	)
+
+	cfg := DefaultConfig()
+	cfg.Nodes = 6
+	cfg.SkipFunding = true
+	cfg.LogLevel = "info"
+	cfg.MagiEnv = map[string]string{
+		"VSC_DOUBLE_SIGN_ACCOUNT": attacker,
+		"VSC_DOUBLE_SIGN_ONCE":    "1",
+		"VSC_SLASH_BURN_DELAY":    "600", // long: residual stays pending so slash_restore (cancel+reverse) has full headroom
+		// Match the proven-working reverse test: devnet-setup derives deterministic
+		// per-witness BLS/consensus keys that line up with the running nodes, so the
+		// genesis-elector finds a valid committee (avoids panic("No members found")).
+		// (The vote path itself signs each witness vote with the initminer key, so it
+		// does not depend on this — it is purely for reliable genesis startup.)
+		"DEVNET_DETERMINISTIC_BLS": "1",
+	}
+	if os.Getenv("DEVNET_KEEP") != "" {
+		cfg.KeepRunning = true
+	}
+	// Short election interval so the 6-witness electorate forms quickly.
+	cfg.SysConfigOverrides = &systemconfig.SysConfigOverrides{
+		ConsensusParams: &params.ConsensusParams{ElectionInterval: 20},
+	}
+
+	d, ctx := startDevnetNoKey(t, cfg, 45*time.Minute)
+
+	// True post-genesis staking baseline (== node-3's pre-slash bond, since every
+	// witness staked equally). node-3's bond must RETURN to this after restoration.
+	baseH := waitForStableBond(t, d, "hive:"+honest, 8*time.Minute)
+	head, _ := getHeadBlock(d.HiveRPCEndpoint())
+	t.Logf("[restore-vote] head=%d baseline(stable honest)=%d", head, baseH)
+
+	// 1) Wait for the double-sign incident to slash node-3's bond below baseline.
+	slashDeadline := time.Now().Add(10 * time.Minute)
+	var cur3 int64 = gqlConsensus(t, d.GQLEndpoint(1), "hive:"+attacker)
+	for time.Now().Before(slashDeadline) {
+		cur3 = gqlConsensus(t, d.GQLEndpoint(1), "hive:"+attacker)
+		if cur3 >= 0 && cur3 < baseH {
+			break
+		}
+		time.Sleep(3 * time.Second)
+	}
+	if !(cur3 >= 0 && cur3 < baseH) {
+		dumpNodeLogs(t, d, ctx, cfg.Nodes, 40)
+		t.Fatalf("[restore-vote] node-3 bond never dropped below baseline (baseH=%d cur=%d) — slash did not fire", baseH, cur3)
+	}
+	slashedTotal := sumSlashDebits(t, d, "hive:"+attacker)
+	t.Logf("[restore-vote] node-3 slashed: bond now=%d (baseline=%d); ledger slash-debit total=%d", cur3, baseH, slashedTotal)
+	if slashedTotal <= 0 {
+		dumpNodeLogs(t, d, ctx, cfg.Nodes, 40)
+		t.Fatalf("[restore-vote] no safety_slash_consensus debit rows for node-3")
+	}
+
+	// 2) Pick ONE slash row to restore. vsc.slash_restore needs only the row's
+	// tx_id + the slashed account — the handler resolves the evidence kind and
+	// amount from the row itself (voters never supply them). A double-sign trips
+	// multiple detectors with DIFFERENT triggering txs, so we choose one row and
+	// the handler will cancel+reverse exactly that (tx_id, kind).
+	var slashRow ledgerRecord
+	rowDeadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(rowDeadline) {
+		rows := findLedgerTXs(t, d.GQLEndpoint(1), "hive:"+attacker, []string{"safety_slash_consensus"})
+		var best ledgerRecord
+		for _, r := range rows {
+			if r.Amount >= 0 || r.Asset != "hive_consensus" {
+				continue
+			}
+			if evidenceKindFromSlashRowID(r.Id) == "" {
+				continue
+			}
+			// Prefer the largest single debit; deterministic tiebreak on row id so
+			// this picks the SAME row the handler's resolver picks (smallest id).
+			if best.TxId == "" || -r.Amount > -best.Amount || (-r.Amount == -best.Amount && r.Id < best.Id) {
+				best = r
+			}
+		}
+		if best.TxId != "" {
+			slashRow = best
+			break
+		}
+		time.Sleep(3 * time.Second)
+	}
+	if slashRow.TxId == "" {
+		dumpNodeLogs(t, d, ctx, cfg.Nodes, 40)
+		t.Fatalf("[restore-vote] no safety_slash_consensus row found for %s", attacker)
+	}
+	slashTxID := slashRow.TxId
+	rowSlashedAmt := -slashRow.Amount // amount this one incident debited; the bond must rise by this
+	t.Logf("[restore-vote] target slash row: id=%s tx_id=%s amount=%d kind=%s",
+		slashRow.Id, slashTxID, slashRow.Amount, evidenceKindFromSlashRowID(slashRow.Id))
+
+	preVote := gqlConsensus(t, d.GQLEndpoint(1), "hive:"+attacker)
+	wantBond := preVote + rowSlashedAmt
+	t.Logf("[restore-vote] pre-vote bond=%d; expect rise by %d -> %d", preVote, rowSlashedAmt, wantBond)
+
+	// 3) Each NON-attacker witness votes to restore by broadcasting vsc.slash_restore
+	// from its OWN account. Payload is just {id, account}. The slashed account
+	// (magi.test3) is the beneficiary and is excluded from the tally, so the
+	// effective electorate is the other 5 witnesses (threshold ceil(2*5/3)=4); we
+	// vote from all 5 to comfortably cross it. Every devnet witness account is
+	// controlled by the initminer key (so the test signs each vote with it) — in
+	// production each operator signs with the key that controls their own account.
+	payload := map[string]interface{}{"id": slashTxID, "account": attacker}
+	voteCount := 0
+	for n := 1; n <= cfg.Nodes; n++ {
+		voter := d.witnessAccount(n)
+		if voter == attacker {
+			continue // beneficiary cannot vote for its own restoration
+		}
+		txID, err := d.BroadcastCustomJSON("vsc.slash_restore", []string{voter}, payload, d.cfg.InitminerWIF)
+		if err != nil {
+			dumpNodeLogs(t, d, ctx, cfg.Nodes, 40)
+			t.Fatalf("[restore-vote] broadcasting vsc.slash_restore from %s: %v", voter, err)
+		}
+		voteCount++
+		t.Logf("[restore-vote] vote %d/%d from %s tx=%s", voteCount, cfg.Nodes-1, voter, txID)
+		time.Sleep(1 * time.Second) // small spacing so votes land in distinct/ordered blocks
+	}
+
+	// 4) Poll node-3's bond on ALL nodes until it RISES by the restored incident's
+	// amount. The votes must be observed on L1, tallied during block replay, and
+	// on crossing 2/3 applySafetySlashReverse re-credits the bond. Allow several
+	// leader rotations.
+	restoreDeadline := time.Now().Add(8 * time.Minute)
+	restored := false
+	for time.Now().Before(restoreDeadline) {
+		b := gqlConsensus(t, d.GQLEndpoint(1), "hive:"+attacker)
+		if b >= wantBond {
+			restored = true
+			break
+		}
+		time.Sleep(3 * time.Second)
+	}
+	if !restored {
+		dumpNodeLogs(t, d, ctx, cfg.Nodes, 40)
+		final := gqlConsensus(t, d.GQLEndpoint(1), "hive:"+attacker)
+		t.Fatalf("[restore-vote] node-3 bond never rose to %d after votes (final=%d, preVote=%d, restoredAmt=%d)",
+			wantBond, final, preVote, rowSlashedAmt)
+	}
+
+	// 5) Cross-node consistency: every node must agree the bond was restored (the
+	// reverse landed in a 2/3-ratified block, so all nodes apply it identically),
+	// and a safety_slash_consensus_reverse credit row must exist for the account.
+	for n := 1; n <= cfg.Nodes; n++ {
+		b := gqlConsensus(t, d.GQLEndpoint(n), "hive:"+attacker)
+		if b < wantBond {
+			dumpNodeLogs(t, d, ctx, cfg.Nodes, 40)
+			t.Fatalf("[restore-vote] node-%d disagrees: bond=%d < want=%d (restoration not consistent across nodes)", n, b, wantBond)
+		}
+	}
+	reverseRows := findLedgerTXs(t, d.GQLEndpoint(1), "hive:"+attacker, []string{"safety_slash_consensus_reverse"})
+	var reverseTotal int64
+	for _, r := range reverseRows {
+		if r.Amount > 0 && r.Asset == "hive_consensus" {
+			reverseTotal += r.Amount
+		}
+	}
+	if reverseTotal < rowSlashedAmt {
+		t.Fatalf("[restore-vote] expected a consensus reverse credit of >= %d, got %d", rowSlashedAmt, reverseTotal)
+	}
+	t.Logf("[restore-vote] SUCCESS: node-3 bond restored to >= %d on all %d nodes via %d witness votes; reverse credit total=%d",
+		wantBond, cfg.Nodes, voteCount, reverseTotal)
+}


### PR DESCRIPTION
- Builds a vote system for node runners to propose and approve restoration of slashed funds and spends from the slashing reserve.
- Slash restoration is keyed to the ID of the slash op, with an idempotent and identical propose/approve op. 
- Slash reserve spends have 2 ops, a proposal and a vote/approval. The proposal takes recipient and amount data, and generates a hashed ID including the proposal height to differentiate proposals of the same amount. The vote op is keyed to this ID, and approves the op.
- No new ops are called automatically, they are node-runner specific ops called from their associated accounts, and approve after receiving votes from 2/3 of the non-interested consensus parties (recipient of funds cannot vote and is excluded from the denominator as well). 