### PR TITLE
Feat/consensus v0.4.0

### DIFF
--- a/modules/common/consensusversion/feature_gates.go
+++ b/modules/common/consensusversion/feature_gates.go
@@ -119,3 +119,43 @@ func GovernanceActionsActive(active Version) bool {
 func SafetySlashBurnDelay7dActive(active Version) bool {
 	return Version0_3_0Active(active)
 }
+
+// V0_4_0 is the consensus version line at which the v0.4.0 safety/correctness
+// batch activates. Every consensus-affecting change in v0.4.0 keys off this single
+// version so the network has ONE coordinated activation, driven by the election
+// floor reaching 0.4.0.
+var V0_4_0 = Version{Major: 0, Consensus: 4, NonConsensus: 0}
+
+// Version0_4_0Active reports whether the v0.4.0 batch is in force given the
+// chain-active consensus version. `active` is resolved by the caller from the
+// on-chain election (deterministic, replay-correct). Below the line every v0.4.0
+// rule is inert and behavior stays byte-identical to 0.3.0, so old and new
+// binaries interoperate until the floor reaches 0.4.0.
+func Version0_4_0Active(active Version) bool {
+	return active.MeetsConsensusMin(V0_4_0)
+}
+
+// MinMembersGuardActive reports whether the GV4-3 sub-MinMembers election-reject
+// guard is enforced given the chain-active consensus version: the state engine
+// rejects an incoming election whose new committee has < MinMembers members before
+// persisting it (see TxElectionResult.ExecuteTx), so a degenerate committee can
+// never drive consensus.GenerateSchedule into witnessList[slot % 0] (a divide-by-
+// zero chain halt). Resolve `active` from the version active at the election's
+// submit height (StateEngine.ActiveConsensusVersion(tx.Self.BlockHeight)); below
+// the line the reject is inert so replay of pre-activation history (which on
+// mainnet includes valid 7-member elections) is byte-identical. A sub-MinMembers
+// election is never legitimate, so the guard can only ever reject degenerate input.
+func MinMembersGuardActive(active Version) bool {
+	return Version0_4_0Active(active)
+}
+
+// UnstakeHbdDirectionFixActive reports whether the F14 fix is in force given the
+// chain-active consensus version: an offchain unstake_hbd op builds TxUnstakeHbd
+// (releases stake) instead of the legacy TxStakeHbd (which wrongly STAKED — the
+// 0.3.0 behavior). Resolve `active` from the version active at the op's anchored
+// height (StateEngine.ActiveConsensusVersion(anchoredHeight)); below the line the
+// legacy stake direction is preserved so a full reindex reproduces historical
+// ledger state. The L1 vsc.unstake_hbd path was already correct and is unaffected.
+func UnstakeHbdDirectionFixActive(active Version) bool {
+	return Version0_4_0Active(active)
+}

--- a/modules/common/consensusversion/feature_gates_test.go
+++ b/modules/common/consensusversion/feature_gates_test.go
@@ -45,9 +45,55 @@ func TestV0_3_0Gates(t *testing.T) {
 		}
 	}
 
+	// v0.3.0 features stay active at/above the later 0.4.0 line (MeetsConsensusMin
+	// is monotone), so a 0.4.0-running binary still honors the governance batch.
+	if !GovernanceActionsActive(V0_4_0) || !SafetySlashBurnDelay7dActive(V0_4_0) {
+		t.Errorf("v0.3.0 gates must remain active at the 0.4.0 line")
+	}
+}
+
+// TestV0_4_0Gates pins the v0.4.0 safety/correctness batch activation: every
+// v0.4.0 feature is inert at/below 0.3.0 and active at/above 0.4.0, all keyed off
+// the single V0_4_0 line so the GV4-3 election guard and the F14 unstake_hbd
+// direction fix flip together. non_consensus is ignored.
+func TestV0_4_0Gates(t *testing.T) {
+	below := []Version{
+		{Major: 0, Consensus: 0},
+		{Major: 0, Consensus: 3},
+		{Major: 0, Consensus: 3, NonConsensus: 9}, // 0.3.x is still below the line
+	}
+	atOrAbove := []Version{
+		{Major: 0, Consensus: 4},
+		{Major: 0, Consensus: 4, NonConsensus: 7}, // non_consensus ignored
+		{Major: 0, Consensus: 9},
+	}
+
+	for _, v := range below {
+		if Version0_4_0Active(v) {
+			t.Errorf("Version0_4_0Active(%s) = true, want false (below the line)", v.Format())
+		}
+		if MinMembersGuardActive(v) {
+			t.Errorf("MinMembersGuardActive(%s) = true, want false", v.Format())
+		}
+		if UnstakeHbdDirectionFixActive(v) {
+			t.Errorf("UnstakeHbdDirectionFixActive(%s) = true, want false", v.Format())
+		}
+	}
+	for _, v := range atOrAbove {
+		if !Version0_4_0Active(v) {
+			t.Errorf("Version0_4_0Active(%s) = false, want true (at/above the line)", v.Format())
+		}
+		if !MinMembersGuardActive(v) {
+			t.Errorf("MinMembersGuardActive(%s) = false, want true", v.Format())
+		}
+		if !UnstakeHbdDirectionFixActive(v) {
+			t.Errorf("UnstakeHbdDirectionFixActive(%s) = false, want true", v.Format())
+		}
+	}
+
 	// The shipped binary must run the version it implements, so the floor can rise.
-	if RunningVersion().Cmp(V0_3_0) != 0 {
-		t.Errorf("RunningVersion() = %s, want %s (bump in the same commit as the v0.3.0 gates)",
-			RunningVersion().Format(), V0_3_0.Format())
+	if RunningVersion().Cmp(V0_4_0) != 0 {
+		t.Errorf("RunningVersion() = %s, want %s (bump in the same commit as the v0.4.0 gates)",
+			RunningVersion().Format(), V0_4_0.Format())
 	}
 }

--- a/modules/common/consensusversion/version.go
+++ b/modules/common/consensusversion/version.go
@@ -45,9 +45,20 @@ import (
 //     which backs (a) by giving witnesses time to gather a slash_restore quorum before
 //     the residual matures. Until 0.3.0 is chain-active the ops are ignored and the
 //     pending window stays 3 days, so old and new binaries interoperate until activation.
+//   - 0.4.0 — the Consensus 3→4 bump gates a safety/correctness batch, all activated
+//     together when the election floor reaches 0.4.0 (consensusversion.V0_4_0):
+//     (a) GV4-3 sub-MinMembers election reject (MinMembersGuardActive) — the state
+//     engine rejects an incoming election whose new committee is below MinMembers
+//     before persisting it, so a degenerate (e.g. empty) committee can never drive
+//     consensus.GenerateSchedule into a divide-by-zero chain halt; below the line the
+//     reject is inert so replay of pre-activation history is byte-identical;
+//     (b) F14 offchain unstake_hbd direction fix (UnstakeHbdDirectionFixActive) — an
+//     offchain unstake_hbd builds TxUnstakeHbd (releases stake) instead of TxStakeHbd
+//     (the 0.3.0 behavior that wrongly STAKED); below the line the legacy stake
+//     direction is preserved so old and new binaries interoperate until activation.
 const (
 	currentMajor        uint64 = 0
-	currentConsensus    uint64 = 3
+	currentConsensus    uint64 = 4
 	currentNonConsensus uint64 = 0
 )
 

--- a/modules/common/consensusversion/version_test.go
+++ b/modules/common/consensusversion/version_test.go
@@ -44,7 +44,7 @@ func TestMaxComponentwise(t *testing.T) {
 // pinned current triple. Update this pin in the SAME commit that bumps the constants in
 // version.go.
 func TestRunningVersionIsSourcePinned(t *testing.T) {
-	want := Version{Major: 0, Consensus: 3, NonConsensus: 0}
+	want := Version{Major: 0, Consensus: 4, NonConsensus: 0}
 	if got := RunningVersion(); got != want {
 		t.Fatalf("running version = %+v, want %+v (source constants in version.go)", got, want)
 	}

--- a/modules/state-processing/consensus.go
+++ b/modules/state-processing/consensus.go
@@ -69,7 +69,8 @@ func GenerateSchedule(blockHeight uint64, witnessList []Witness, seed [32]byte) 
 	// divide-by-zero panic that fires identically on every node (network halt).
 	// Return an empty schedule (= no producer this round), which callers already
 	// treat as "nobody scheduled". Deterministic: witnessList is on-chain election
-	// data. Defense-in-depth behind the proposer's MinMembers floor.
+	// data. Defense-in-depth behind the GV4-3 sub-MinMembers election reject in
+	// TxElectionResult.ExecuteTx (and the proposer's MinMembers floor).
 	if len(witnessList) == 0 {
 		return []WitnessSlot{}
 	}

--- a/modules/state-processing/consensus_gv4_3_test.go
+++ b/modules/state-processing/consensus_gv4_3_test.go
@@ -1,0 +1,48 @@
+package state_engine
+
+import "testing"
+
+// TestGenerateScheduleEmptyWitnessListNoPanic verifies the GV4-3 scheduler
+// backstop: GenerateSchedule must not panic (it previously did
+// witnessList[slot % uint64(len(witnessList))], an integer divide-by-zero when
+// the list is empty) but instead return an empty schedule. This is the
+// last-resort guard behind the TxElectionResult.ExecuteTx MinMembers reject; if
+// a degenerate (0-member) election ever reaches scheduling, the node degrades to
+// "no producer this round" rather than panic-crashing the whole network.
+//
+// The full multi-node behaviour (empty election accepted with the guard off ->
+// every node crashes; rejected with the guard on -> chain stays alive) is proven
+// on devnet by tests/devnet TestGV43SubMinElectionHalt / ...Guarded.
+func TestGenerateScheduleEmptyWitnessListNoPanic(t *testing.T) {
+	var seed [32]byte
+	cases := map[string][]Witness{
+		"empty": {},
+		"nil":   nil,
+	}
+	for name, wl := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Must not panic.
+			sched := GenerateSchedule(100, wl, seed)
+			if len(sched) != 0 {
+				t.Fatalf("expected empty schedule for %s witness list, got %d slots", name, len(sched))
+			}
+		})
+	}
+}
+
+// TestGenerateScheduleNonEmptyStillSchedules is a sanity check that the backstop
+// did not change normal scheduling: a valid (>= MinMembers) witness set still
+// yields a populated schedule.
+func TestGenerateScheduleNonEmptyStillSchedules(t *testing.T) {
+	var seed [32]byte
+	wl := []Witness{{Account: "a"}, {Account: "b"}, {Account: "c"}}
+	sched := GenerateSchedule(100, wl, seed)
+	if len(sched) == 0 {
+		t.Fatalf("expected a non-empty schedule for a %d-witness list", len(wl))
+	}
+	for i, slot := range sched {
+		if slot.Account == "" {
+			t.Fatalf("schedule slot %d has empty account", i)
+		}
+	}
+}

--- a/modules/state-processing/f4_nil_op_chain_halt_test.go
+++ b/modules/state-processing/f4_nil_op_chain_halt_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"vsc-node/modules/common"
+	"vsc-node/modules/common/consensusversion"
 	transactionpool "vsc-node/modules/transaction-pool"
 
 	stateEngine "vsc-node/modules/state-processing"
@@ -46,7 +47,7 @@ func TestF4_UnknownOpFailsWholeTx(t *testing.T) {
 	}
 	tx.Headers.RequiredAuths = []string{"hive:alice"}
 
-	ops, err := tx.ToTransaction()
+	ops, err := tx.ToTransaction(consensusversion.Version{})
 	if err == nil {
 		t.Fatal("F4 REGRESSION: unknown op did not fail the tx (err == nil) — halt path open")
 	}
@@ -68,7 +69,7 @@ func TestF4_ValidPlusInvalidFailsWholeTx(t *testing.T) {
 	}
 	tx.Headers.RequiredAuths = []string{"hive:alice"}
 
-	ops, err := tx.ToTransaction()
+	ops, err := tx.ToTransaction(consensusversion.Version{})
 	if err == nil {
 		t.Fatal("F4 ATOMICITY: tx with one invalid op must fail entirely (err == nil)")
 	}
@@ -92,7 +93,7 @@ func TestF4_ValidTxResolvesAllOpsNoNil(t *testing.T) {
 	}
 	tx.Headers.RequiredAuths = []string{"hive:alice"}
 
-	ops, err := tx.ToTransaction()
+	ops, err := tx.ToTransaction(consensusversion.Version{})
 	if err != nil {
 		t.Fatalf("F4: valid tx unexpectedly failed to resolve: %v", err)
 	}
@@ -123,6 +124,48 @@ func TestF4_ReachabilityOpTypeNotValidatedInTxPool(t *testing.T) {
 	t.Logf("F4 NOTE: tx-pool still has no op-type allowlist (cost=%d); the failure is enforced downstream at ToTransaction, not here", cost)
 }
 
+// TestF14_UnstakeHbdDirectionVersionGated: an offchain "unstake_hbd" op (valid
+// payload) must build a *TxUnstakeHbd (whose ExecuteTx releases stake) ONLY once
+// the chain-active consensus version reaches 0.4.0. Below the line it keeps the
+// legacy 0.3.0 behavior — *TxStakeHbd (the wrong direction, but byte-identical on
+// replay). Proves the F14 fix is gated, not unconditional. Cherry-picked from
+// a1c171d7 and converted from an unconditional fix to the 0.4.0 version gate.
+func TestF14_UnstakeHbdDirectionVersionGated(t *testing.T) {
+	build := func(active consensusversion.Version) stateEngine.VSCTransaction {
+		tx := &stateEngine.OffchainTransaction{}
+		tx.Tx = []transactionpool.VSCTransactionOp{
+			{Type: "unstake_hbd", Payload: validPayload(t, map[string]interface{}{
+				"from": "hive:alice", "to": "hive:alice", "amount": "1.000", "asset": "hbd",
+			})},
+		}
+		tx.Headers.RequiredAuths = []string{"hive:alice"}
+		ops, err := tx.ToTransaction(active)
+		if err != nil {
+			t.Fatalf("F14: valid unstake_hbd unexpectedly failed: %v", err)
+		}
+		if len(ops) != 1 {
+			t.Fatalf("F14: expected 1 element for unstake_hbd, got %d", len(ops))
+		}
+		return ops[0]
+	}
+
+	// Below 0.4.0: legacy behavior — builds TxStakeHbd (staked, the wrong direction).
+	if op := build(consensusversion.Version{Major: 0, Consensus: 3}); op == nil {
+		t.Fatal("F14: nil op below the gate")
+	} else if _, ok := op.(*stateEngine.TxStakeHbd); !ok {
+		t.Fatalf("F14: below 0.4.0 unstake_hbd built %T, expected legacy *TxStakeHbd", op)
+	}
+
+	// At/above 0.4.0: fixed — builds TxUnstakeHbd (releases stake).
+	if op := build(consensusversion.V0_4_0); op == nil {
+		t.Fatal("F14: nil op at the gate")
+	} else if _, ok := op.(*stateEngine.TxUnstakeHbd); !ok {
+		t.Fatalf("F14 REGRESSION: at 0.4.0 unstake_hbd built %T, expected *TxUnstakeHbd (releases stake)", op)
+	} else if got := op.Type(); got != "unstake_hbd" {
+		t.Fatalf("F14: Type() = %q, want unstake_hbd", got)
+	}
+}
+
 // TestF21_BadPayloadFailsWholeTx: a KNOWN op type carrying an empty/malformed
 // CBOR payload must NOT panic DecodeTxCbor (which previously dropped the decode
 // error and dereferenced a nil node in MarshalJSON → chain halt). Post-fix it
@@ -143,7 +186,7 @@ func TestF21_BadPayloadFailsWholeTx(t *testing.T) {
 		)
 		func() {
 			defer func() { panicVal = recover() }()
-			ops, err = tx.ToTransaction()
+			ops, err = tx.ToTransaction(consensusversion.Version{})
 		}()
 		if panicVal != nil {
 			t.Fatalf("F21 REGRESSION: ToTransaction panicked on empty-payload %q op: %v", opType, panicVal)

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -811,6 +811,12 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 							// double-sign that already fired in this same incident
 							// so we don't stack two independent 10% slashes against
 							// CorrelatedSlashCapBps without acknowledging it.
+							// Reason logged symmetrically with the Skip/Stale cases
+							// above so the deterministic rejection is observable
+							// (e.g. "malformed BLS signature") instead of silent.
+							log.Warn("invalid block proposal rejected",
+								"account", cj.RequiredAuths[0], "tx_id", tx.TransactionID,
+								"slot_height", slotInfo.StartHeight, "reason", outcome.Reason)
 							_ = doubleSign
 							slashRes := se.slashForEvidenceIfPolicyAllows(
 								cj.RequiredAuths[0],

--- a/modules/state-processing/system_txs.go
+++ b/modules/state-processing/system_txs.go
@@ -704,6 +704,34 @@ func (tx *TxElectionResult) ExecuteTx(se *StateEngine) {
 			bbytes, _ := dagNode.MarshalJSON()
 			json.Unmarshal(bbytes, &elecResult)
 
+			// GV4-3 fix (defense-in-depth, mirrors the proposer's MinMembers abort
+			// in election-proposer.go HoldElection). The signer-quorum check above
+			// proves the PREVIOUS committee approved this result, but nothing has
+			// validated the NEW committee's size. A sub-MinMembers (e.g. empty)
+			// Members list would be persisted here and then drive
+			// consensus.GenerateSchedule into witnessList[slot % 0] — an integer
+			// divide-by-zero that panic-crashes every validating node (full chain
+			// halt). Reject before StoreElection so the prior committee stays in
+			// charge and the chain keeps producing; the next proposer retries.
+			// A sub-MinMembers election is never valid, so this can never reject a
+			// legitimate election. Version-gated on the 0.4.0 consensus line
+			// (MinMembersGuardActive): the accept/reject decision flips network-wide
+			// only once the election floor reaches 0.4.0, resolved deterministically
+			// from the version ACTIVE at this election's submit height
+			// (ActiveConsensusVersion(tx.Self.BlockHeight) — the outgoing committee's
+			// ResultVersion, on-chain and identical on every node). Below the line the
+			// reject is inert so replay of pre-activation history (mainnet has valid
+			// pre-raise 7-member elections) is byte-identical.
+			if consensusversion.MinMembersGuardActive(se.ActiveConsensusVersion(tx.Self.BlockHeight)) &&
+				len(elecResult.Members) < se.sconf.ConsensusParams().MinMembers {
+				log.Warn("election rejected: sub-MinMembers committee",
+					"epoch", tx.Epoch,
+					"members", len(elecResult.Members),
+					"min_members", se.sconf.ConsensusParams().MinMembers,
+					"proposer", elecResult.Proposer)
+				return
+			}
+
 			// Apply inlined pendulum settlement BEFORE StoreElection so
 			// validatePendulumSettlement's GetElectionByHeight(SnapshotRangeTo)
 			// resolves to the CLOSING committee, not the incoming one. Two

--- a/modules/state-processing/system_txs.go
+++ b/modules/state-processing/system_txs.go
@@ -1154,7 +1154,10 @@ func (t *TxProposeBlock) ExecuteTx(se *StateEngine) {
 			}
 			confirmedNonces[keyId].Nonces[tx.Headers.Nonce] = true
 
-			txs, txErr := tx.ToTransaction()
+			// Resolve op builds against the version active at this block's height
+			// (same height threaded into Ingest above) so version-gated op builds
+			// — e.g. the F14 unstake_hbd direction — are deterministic on-chain.
+			txs, txErr := tx.ToTransaction(se.ActiveConsensusVersion(uint64(t.SignedBlock.Headers.Br[1])))
 			if txErr != nil {
 				// The tx contains an op that can't be executed exactly as
 				// submitted (unknown type / undecodable payload). Fail the WHOLE

--- a/modules/state-processing/transactions.go
+++ b/modules/state-processing/transactions.go
@@ -658,7 +658,6 @@ func (t *TxUnstakeHbd) Type() string {
 	return "unstake_hbd"
 }
 
-
 type TxConsensusStake struct {
 	Self TxSelf `json:"-"`
 
@@ -1221,7 +1220,10 @@ func (tx *OffchainTransaction) Ingest(se *StateEngine, vscBlockTxId string, txSe
 	// oplog round-trip driven by ExecuteBatch's TxPacket.Invalid branch, exactly
 	// as every other tx's status is finalized. Resolving zero ops here never
 	// means "success": empty Ops on an invalid tx ride the FAILED path.
-	txs, _ := tx.ToTransaction()
+	// Resolve op builds against the version active at the anchored height (same
+	// height used for execution in ExecuteBatch) so the indexed op types match
+	// what actually executes (e.g. F14 unstake_hbd direction).
+	txs, _ := tx.ToTransaction(se.ActiveConsensusVersion(anchoredHeight))
 
 	opTypes := make([]string, 0)
 	opTypesM := make(map[string]bool, 0)
@@ -1281,7 +1283,7 @@ func (tx *OffchainTransaction) TxSelf() TxSelf {
 // Determinism: invalidity is a pure function of the content-addressed tx bytes
 // (op.Type string match + CBOR decodability), so every node either resolves the
 // identical op list or fails the identical tx, producing the same block CID.
-func (tx *OffchainTransaction) ToTransaction() ([]VSCTransaction, error) {
+func (tx *OffchainTransaction) ToTransaction(activeVersion consensusversion.Version) ([]VSCTransaction, error) {
 	self := tx.TxSelf()
 	self.RequiredAuths = tx.Headers.RequiredAuths
 
@@ -1333,12 +1335,32 @@ func (tx *OffchainTransaction) ToTransaction() ([]VSCTransaction, error) {
 
 			vtx = &stakeTx
 		case "unstake_hbd":
-			// NOTE: offchain unstake_hbd intentionally still builds TxStakeHbd
-			// here (the 0.3.0 behavior — it STAKES instead of releasing). The
-			// direction is wrong, but correcting it changes ledger state on a
-			// VALID input and would fork live 0.3.0 nodes, so the fix (F14, build
-			// TxUnstakeHbd) is deferred to the version-gated 0.4.0 rollout and
-			// lives in its own commit.
+			// F14: correct the offchain unstake_hbd direction, version-gated on the
+			// 0.4.0 consensus line (UnstakeHbdDirectionFixActive). Below the line this
+			// case built TxStakeHbd (identical to "stake_hbd"), so an offchain
+			// unstake_hbd STAKED funds instead of releasing them — the wrong
+			// direction. Correcting it changes ledger state on a VALID input, so it
+			// must flip network-wide only once the floor reaches 0.4.0; activeVersion
+			// is resolved by the caller from the op's anchored height
+			// (ActiveConsensusVersion), on-chain and identical on every node, so a
+			// full reindex reproduces historical ledger state. At/above 0.4.0, build
+			// the dedicated TxUnstakeHbd, whose ExecuteTx calls ledgerSession.Unstake.
+			// (The L1 vsc.unstake_hbd path was already correct; only this offchain
+			// path was wrong.)
+			if consensusversion.UnstakeHbdDirectionFixActive(activeVersion) {
+				unstakeTx := TxUnstakeHbd{
+					Self:  self,
+					NetId: tx.Headers.NetId,
+				}
+
+				if err := transactionpool.DecodeTxCbor(op, &unstakeTx); err != nil {
+					return nil, fmt.Errorf("op %d (%q): %w", idx, op.Type, err)
+				}
+
+				vtx = &unstakeTx
+				break
+			}
+
 			stakeTx := TxStakeHbd{
 				Self:  self,
 				NetId: tx.Headers.NetId,
@@ -1390,5 +1412,9 @@ type VSCTransaction interface {
 
 type VscTxContainer interface {
 	Type() string //Hive, offchain
-	ToTransaction() ([]VSCTransaction, error)
+	// ToTransaction resolves the offchain op list into executable VSCTransactions.
+	// activeVersion is the chain-active consensus version at the tx's anchored
+	// height (StateEngine.ActiveConsensusVersion), threaded in so version-gated op
+	// builds (e.g. F14 unstake_hbd direction) resolve deterministically on-chain.
+	ToTransaction(activeVersion consensusversion.Version) ([]VSCTransaction, error)
 }


### PR DESCRIPTION
## 2 fixes and version 0.4.0 configuration

### Fix 1 reject sub-MinMembers elections before scheduling (GV4-3)

An incoming election whose new committee is below MinMembers (e.g. empty)
would persist and then drive consensus.GenerateSchedule into
witnessList[slot % 0] -- an integer divide-by-zero that panic-halts every
validating node. Reject it in TxElectionResult.ExecuteTx before StoreElection
so the prior committee stays in charge and the chain keeps producing.

Gated on the 0.4.0 consensus line (MinMembersGuardActive), resolved from the
version active at the election's submit height
(ActiveConsensusVersion(tx.Self.BlockHeight)) -- deterministic on-chain and
replay-safe (mainnet history has valid pre-raise 7-member elections). Keep the
pure GenerateSchedule empty-list backstop (already on develop as the F13 fix)
as defense-in-depth, and log invalid block-proposal rejections symmetrically
with the skip/stale cases.

### Fix 2 offchain unstake_hbd releases stake (F14) 

The offchain unstake_hbd op built TxStakeHbd (identical to stake_hbd), so it
STAKED funds instead of releasing them -- the wrong direction. Build the
dedicated TxUnstakeHbd (ledgerSession.Unstake) instead. The L1 vsc.unstake_hbd
path was already correct; only the offchain path was wrong.

Correcting the direction changes ledger state on a VALID input, so it is
version-gated on the 0.4.0. chain-active version is threaded into
OffchainTransaction.ToTransaction via ActiveConsensusVersion at the op's
anchored height (same height in Ingest and ExecuteBatch), so a full reindex
reproduces historical ledger state and the fix flips network-wide only at
the 0.4.0 floor.