### PR TITLE
fix(tss): keep committee connections warm + reconnect on stale sends

### DIFF
--- a/modules/tss/p2p.go
+++ b/modules/tss/p2p.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 	"vsc-node/modules/common"
 	tss_helpers "vsc-node/modules/tss/helpers"
@@ -17,7 +19,9 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/protocol"
+	multiaddr "github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multicodec"
 	blsu "github.com/protolambda/bls12-381-util"
 )
@@ -437,10 +441,22 @@ func (tss *TssManager) SendMsg(
 		return err
 	}
 
+	// Ensure a live connection before sending. TSS reshare delivers its round
+	// messages over on-demand unicast RPC streams; between reshares these
+	// connections go idle and can be torn down by NAT idle-eviction or transport
+	// keepalive timeouts. If libp2p reports the peer as disconnected, re-dial
+	// from its announced addresses so THIS send can proceed over a fresh
+	// connection instead of failing outright. (This handles the
+	// reported-disconnected case; a half-open "Connected" connection is healed
+	// by the ClosePeer below on an idle-death send error.) Transport-only: the
+	// message bytes are unchanged.
 	if !tss.isPeerConnected(peerId) {
-		log.Warn("peer not connected",
-			"sessionId", sessionId, "to", participant.Account, "peerId", peerId.String())
-		return fmt.Errorf("peer %s not connected", peerId.String())
+		tss.reconnectPeer(context.Background(), peerId, witness.PeerAddrs)
+		if !tss.isPeerConnected(peerId) {
+			log.Warn("peer not connected",
+				"sessionId", sessionId, "to", participant.Account, "peerId", peerId.String())
+			return fmt.Errorf("peer %s not connected", peerId.String())
+		}
 	}
 
 	tMsg := TMsg{
@@ -474,6 +490,22 @@ func (tss *TssManager) SendMsg(
 			"sessionId", sessionId, "from", fromAccount, "to", participant.Account,
 			"peerId", peerId.String(), "duration", duration, "err", err)
 		tss.metrics.IncrementMessageSendFailure()
+		// An unambiguous idle-death error means the connection is dead even
+		// though libp2p may briefly still report the peer as "connected"
+		// (half-open, killed by NAT idle-eviction / keepalive timeout). Evict it
+		// so it is re-established by the next keepalive pass or the pre-send
+		// reconnect above, instead of subsequent sends repeatedly failing over
+		// the same dead connection. Gated on isTransportErr (idle-death only, see
+		// there) so a live-but-busy peer's connection is never dropped — note
+		// ClosePeer is connection-wide and the reshare path does not retry
+		// individual messages. Transport-only: message bytes are unchanged, so
+		// this cannot affect the party list or the commitment CID.
+		if isTransportErr(err) {
+			if cerr := tss.p2p.Host().Network().ClosePeer(peerId); cerr != nil {
+				log.Trace("failed to evict stale peer connection",
+					"peerId", peerId.String(), "err", cerr)
+			}
+		}
 		return err
 	}
 
@@ -568,4 +600,186 @@ func (tss *TssManager) isPeerConnected(peerId peer.ID) bool {
 		log.Trace("peer connection check", "peerId", peerId.String(), "state", connState)
 	}
 	return connected
+}
+
+// parseWitnessAddrs converts a witness's announced multiaddr strings into
+// multiaddrs, skipping any that fail to parse.
+func parseWitnessAddrs(addrStrs []string) []multiaddr.Multiaddr {
+	addrs := make([]multiaddr.Multiaddr, 0, len(addrStrs))
+	for _, s := range addrStrs {
+		a, err := multiaddr.NewMultiaddr(s)
+		if err != nil {
+			continue
+		}
+		addrs = append(addrs, a)
+	}
+	return addrs
+}
+
+// isTransportErr reports whether an RPC error indicates a genuinely dead,
+// idle-killed connection. It matches ONLY libp2p's own idle-detection strings
+// ("no recent network activity", "keepalive timeout") — the exact symptoms of
+// the production half-open stalls (e.g. "stream reset: connection closed:
+// keepalive timeout", "timeout: no recent network activity"), so real coverage
+// is retained.
+//
+// It deliberately does NOT match "stream reset" / "connection closed" /
+// "canceled by remote" / "context deadline exceeded" on their own: those are
+// also produced by a LIVE-but-busy peer under resource-manager or stream-limit
+// pressure (and by our own ClosePeer). Because the caller reacts with a
+// connection-wide ClosePeer, and the reshare send path does NOT retry
+// individual messages, treating those ambiguous errors as death would evict a
+// healthy connection mid-reshare — dropping any concurrent in-flight round
+// message on it and stalling that peer for the full timeout. Narrow on purpose.
+func isTransportErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	for _, tok := range []string{
+		"no recent network activity",
+		"keepalive timeout",
+	} {
+		if strings.Contains(s, tok) {
+			return true
+		}
+	}
+	return false
+}
+
+// reconnectPeer re-establishes a direct connection to a peer from its announced
+// addresses. The dial is bounded by both a 10s timeout and the caller's ctx so
+// it unwinds promptly on shutdown. Transport-only: it does not read or modify
+// any TSS message, party list, or commitment.
+func (tss *TssManager) reconnectPeer(ctx context.Context, peerId peer.ID, addrStrs []string) {
+	addrs := parseWitnessAddrs(addrStrs)
+	if len(addrs) == 0 {
+		return
+	}
+	tss.p2p.Peerstore().AddAddrs(peerId, addrs, peerstore.TempAddrTTL)
+	dialCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := tss.p2p.Connect(dialCtx, peer.AddrInfo{ID: peerId, Addrs: addrs}); err != nil {
+		log.Trace("reconnect failed", "peerId", peerId.String(), "err", err)
+	}
+}
+
+// runConnectionKeepalive keeps direct libp2p connections to the other witnesses
+// warm for the lifetime of the node. TSS reshare delivers its round messages
+// over on-demand unicast RPC streams to specific peers; between reshares those
+// direct connections sit idle and are torn down by NAT idle-eviction,
+// connection-manager trimming, or transport keepalive timeouts. Ordinary block
+// production is unaffected because it rides the continuously active gossip mesh,
+// but the next reshare then fails to deliver its messages over a
+// dead-but-"Connected" stream, stalling the reshare until the connection
+// happens to be alive again. This loop is the production counterpart of the TSS
+// test harness (startPeerKeepalive + ConnManager().Protect) — the mechanism
+// that makes reshares succeed under test but which was absent in production.
+// Transport-only: it never reads or modifies party lists, btss inputs, or
+// serialized commitments.
+func (tss *TssManager) runConnectionKeepalive(ctx context.Context) {
+	const keepaliveInterval = 15 * time.Second
+	ticker := time.NewTicker(keepaliveInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// Guard against a startup race where the p2p host is not yet
+			// initialized — P2PServer.Host() panics rather than returning nil,
+			// and an unrecovered panic in this background goroutine would crash
+			// the whole node.
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Warn("keepalive pass panicked, skipping", "panic", r)
+					}
+				}()
+				tss.warmCommitteePeers(ctx)
+			}()
+		}
+	}
+}
+
+// warmCommitteePeers protects, (re)connects, and probes every other enabled
+// witness so each direct TSS connection stays alive before the next reshare
+// needs it. Per-peer work runs concurrently so a few slow or unreachable peers
+// cannot stall warming of the healthy ones.
+func (tss *TssManager) warmCommitteePeers(ctx context.Context) {
+	self := tss.config.Get().HiveUsername
+	witnessList, err := tss.witnessDb.GetLastestWitnesses()
+	if err != nil {
+		log.Trace("keepalive: failed to list witnesses", "err", err)
+		return
+	}
+	host := tss.p2p.Host()
+	// GetLastestWitnesses returns every announcement row (height-descending),
+	// not one per account, so dedup to the latest row per account. This both
+	// cuts per-pass work (accounts re-announce many times) and evaluates each
+	// account on its most recent announcement — current peer_id / enabled state
+	// — instead of warming stale rows. We intentionally warm the full enabled
+	// witness set (no network filter): the committee is always a subset of it,
+	// and skipping a member risks reintroducing the very idle-death this fixes.
+	seen := make(map[string]bool)
+	var wg sync.WaitGroup
+	for _, w := range witnessList {
+		if w.Account == self || seen[w.Account] {
+			continue
+		}
+		seen[w.Account] = true
+		if !w.Enabled || w.PeerId == "" {
+			continue
+		}
+		peerId, err := peer.Decode(w.PeerId)
+		if err != nil {
+			continue
+		}
+		// Keep committee peers out of the connection-manager trim set.
+		tss.p2p.ConnManager().Protect(peerId, "tss-committee")
+		if addrs := parseWitnessAddrs(w.PeerAddrs); len(addrs) > 0 {
+			tss.p2p.Peerstore().AddAddrs(peerId, addrs, peerstore.TempAddrTTL)
+		}
+		wg.Add(1)
+		go func(peerId peer.ID, account string, addrStrs []string) {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					log.Warn("keepalive peer task panicked", "account", account, "panic", r)
+				}
+			}()
+			if host.Network().Connectedness(peerId) != network.Connected {
+				// Re-establish a dropped connection ahead of the next reshare.
+				tss.reconnectPeer(ctx, peerId, addrStrs)
+				return
+			}
+			// Connected: send a cheap probe to generate traffic and reset
+			// NAT/transport idle timers. A failed probe is deliberately NOT
+			// treated as a dead connection — under heavy TSS load a busy peer can
+			// miss a probe while remaining reachable, and closing a live
+			// connection mid-reshare is exactly the harm we are avoiding. Genuine
+			// dead-connection eviction happens in SendMsg on a real send failure
+			// (unambiguous transport error), and libp2p's own keepalive will
+			// eventually drop a truly dead connection, after which the branch
+			// above reconnects it on the next pass.
+			if err := tss.pingPeerAlive(ctx, peerId); err != nil {
+				log.Trace("keepalive: probe failed (connection left intact)", "account", account, "err", err)
+			}
+		}(peerId, w.Account, w.PeerAddrs)
+	}
+	wg.Wait()
+}
+
+// pingPeerAlive sends a lightweight readiness RPC over the direct connection to
+// generate traffic that resets NAT / transport idle timers, keeping the
+// connection warm. It reuses the existing "ready" handler (rpc.go), which
+// replies with a cheap ack and has no side effects. The returned error is used
+// only for logging — a failed probe is deliberately not treated as a dead
+// connection (see warmCommitteePeers).
+func (tss *TssManager) pingPeerAlive(ctx context.Context, peerId peer.ID) error {
+	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	tMsg := TMsg{Type: "ready"}
+	tRes := TRes{}
+	return tss.client.CallContext(pingCtx, peerId, "vsc.tss", "ReceiveMsg", &tMsg, &tRes)
 }

--- a/modules/tss/redial_test.go
+++ b/modules/tss/redial_test.go
@@ -1,0 +1,94 @@
+package tss
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsTransportErr locks in the deliberately-narrow classification: only
+// libp2p's own idle-death signals ("no recent network activity", "keepalive
+// timeout") count as a dead connection worth evicting. Ambiguous errors that a
+// LIVE-but-busy peer can also emit under load must NOT classify as dead —
+// evicting on them would drop a concurrent, un-retried reshare message (the
+// regression this narrowing guards against).
+func TestIsTransportErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  string
+		want bool
+	}{
+		// Genuine idle-death — evict.
+		{"keepalive timeout", "yamux: keepalive timeout", true},
+		{"no recent network activity", "timeout: no recent network activity", true},
+		// The real production strings observed in the mainnet stall: the
+		// idle-death token is embedded in a longer message, so substring
+		// matching must still catch it.
+		{"prod stream-reset+keepalive", "msgpack decode error [pos 0]: stream reset: stream reset: connection closed: keepalive timeout", true},
+		{"prod no-recent-activity", "msgpack decode error [pos 0]: timeout: no recent network activity", true},
+		// Case-insensitivity (errors from different layers vary in casing).
+		{"uppercase", "KEEPALIVE TIMEOUT", true},
+
+		// Ambiguous — a live-but-busy peer emits these under resource-manager /
+		// stream-limit pressure. Must NOT evict.
+		{"bare stream reset", "stream reset", false},
+		{"bare connection closed", "connection closed", false},
+		{"canceled by remote", "msgpack encode error: stream reset (remote): code: 0x0: transport error: stream 5 canceled by remote with error code 0", false},
+		{"context deadline exceeded", "context deadline exceeded", false},
+		{"eof", "EOF", false},
+		{"connection refused", "dial tcp: connect: connection refused", false},
+		{"unrelated app error", "no documents in result", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isTransportErr(errors.New(tc.err)))
+		})
+	}
+
+	// A nil error is never a transport failure.
+	assert.False(t, isTransportErr(nil))
+}
+
+// TestParseWitnessAddrs verifies announced multiaddr strings are parsed,
+// malformed entries are skipped rather than failing the whole set, and empty
+// input yields an empty (non-nil-panicking) slice.
+func TestParseWitnessAddrs(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		assert.Len(t, parseWitnessAddrs(nil), 0)
+		assert.Len(t, parseWitnessAddrs([]string{}), 0)
+	})
+
+	t.Run("valid addrs parsed (real witness announce format)", func(t *testing.T) {
+		in := []string{
+			"/ip4/121.99.241.161/tcp/10720",
+			"/ip4/121.99.241.161/udp/10720/quic-v1",
+			"/ip6/2404:4400:4122:4200::1189/tcp/10720",
+		}
+		got := parseWitnessAddrs(in)
+		assert.Len(t, got, 3)
+		// Round-trips back to the same canonical strings.
+		for i, a := range got {
+			assert.Equal(t, in[i], a.String())
+		}
+	})
+
+	t.Run("malformed entries skipped, valid ones kept", func(t *testing.T) {
+		in := []string{
+			"not-a-multiaddr",
+			"/ip4/10.0.0.1/tcp/4001",
+			"",
+			"/nonsense/xyz",
+			"/ip4/10.0.0.2/udp/4001/quic-v1",
+		}
+		got := parseWitnessAddrs(in)
+		assert.Len(t, got, 2)
+		assert.Equal(t, "/ip4/10.0.0.1/tcp/4001", got[0].String())
+		assert.Equal(t, "/ip4/10.0.0.2/udp/4001/quic-v1", got[1].String())
+	})
+
+	t.Run("all malformed yields empty", func(t *testing.T) {
+		assert.Len(t, parseWitnessAddrs([]string{"bad", "worse", ""}), 0)
+	})
+}

--- a/modules/tss/tss.go
+++ b/modules/tss/tss.go
@@ -2078,6 +2078,11 @@ func (tssMgr *TssManager) Start() *promise.Promise[any] {
 	bgCtx, bgCancel := context.WithCancel(context.Background())
 	tssMgr.bgCancel = bgCancel
 
+	// Keep direct TSS connections to committee peers warm so reshare round
+	// messages are not lost over idle-killed connections (see
+	// runConnectionKeepalive in p2p.go).
+	go tssMgr.runConnectionKeepalive(bgCtx)
+
 	go func() {
 		//Every one minute
 		ticker := time.NewTicker(time.Minute)


### PR DESCRIPTION
TSS reshare delivers its round messages over on-demand unicast RPC streams to specific peers. Between reshares these direct connections sit idle and get torn down by NAT idle-eviction, connection-manager trimming, or transport keepalive timeouts — while libp2p still reports the peer as "connected" (half-open). Ordinary block production is unaffected because it rides the continuously active gossip mesh, but the next reshare then fails to deliver its round messages over a dead-but-"Connected" stream, stalling the reshare until the connection happens to be alive again (observed as ~30h mainnet stalls with the key frozen at an epoch; failing messages were only ~200 bytes, with errors like "no recent network activity" / "keepalive timeout").

The TSS test harness masks this in CI by keeping the mesh warm (startPeerKeepalive + ConnManager().Protect + reconnectNode); production had no equivalent.

Two transport-only changes (no impact on party-list construction, the serialized commitment, or the resulting CID):

1. runConnectionKeepalive (p2p.go, launched from TssManager.Start()): every 15s, for each enabled witness (deduped to its latest announcement) — Protect against connmgr trimming, reconnect if libp2p reports it disconnected, and send a cheap "ready" ping to generate traffic that resets NAT/transport idle timers so the connection never goes idle in the first place. Per-peer work runs concurrently; a failed ping is deliberately NOT treated as death (a live-but-busy peer must not be evicted). This traffic-generating warm-up is the load-bearing part.

2. SendMsg: reconnect from announced addresses if the peer is reported disconnected before giving up; and on an UNAMBIGUOUS idle-death send error ("no recent network activity" / "keepalive timeout" only) evict the half-open connection so it is re-dialed for subsequent sends. The eviction is intentionally narrow: ClosePeer is connection-wide and the reshare send path does not retry individual messages, so evicting on an ambiguous error (as a live-but-busy peer can emit under load) could drop a concurrent in-flight round message and stall that peer.

Adds unit coverage for the two new pure helpers (isTransportErr token classification, incl. regression guards that ambiguous errors do not evict; parseWitnessAddrs). go build ./modules/tss/..., go vet, and go test ./modules/tss/ (unit) all pass. The 6-node integration suite and the full devnet regression are CPU/RAM-bound and must be validated in CI / on a testnet canary.