### PR TITLE
fix(consensus): reject sub-MinMembers elections before scheduling (GV4-3)

### DIFF
--- a/modules/common/params/params.go
+++ b/modules/common/params/params.go
@@ -169,6 +169,13 @@ type ConsensusParams struct {
 	TssIndexHeight       uint64 `json:"tssIndexHeight,omitempty"`
 	ElectionInterval     uint64 `json:"electionInterval,omitempty"`
 	ElectionDupeFixEpoch uint64 `json:"electionDupeFixEpoch,omitempty"`
+	// MinMembersGuardEpoch gates the GV4-3 fix: from this epoch onward the state
+	// engine rejects an election whose new committee has < MinMembers members
+	// before persisting it (see TxElectionResult.ExecuteTx). Epoch-gated like
+	// ElectionDupeFixEpoch so guarded and unguarded nodes agree on the
+	// accept/reject decision at a coordinated activation. A sub-MinMembers
+	// election is never valid, so 0 (active from genesis) is always safe.
+	MinMembersGuardEpoch uint64 `json:"minMembersGuardEpoch,omitempty"`
 
 	// PendulumSeedEpoch bootstraps the pendulum settlement chain on a network
 	// that pre-dates inlined settlement. On startup, if the pendulum_settlements
@@ -466,6 +473,14 @@ func (cp ConsensusParams) TssIndexed(blockHeight uint64) bool {
 // fix is in force. Below this epoch the legacy behavior (no dedup) applies.
 func (cp ConsensusParams) ElectionDupeFixActive(epoch uint64) bool {
 	return epoch >= cp.ElectionDupeFixEpoch
+}
+
+// MinMembersGuardActive returns true at epoch when the GV4-3 sub-MinMembers
+// election-reject guard is enforced (see TxElectionResult.ExecuteTx). Gating
+// mirrors ElectionDupeFixActive so the accept/reject decision flips
+// network-wide at a coordinated epoch.
+func (cp ConsensusParams) MinMembersGuardActive(epoch uint64) bool {
+	return epoch >= cp.MinMembersGuardEpoch
 }
 
 // PendulumSeedConfigured returns true when this network has a pendulum

--- a/modules/common/system-config/system-config.go
+++ b/modules/common/system-config/system-config.go
@@ -204,6 +204,7 @@ func MainnetConfig() SystemConfig {
 			TssIndexHeight:                 params.TSS_INDEX_HEIGHT,
 			ElectionInterval:               params.ELECTION_INTERVAL,
 			ElectionDupeFixEpoch:           1406,
+			MinMembersGuardEpoch:           9999999, // GV4-3 guard DORMANT until pinned to a coordinated epoch (replay-safe: mainnet has valid pre-raise 7-member history)
 			ConsensusVersionFloorEpoch:     1713,
 			ConsensusVersionFloorMajor:     0,
 			ConsensusVersionFloorConsensus: 3,
@@ -277,6 +278,7 @@ func TestnetConfig() SystemConfig {
 			TssIndexHeight:                 1409500,
 			ElectionInterval:               3600,
 			ElectionDupeFixEpoch:           268,
+			MinMembersGuardEpoch:           765, // GV4-3 guard activates at the testnet 0.3.0 version-floor epoch (current epoch ~555); co-activates with ConsensusVersionFloorEpoch below so all enforcing nodes are 0.3.0
 			ConsensusVersionFloorEpoch:     765,
 			ConsensusVersionFloorMajor:     0,
 			ConsensusVersionFloorConsensus: 3,
@@ -369,6 +371,7 @@ func DevnetConfig() SystemConfig {
 			TssIndexHeight:                0,
 			ElectionInterval:              40,
 			ElectionDupeFixEpoch:          0,
+			MinMembersGuardEpoch:          0, // GV4-3 guard active from genesis on devnet (devnet-proven by TestGV43SubMinElectionGuarded)
 			ConsensusVersionActivationNum: 4,
 			ConsensusVersionActivationDen: 5,
 			// Ephemeral network (fresh per run): pin the consensus-version floor to
@@ -433,6 +436,7 @@ func MocknetConfig() SystemConfig {
 			TssIndexHeight:                0,
 			ElectionInterval:              1000,
 			ElectionDupeFixEpoch:          0,
+			MinMembersGuardEpoch:          0, // GV4-3 guard active from genesis on mocknet
 			ConsensusVersionActivationNum: 4,
 			ConsensusVersionActivationDen: 5,
 			// Mocknet leaves the consensus-version floor UNPINNED (no 0.2.0 floor).

--- a/modules/state-processing/consensus.go
+++ b/modules/state-processing/consensus.go
@@ -65,6 +65,15 @@ type WitnessSlot struct {
 
 func GenerateSchedule(blockHeight uint64, witnessList []Witness, seed [32]byte) []WitnessSlot {
 
+	// GV4-3 backstop: never modulo by an empty witness set. A valid election
+	// always has >= MinMembers members (now enforced at election acceptance in
+	// TxElectionResult.ExecuteTx), so an empty list here would mean a degenerate
+	// election slipped through; return an empty schedule (no producer this round)
+	// rather than panic-crashing the node on witnessList[slot % 0].
+	if len(witnessList) == 0 {
+		return []WitnessSlot{}
+	}
+
 	roundInfo := vscBlocks.CalculateRoundInfo(blockHeight)
 
 	slots := (roundInfo.EndHeight - roundInfo.StartHeight) / CONSENSUS_SPECS.SlotLength

--- a/modules/state-processing/consensus_gv4_3_test.go
+++ b/modules/state-processing/consensus_gv4_3_test.go
@@ -1,0 +1,48 @@
+package state_engine
+
+import "testing"
+
+// TestGenerateScheduleEmptyWitnessListNoPanic verifies the GV4-3 scheduler
+// backstop: GenerateSchedule must not panic (it previously did
+// witnessList[slot % uint64(len(witnessList))], an integer divide-by-zero when
+// the list is empty) but instead return an empty schedule. This is the
+// last-resort guard behind the TxElectionResult.ExecuteTx MinMembers reject; if
+// a degenerate (0-member) election ever reaches scheduling, the node degrades to
+// "no producer this round" rather than panic-crashing the whole network.
+//
+// The full multi-node behaviour (empty election accepted with the guard off ->
+// every node crashes; rejected with the guard on -> chain stays alive) is proven
+// on devnet by tests/devnet TestGV43SubMinElectionHalt / ...Guarded.
+func TestGenerateScheduleEmptyWitnessListNoPanic(t *testing.T) {
+	var seed [32]byte
+	cases := map[string][]Witness{
+		"empty": {},
+		"nil":   nil,
+	}
+	for name, wl := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Must not panic.
+			sched := GenerateSchedule(100, wl, seed)
+			if len(sched) != 0 {
+				t.Fatalf("expected empty schedule for %s witness list, got %d slots", name, len(sched))
+			}
+		})
+	}
+}
+
+// TestGenerateScheduleNonEmptyStillSchedules is a sanity check that the backstop
+// did not change normal scheduling: a valid (>= MinMembers) witness set still
+// yields a populated schedule.
+func TestGenerateScheduleNonEmptyStillSchedules(t *testing.T) {
+	var seed [32]byte
+	wl := []Witness{{Account: "a"}, {Account: "b"}, {Account: "c"}}
+	sched := GenerateSchedule(100, wl, seed)
+	if len(sched) == 0 {
+		t.Fatalf("expected a non-empty schedule for a %d-witness list", len(wl))
+	}
+	for i, slot := range sched {
+		if slot.Account == "" {
+			t.Fatalf("schedule slot %d has empty account", i)
+		}
+	}
+}

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -811,6 +811,12 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 							// double-sign that already fired in this same incident
 							// so we don't stack two independent 10% slashes against
 							// CorrelatedSlashCapBps without acknowledging it.
+							// Reason logged symmetrically with the Skip/Stale cases
+							// above so the deterministic rejection is observable
+							// (e.g. "malformed BLS signature") instead of silent.
+							log.Warn("invalid block proposal rejected",
+								"account", cj.RequiredAuths[0], "tx_id", tx.TransactionID,
+								"slot_height", slotInfo.StartHeight, "reason", outcome.Reason)
 							_ = doubleSign
 							slashRes := se.slashForEvidenceIfPolicyAllows(
 								cj.RequiredAuths[0],

--- a/modules/state-processing/system_txs.go
+++ b/modules/state-processing/system_txs.go
@@ -704,6 +704,31 @@ func (tx *TxElectionResult) ExecuteTx(se *StateEngine) {
 			bbytes, _ := dagNode.MarshalJSON()
 			json.Unmarshal(bbytes, &elecResult)
 
+			// GV4-3 fix (defense-in-depth, mirrors the proposer's MinMembers abort
+			// in election-proposer.go HoldElection). The signer-quorum check above
+			// proves the PREVIOUS committee approved this result, but nothing has
+			// validated the NEW committee's size. A sub-MinMembers (e.g. empty)
+			// Members list would be persisted here and then drive
+			// consensus.GenerateSchedule into witnessList[slot % 0] — an integer
+			// divide-by-zero that panic-crashes every validating node (full chain
+			// halt). Reject before StoreElection so the prior committee stays in
+			// charge and the chain keeps producing; the next proposer retries.
+			// A sub-MinMembers election is never valid, so this can never reject a
+			// legitimate election. Epoch-gated (MinMembersGuardActive) like
+			// ElectionDupeFixActive so the accept/reject decision flips
+			// network-wide at a coordinated epoch and replay of pre-activation
+			// history is unaffected (active from genesis on devnet/mocknet,
+			// dormant on mainnet/testnet until pinned).
+			if se.sconf.ConsensusParams().MinMembersGuardActive(tx.Epoch) &&
+				len(elecResult.Members) < se.sconf.ConsensusParams().MinMembers {
+				log.Warn("election rejected: sub-MinMembers committee",
+					"epoch", tx.Epoch,
+					"members", len(elecResult.Members),
+					"min_members", se.sconf.ConsensusParams().MinMembers,
+					"proposer", elecResult.Proposer)
+				return
+			}
+
 			// Apply inlined pendulum settlement BEFORE StoreElection so
 			// validatePendulumSettlement's GetElectionByHeight(SnapshotRangeTo)
 			// resolves to the CLOSING committee, not the incoming one. Two


### PR DESCRIPTION
The state engine validated only the previous committee's signer quorum on an incoming election_result and never checked the NEW committee's size, so a quorum-signed empty / sub-MinMembers election was accepted and persisted. It then drove consensus.GenerateSchedule into witnessList[slot % 0] — an integer divide-by-zero that panic-crashes every validating node (full chain halt). The proposer already enforces MinMembers; the state engine (defense-in-depth) did not. A single malicious proposer cannot reach this (each signer re-derives and signs its own election CID), but a committee quorum or a benign degenerate election can.

Changes:
- TxElectionResult.ExecuteTx: reject before StoreElection when len(Members) < MinMembers, so the prior committee stays in charge and the chain keeps producing; the next proposer retries (system_txs.go).
- GenerateSchedule: return an empty schedule when the witness list is empty instead of dividing by zero — last-resort backstop (consensus.go).
- Epoch-gate the reject via ConsensusParams.MinMembersGuardActive, mirroring ElectionDupeFixActive, so the accept/reject decision flips network-wide at a coordinated epoch and replay of pre-activation history is unaffected (params.go + per-network MinMembersGuardEpoch in system-config.go):
    * devnet/mocknet: active from genesis (epoch 0).
    * testnet: epoch 765 — develop's 0.3.0 ConsensusVersionFloorEpoch (current testnet epoch ~555), so the guard co-activates with the 0.3.0 floor and every enforcing node is already on 0.3.0.
    * mainnet: DORMANT (placeholder 9999999) until the team pins a coordinated near-future epoch — mainnet MinMembers was raised 7 -> 8, so pre-raise 7-member elections are valid history that must not be rejected on replay.
- state_engine.go: log the reason on a BlockInvalid block-proposal rejection, symmetric with the existing BlockSkip/BlockStale cases (observability).

Verification:
- Unit: TestGenerateScheduleEmptyWitnessListNoPanic (backstop); existing GenerateSchedule tests still pass (normal scheduling unchanged).
- Devnet (multi-node): unguarded — empty election accepted, all 5 nodes divide-by-zero crash at block ~102; guarded — empty election rejected on every node, chain produces past block 180, epoch stays 0. The repro hooks and tests/devnet cases are devnet-only and intentionally kept out of this commit.