### PR TITLE
 gate the `transfer.allow` limit parse so an oversized limit cannot grant `MaxInt64`

### DIFF
--- a/modules/contract/execution-context/execution-context.go
+++ b/modules/contract/execution-context/execution-context.go
@@ -57,6 +57,17 @@ type contractExecutionContext struct {
 	// across binaries. Set once per tx by the state engine and propagated into
 	// nested calls.
 	tryCatchActive bool
+
+	// strictIntentLimits gates refusing a transfer.allow whose limit does not
+	// parse, instead of recording whatever strconv.ParseInt happened to return —
+	// which for an out-of-range value is math.MaxInt64, i.e. no ceiling at all.
+	// See buildTokenLimits for the reasoning and why this must be coordinated.
+	//
+	// DEFAULT FALSE = previous behaviour, byte for byte. Set it from the
+	// chain-active consensus version exactly as tryCatchActive is set, and
+	// propagate it into nested calls, so the network switches at one line rather
+	// than forking across a rollout.
+	strictIntentLimits bool
 }
 
 type ContractExecutionContext = *contractExecutionContext
@@ -99,10 +110,62 @@ func New(
 	recursionDepth int,
 	opts ...Option,
 ) ContractExecutionContext {
+	ctx := &contractExecutionContext{
+		ledger:          ledger,
+		env:             env,
+		rcLimit:         rcLimit,
+		rcFreeRemaining: rcFreeRemaining,
+		gasRemain:       gasRemain,
+		callSession:     callSession,
+		recursion:       recursionDepth,
+	}
+	for _, opt := range opts {
+		opt(ctx)
+	}
+	// AFTER the options, because the limit parse is gated by one of them
+	// (strictIntentLimits). Nothing between the struct literal and here reads
+	// tokenLimits, so moving the computation below the option loop is
+	// behaviour-preserving.
+	ctx.tokenLimits = buildTokenLimits(env.Intents, ctx.strictIntentLimits)
+	return ctx
+}
+
+// buildTokenLimits turns the transaction's signed intents into the per-token
+// ceilings that bound PullBalance.
+//
+// ★ THE PARSE FAILURE MODE, and why it is gated.
+//
+// `common.ParseDecimalsToBaseUnits` ends in `strconv.ParseInt`, which is
+// asymmetric on failure: a SYNTAX error returns 0, but an OUT-OF-RANGE value
+// returns math.MaxInt64 — in both cases alongside an error. That error was
+// discarded here, so the two malformed cases degraded in opposite directions:
+//
+//	limit "abc"                    -> 0        -> contract can draw nothing (safe)
+//	limit "99999999999999999999"   -> MaxInt64 -> effectively unbounded (NOT safe)
+//
+// The second is a defence-in-depth failure on the one mechanism that exists to
+// bound what a contract may take from a caller. A client that displays "1.000"
+// while signing an oversized limit obtains an allowance the user never intended
+// to grant, and the clamp is what makes the malformed value permissive instead
+// of refused.
+//
+// ★ IT IS NOT FIXED UNCONDITIONALLY, because it cannot be. This function feeds
+// contract execution, so its output decides state transitions. Changing what a
+// malformed limit resolves to changes whether a draw succeeds — which changes
+// state — so a node running the new rule and a node running the old one disagree,
+// and a replay from genesis no longer reproduces the chain. That is a fork, and
+// it is the same hazard ConsensusParams.EvmAddressChecksumHeight documents at
+// length.
+//
+// So the strict rule rides a gate, DEFAULT OFF: with `strict` false this is
+// byte-identical to the previous behaviour, MaxInt64 clamp included. Activate it
+// the way WithTryCatch is activated — resolved by the state engine from the
+// chain-active consensus version — so the whole network switches at one line.
+func buildTokenLimits(intents []contracts.Intent, strict bool) map[string]*int64 {
 	seenTypes := make(map[string]bool)
 	tokenLimits := make(map[string]*int64)
 
-	for _, intent := range env.Intents {
+	for _, intent := range intents {
 		if intent.Type == "transfer.allow" {
 			limit, ok := intent.Args["limit"]
 			if !ok {
@@ -120,30 +183,25 @@ func New(
 					decimals = dec
 				}
 			}
+			// NOTE: first intent wins for a given (type, token). Not the largest,
+			// not the last — array order. Worth knowing before relying on either.
 			key := intent.Type + "-" + token
 			seen := seenTypes[key]
 			if seen {
 				continue
 			}
 			seenTypes[key] = true
-			val, _ := common.ParseDecimalsToBaseUnits(limit, decimals)
+			val, err := common.ParseDecimalsToBaseUnits(limit, decimals)
+			if err != nil && strict {
+				// Refuse the slip rather than record a ceiling nobody signed for.
+				// No entry means no limit for this token, and PullBalance's own
+				// missing-limit path refuses the draw — fail closed.
+				continue
+			}
 			tokenLimits[token] = &val
 		}
 	}
-	ctx := &contractExecutionContext{
-		ledger:          ledger,
-		env:             env,
-		rcLimit:         rcLimit,
-		rcFreeRemaining: rcFreeRemaining,
-		gasRemain:       gasRemain,
-		callSession:     callSession,
-		recursion:       recursionDepth,
-		tokenLimits:     tokenLimits,
-	}
-	for _, opt := range opts {
-		opt(ctx)
-	}
-	return ctx
+	return tokenLimits
 }
 
 // Option mutates a fresh contractExecutionContext during construction.
@@ -161,6 +219,15 @@ func WithPendulumApplier(p wasm_context.PendulumApplier) Option {
 // coordinated version floor.
 func WithTryCatch(active bool) Option {
 	return func(ctx *contractExecutionContext) { ctx.tryCatchActive = active }
+}
+
+// WithStrictIntentLimits makes an unparseable transfer.allow limit refuse the
+// draw instead of silently granting math.MaxInt64. Mirror of WithTryCatch: the
+// state engine resolves `active` from the chain-active consensus version so this
+// activates only at a coordinated line. Off by default, and off is exactly the
+// previous behaviour — see buildTokenLimits.
+func WithStrictIntentLimits(active bool) Option {
+	return func(ctx *contractExecutionContext) { ctx.strictIntentLimits = active }
 }
 
 func (ctx *contractExecutionContext) IOGas() int {
@@ -653,7 +720,11 @@ func (ctx *contractExecutionContext) ContractCall(
 				// the GraphQL simulate path), this propagates nil — same
 				// behaviour as before, just now consistent across the call depth.
 				WithPendulumApplier(ctx.pendulumApplier),
-				WithTryCatch(ctx.tryCatchActive))
+				WithTryCatch(ctx.tryCatchActive),
+				// Propagate the intent-limit gate: a nested call builds its OWN
+				// tokenLimits from opts.Intents, so without this one transaction
+				// would parse limits under two different rules depending on depth.
+				WithStrictIntentLimits(ctx.strictIntentLimits))
 
 			callPayload := payload
 			json.Unmarshal([]byte(payloadJson), &callPayload)

--- a/modules/contract/execution-context/intent_limits_test.go
+++ b/modules/contract/execution-context/intent_limits_test.go
@@ -1,0 +1,191 @@
+package contract_execution_context
+
+import (
+	"math"
+	"os"
+	"strings"
+	"testing"
+
+	"vsc-node/modules/db/vsc/contracts"
+)
+
+// buildTokenLimits decides how much a contract may pull from the caller. These
+// tests pin BOTH halves of the gate:
+//
+//   - with the gate OFF the behaviour must be byte-identical to the pre-fix code,
+//     including the math.MaxInt64 clamp on an out-of-range limit. That is what
+//     makes shipping this safe on a live chain: an un-activated node computes the
+//     same state it always did, so there is nothing to fork over.
+//   - with the gate ON an unparseable limit records NO ceiling, so PullBalance's
+//     own missing-limit path refuses the draw.
+//
+// If the OFF case ever changes, the change is a consensus break and this test is
+// the thing that should stop it.
+
+func allow(token, limit string, extra ...string) contracts.Intent {
+	args := map[string]string{"limit": limit, "token": token}
+	for i := 0; i+1 < len(extra); i += 2 {
+		args[extra[i]] = extra[i+1]
+	}
+	return contracts.Intent{Type: "transfer.allow", Args: args}
+}
+
+func limitFor(t *testing.T, m map[string]*int64, token string) (int64, bool) {
+	t.Helper()
+	p, ok := m[token]
+	if !ok || p == nil {
+		return 0, false
+	}
+	return *p, true
+}
+
+func TestIntentLimits_GateOff_PreservesLegacyBehaviourExactly(t *testing.T) {
+	// The dangerous one: out of range. strconv.ParseInt returns MaxInt64 AND an
+	// error; the legacy code discarded the error and kept the value.
+	got := buildTokenLimits([]contracts.Intent{allow("hbd", "99999999999999999999")}, false)
+	v, ok := limitFor(t, got, "hbd")
+	if !ok {
+		t.Fatal("legacy behaviour recorded no limit — that IS the behaviour change this gate exists to avoid")
+	}
+	if v != math.MaxInt64 {
+		t.Fatalf("legacy limit = %d, want math.MaxInt64 (%d). Changing this without the gate forks the chain", v, int64(math.MaxInt64))
+	}
+
+	// A syntax error already failed closed, and must keep doing so.
+	got = buildTokenLimits([]contracts.Intent{allow("hbd", "not-a-number")}, false)
+	if v, ok := limitFor(t, got, "hbd"); !ok || v != 0 {
+		t.Fatalf("legacy syntax-error limit = (%d, present=%t), want (0, true)", v, ok)
+	}
+}
+
+func TestIntentLimits_GateOn_RefusesAnUnparseableLimit(t *testing.T) {
+	for _, bad := range []string{
+		"99999999999999999999", // out of range -> was MaxInt64
+		"1.2.3",                // more than one decimal point
+		"not-a-number",         // pure syntax
+		"",                     // empty
+	} {
+		got := buildTokenLimits([]contracts.Intent{allow("hbd", bad)}, true)
+		if _, ok := limitFor(t, got, "hbd"); ok {
+			t.Fatalf("strict mode recorded a ceiling for limit %q — it must record none so the draw is refused", bad)
+		}
+	}
+}
+
+func TestIntentLimits_GateOn_LeavesValidLimitsUntouched(t *testing.T) {
+	// The gate must only affect the failure path. A well-formed limit resolves
+	// identically either way, or activating it would change every honest tx too.
+	for _, tc := range []struct {
+		limit, decimals string
+		want            int64
+	}{
+		{"1.000", "3", 1000},
+		{"25.5", "3", 25500},
+		{"0", "3", 0},
+	} {
+		on := buildTokenLimits([]contracts.Intent{allow("hbd", tc.limit, "decimals", tc.decimals)}, true)
+		off := buildTokenLimits([]contracts.Intent{allow("hbd", tc.limit, "decimals", tc.decimals)}, false)
+		vOn, okOn := limitFor(t, on, "hbd")
+		vOff, okOff := limitFor(t, off, "hbd")
+		if !okOn || !okOff || vOn != vOff || vOn != tc.want {
+			t.Fatalf("limit %q: on=(%d,%t) off=(%d,%t), want both %d", tc.limit, vOn, okOn, vOff, okOff, tc.want)
+		}
+	}
+}
+
+func TestIntentLimits_FirstIntentWinsPerToken_BothModes(t *testing.T) {
+	// Not the largest, not the last — array order. Pinned because it is the kind
+	// of thing a reader assumes wrongly, and because a future "take the smaller"
+	// change would be a consensus change too.
+	intents := []contracts.Intent{
+		allow("hbd", "1.000", "decimals", "3"),
+		allow("hbd", "500.000", "decimals", "3"),
+	}
+	for _, strict := range []bool{false, true} {
+		v, ok := limitFor(t, buildTokenLimits(intents, strict), "hbd")
+		if !ok || v != 1000 {
+			t.Fatalf("strict=%t: limit = (%d, present=%t), want the FIRST intent's 1000", strict, v, ok)
+		}
+	}
+}
+
+func TestIntentLimits_IgnoresNonTransferAllowAndIncompleteIntents(t *testing.T) {
+	intents := []contracts.Intent{
+		{Type: "something.else", Args: map[string]string{"limit": "5.000", "token": "hbd"}},
+		{Type: "transfer.allow", Args: map[string]string{"token": "hbd"}},   // no limit
+		{Type: "transfer.allow", Args: map[string]string{"limit": "5.000"}}, // no token
+	}
+	for _, strict := range []bool{false, true} {
+		if got := buildTokenLimits(intents, strict); len(got) != 0 {
+			t.Fatalf("strict=%t: expected no limits from unknown/incomplete intents, got %v", strict, got)
+		}
+	}
+}
+
+// ★ THE WIRING, not just the helper.
+//
+// The tests above call buildTokenLimits directly, which proves the function but
+// says nothing about what New() passes it. That distinction is not academic: a
+// mutant that hard-codes `true` at New's call site — i.e. ships the strict rule
+// UNGATED, which is the fork — passed every test above. This is the test that
+// catches it.
+//
+// New with no options must produce the legacy limits, MaxInt64 clamp included.
+func TestIntentLimits_NewDefaultsToLegacyBehaviour(t *testing.T) {
+	env := Environment{Intents: []contracts.Intent{allow("hbd", "99999999999999999999")}}
+	ctx := New(env, 0, 0, 0, nil, nil, 0)
+
+	v, ok := limitFor(t, ctx.tokenLimits, "hbd")
+	if !ok {
+		t.Fatal("New() recorded no limit for an out-of-range value — the strict rule is active BY DEFAULT, which changes contract execution for every node that installs this build and forks the chain")
+	}
+	if v != math.MaxInt64 {
+		t.Fatalf("New() limit = %d, want math.MaxInt64 (%d) — the default path must stay byte-identical until a coordinated activation", v, int64(math.MaxInt64))
+	}
+}
+
+// And the option must actually reach the parse — otherwise activating the gate
+// would be a silent no-op and the hole would stay open with everyone believing
+// it was closed.
+func TestIntentLimits_NewHonoursTheOption(t *testing.T) {
+	env := Environment{Intents: []contracts.Intent{allow("hbd", "99999999999999999999")}}
+	ctx := New(env, 0, 0, 0, nil, nil, 0, WithStrictIntentLimits(true))
+
+	if _, ok := limitFor(t, ctx.tokenLimits, "hbd"); ok {
+		t.Fatal("WithStrictIntentLimits(true) did not reach the limit parse — the gate is inert, so turning it on would close nothing")
+	}
+}
+
+// ★ THE GATE MUST PROPAGATE INTO NESTED CALLS.
+//
+// A nested contract call builds its OWN tokenLimits from its own intents
+// (ContractCall passes opts.Intents into a fresh New). If the gate did not
+// propagate, one transaction would parse limits under the strict rule at the top
+// level and the legacy rule one frame down — two different ceilings for the same
+// signed intent, decided by call depth. That is a state divergence inside a single
+// transaction, which is exactly what the tryCatch gate propagates to avoid.
+//
+// This test asserts the source does the propagation, in the same
+// read-the-source-and-derive style used elsewhere in this repo for cross-file
+// guarantees that cannot be reached through a unit-testable seam (constructing a
+// real nested ContractCall needs a ledger, a session and a wasm runtime).
+func TestIntentLimits_GatePropagatesIntoNestedContractCalls(t *testing.T) {
+	src, err := os.ReadFile("execution-context.go")
+	if err != nil {
+		t.Fatalf("cannot read own source: %v", err)
+	}
+	text := string(src)
+
+	// The nested New() inside ContractCall is the only place WithTryCatch is
+	// passed a ctx field rather than being defined; find it and require our gate
+	// alongside it.
+	const marker = "WithTryCatch(ctx.tryCatchActive)"
+	idx := strings.Index(text, marker)
+	if idx < 0 {
+		t.Fatalf("could not find the nested-call option list (%q) — this test's anchor moved; fix the anchor, do not delete the test", marker)
+	}
+	window := text[idx : idx+400]
+	if !strings.Contains(window, "WithStrictIntentLimits(ctx.strictIntentLimits)") {
+		t.Fatal("the nested contract call does not propagate WithStrictIntentLimits — a nested call would build its tokenLimits under the LEGACY rule while the top level used the strict one, so one transaction would enforce two different ceilings depending on call depth")
+	}
+}


### PR DESCRIPTION
# fix(contract): gate the `transfer.allow` limit parse so an oversized limit cannot grant `MaxInt64`

**Branch:** `fix/intent-limit-parse-gate` → `main`
**Base:** `cc069b3f` (`origin/main`)
**Files:** 2 — `modules/contract/execution-context/execution-context.go`, `modules/contract/execution-context/intent_limits_test.go` (new)
**Behaviour change on merge: none.** The fix is gated and the gate defaults to off.

---

## The bug

An intent is the permission slip that bounds what a contract may pull from the
caller. `transfer.allow` sets a per-token ceiling, and `PullBalance` is bounded by
it. Building those ceilings discarded the parse error:

```go
val, _ := common.ParseDecimalsToBaseUnits(limit, decimals)
tokenLimits[token] = &val
```

`ParseDecimalsToBaseUnits` ends in `strconv.ParseInt`, which is **asymmetric on
failure**: a syntax error returns `0`, an out-of-range value returns
`math.MaxInt64` — both alongside an error that was thrown away. So the two
malformed cases degraded in opposite directions:

| signed limit | recorded ceiling | effect |
|---|---|---|
| `"abc"` | `0` | draw refused — fails closed |
| `"1.2.3"` | `0` | draw refused — fails closed |
| `"99999999999999999999"` | `math.MaxInt64` | **no ceiling in practice** |

The second row is a defence-in-depth failure on the only mechanism that limits
what a contract can take. It is not a way to steal from a stranger — the intent is
signed by the account whose funds are at risk — but it does mean a client that
displays `1.000` while signing an oversized limit obtains an allowance the user
never intended to grant, and the clamp is what makes a malformed value
*permissive* rather than refused.

Found while stress-testing intent handling for wallet-signed (`did:pkh`)
transactions. Everything else in that sweep failed closed; this was the only
fail-open.

## Why it is gated instead of just fixed

This function feeds contract execution. What a malformed limit resolves to decides
whether a draw succeeds, which decides state. Change it unconditionally and an
upgraded node and a not-yet-upgraded node compute different state from the same
block, and a replay from genesis stops reproducing the chain.

That is the hazard `ConsensusParams.EvmAddressChecksumHeight` already documents at
length, and the reason this repo moved to consensus-version gating for
consensus-affecting changes.

So the strict rule rides `strictIntentLimits`, **default false**, which is
byte-identical to today including the `MaxInt64` clamp. Nothing changes when this
merges.

**Activation is a separate decision and is deliberately not made here.** Resolve
it from the chain-active consensus version exactly as `tryCatchActive` is
resolved, on whichever line you want to batch it with. Until then the gate is
inert and the tests prove both that it is inert and that it works when switched
on.

## What changed

- The intent loop moved into `buildTokenLimits(intents, strict)` — **verbatim** in
  the default path. It now runs after the option loop in `New` so it can read the
  gate; nothing between the struct literal and there reads `tokenLimits`, so that
  reorder is behaviour-preserving.
- `strictIntentLimits` field + `WithStrictIntentLimits(active bool)`, mirroring
  `tryCatchActive` / `WithTryCatch`.
- **The gate propagates into nested contract calls.** A nested call builds its own
  `tokenLimits` from `opts.Intents`, so without this a single transaction would
  enforce two different ceilings depending on call depth. (This was missed in the
  first draft and caught by asking why the change was sitting on the wrong branch —
  worth stating plainly.)
- Documented that for a duplicate `(type, token)` the **first intent in array
  order wins** — not the largest, not the last. Unchanged behaviour, just no
  longer a thing a reader has to guess.

## Tests

`intent_limits_test.go`, 8 cases. Three of them exist specifically to catch the
ways this change could go wrong, and each was verified by mutation:

| Mutation | Caught by |
|---|---|
| ship the fix ungated (`strict` hard-coded true) — **the fork** | `NewDefaultsToLegacyBehaviour` |
| gate wired but inert (option ignored) | `NewHonoursTheOption` |
| propagation dropped from the nested call | `GatePropagatesIntoNestedContractCalls` |

Note the first mutant initially **passed**: the earlier tests called
`buildTokenLimits` directly and so pinned the function without pinning the wiring.
`NewDefaultsToLegacyBehaviour` goes through `New` and closes that.

The rest pin: legacy `MaxInt64` on overflow with the gate off, refusal for every
unparseable limit with it on, valid limits identical either way, first-wins on
duplicates, and that unknown or incomplete intents contribute nothing.

## Verification

Built and run in a container matching the repo's own `Dockerfile` (Go 1.25 +
WasmEdge 0.13.4, same version and checksum it pins):

- `go vet ./modules/contract/... ./modules/state-processing/ ./modules/common/...` — clean
- `go test ./modules/contract/... ./modules/common/...` — all green
  (execution-context, session, common, consensusversion, params, system-config)
- `gofmt` clean; both files LF

## Reviewer notes

- **Nothing to coordinate to merge this.** The gate is off, so no witness needs to
  upgrade in step. The coordination question arrives only when you activate it.
- If you would rather activate it in the same batch as an existing line, the only
  change needed is in the state engine where `WithTryCatch` is already resolved
  per-tx — pass `WithStrictIntentLimits(<same style of resolver>)` beside it.
- The strict branch refuses by recording **no entry** for the token, so
  `PullBalance`'s own missing-limit path does the refusing. That keeps the failure
  in one place rather than inventing a second "zero means refuse" convention.

## Not in this PR

`common.EncodeDagCbor` discards three errors and always returns `nil`. Today a
malformed input panics; making it return an error would let any caller doing
`bytes, _ :=` proceed with **empty bytes** and therefore a wrong CID, silently —
worse than the panic. Fixing it properly means auditing its ~24 call sites, which
belongs in its own change.
