### PR TITLE
fix: deterministic interest ids, fail-stop interest writes, ordered b…

### DIFF
--- a/lib/test_utils/mock_ledger.go
+++ b/lib/test_utils/mock_ledger.go
@@ -89,6 +89,23 @@ func (m *MockLedgerDb) StoreLedger(ledgerRecords ...ledgerDb.LedgerRecord) error
 	return nil
 }
 
+// DeleteLegacyInterestRecords mirrors the production delete: drop interest rows
+// at recordBlockHeight whose Id has no '#' (the old index-based scheme), leaving
+// account-keyed rows intact.
+func (m *MockLedgerDb) DeleteLegacyInterestRecords(recordBlockHeight uint64) error {
+	for owner, records := range m.LedgerRecords {
+		kept := make([]ledgerDb.LedgerRecord, 0, len(records))
+		for _, r := range records {
+			if r.Type == "interest" && r.BlockHeight == recordBlockHeight && !strings.Contains(r.Id, "#") {
+				continue
+			}
+			kept = append(kept, r)
+		}
+		m.LedgerRecords[owner] = kept
+	}
+	return nil
+}
+
 func (m *MockLedgerDb) GetLedgerAfterHeight(account string, blockHeight uint64, asset string, limit *int64) (*[]ledgerDb.LedgerRecord, error) {
 	das := m.LedgerRecords[account]
 	filteredResults := make([]ledgerDb.LedgerRecord, 0)

--- a/modules/block-producer/blockProducer.go
+++ b/modules/block-producer/blockProducer.go
@@ -172,10 +172,15 @@ type generateBlockParams struct {
 
 // This function should generate a deterministically generated block
 // In the future we should apply protocol versioning to this
+// GenerateBlock returns the derived header, the input tx ids, and the
+// per-component CIDs that produced the header. The components are diagnostics
+// only — they are never signed and never gate accept/reject — but they let a
+// CID mismatch name the component that diverged instead of printing two opaque
+// header CIDs. See HandleBlockMsg.
 func (bp *BlockProducer) GenerateBlock(
 	slotHeight uint64,
 	options ...generateBlockParams,
-) (*vscBlocks.VscHeader, []string, error) {
+) (*vscBlocks.VscHeader, []string, *blockComponents, error) {
 	prevBlock, err := bp.VscBlocks.GetBlockByHeight(slotHeight)
 	daSession := datalayer.NewSession(bp.Datalayer)
 
@@ -261,7 +266,7 @@ func (bp *BlockProducer) GenerateBlock(
 	mr, err := MerklizeCids(outCids)
 
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	blockData := vscBlocks.VscBlock{
@@ -277,7 +282,7 @@ func (bp *BlockProducer) GenerateBlock(
 	blockCid, err := bp.Datalayer.PutObject(blockData)
 
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	blockHeader := vscBlocks.VscHeader{
@@ -296,6 +301,27 @@ func (bp *BlockProducer) GenerateBlock(
 
 	daSession.Commit()
 
+	// Diagnostics only — see blockComponents. Assembled from the exact values
+	// that produced blockHeader above, so a mismatch can be attributed to a
+	// component rather than to the header CID as a whole.
+	comps := &blockComponents{
+		Br:         prevRange,
+		MerkleRoot: mr,
+		BlockCid:   blockCid.String(),
+	}
+	if prevBlockId != nil {
+		comps.Prevb = *prevBlockId
+	}
+	if oplog != nil {
+		comps.Oplog = oplog.Id
+	}
+	for _, co := range contractOutputs {
+		comps.Outputs = append(comps.Outputs, co.Id)
+	}
+	for _, tx := range offchainTxs {
+		comps.Leaves = append(comps.Leaves, tx.Id)
+	}
+
 	vlog.Verbose(
 		"GenerateBlock",
 		"merkleRoot",
@@ -308,7 +334,7 @@ func (bp *BlockProducer) GenerateBlock(
 		prevRange,
 	)
 
-	return &blockHeader, outTxs, nil
+	return &blockHeader, outTxs, comps, nil
 }
 
 func (bp *BlockProducer) generateTransactions(slotHeight uint64) []vscBlocks.VscBlockTx {
@@ -458,7 +484,7 @@ func (bp *BlockProducer) ProduceBlock(bh uint64) {
 	// processed by the state engine, so state is already current; the wait
 	// served no purpose. Removed so GenerateBlock runs immediately.
 
-	genBlock, transactions, err := bp.GenerateBlock(bh, generateBlockParams{
+	genBlock, transactions, comps, err := bp.GenerateBlock(bh, generateBlockParams{
 		PopulateTxs: true,
 	})
 
@@ -469,7 +495,8 @@ func (bp *BlockProducer) ProduceBlock(bh uint64) {
 
 	cid, _ := bp.Datalayer.HashObject(genBlock)
 
-	vlog.Info("ProduceBlock PRODUCER", "headerCid", cid.String(), "slotHeight", bh)
+	vlog.Info("ProduceBlock PRODUCER", "headerCid", cid.String(), "slotHeight", bh,
+		"components", comps.summary())
 
 	// TEST-ONLY (devnet) malicious DOUBLE-BLOCK-SIGN injection. When this node ==
 	// VSC_DOUBLE_SIGN_ACCOUNT (harness-set; never mainnet), broadcast TWO
@@ -525,6 +552,10 @@ func (bp *BlockProducer) ProduceBlock(bh uint64) {
 				"producer":     bp.config.Config.Get().HiveUsername,
 				"transactions": transactions,
 				"block_cid":    cid.String(),
+				// Additive diagnostics: peers on older code ignore this key,
+				// and HandleBlockMsg tolerates its absence. Never signed,
+				// never gates accept/reject.
+				"components": comps.toMap(),
 			},
 		})
 	}()
@@ -719,7 +750,7 @@ func (bp *BlockProducer) HandleBlockMsg(msg p2pMessage) (string, error) {
 	waitCancel()
 
 	// Independently derive block (including oplog + contract outputs)
-	blockHeader, _, err := bp.GenerateBlock(msg.SlotHeight, generateBlockParams{
+	blockHeader, _, localComps, err := bp.GenerateBlock(msg.SlotHeight, generateBlockParams{
 		Transactions: transactions,
 	})
 
@@ -740,8 +771,35 @@ func (bp *BlockProducer) HandleBlockMsg(msg p2pMessage) (string, error) {
 		return "", errors.New("missing block_cid in message")
 	}
 	if localCid.String() != producerCidStr {
-		vlog.Error("CID MISMATCH", "local", localCid.String(), "producer", producerCidStr)
-		return "", fmt.Errorf("block CID mismatch: local=%s producer=%s", localCid.String(), producerCidStr)
+		// Name the component that diverged. Without this the operator sees two
+		// opaque header CIDs and has to reconstruct both blocks by hand to find
+		// out which input differed.
+		remoteComps := parseComponents(msg.Data["components"])
+		divergent := localComps.Diff(remoteComps)
+		divergentStr := strings.Join(divergent, ",")
+		if remoteComps == nil {
+			divergentStr = "<producer sent no component detail>"
+		} else if len(divergent) == 0 {
+			// Every compared component agrees yet the header CIDs differ, so
+			// the divergence is in a header field that is not covered above
+			// (or in the CBOR encoding itself).
+			divergentStr = "<none — header-level divergence>"
+		}
+		vlog.Error("CID MISMATCH",
+			"divergent", divergentStr,
+			"slotHeight", msg.SlotHeight,
+			"producer", producer,
+			"localCid", localCid.String(),
+			"producerCid", producerCidStr,
+			"localComponents", localComps.summary(),
+			"producerComponents", remoteComps.summary(),
+			"localOutputs", joinCids(localComps.Outputs),
+			"producerOutputs", joinCids(remoteComps.outputs()),
+			"localTxList", joinCids(localComps.Leaves),
+			"producerTxList", joinCids(remoteComps.leaves()),
+		)
+		return "", fmt.Errorf("block CID mismatch: divergent=%s local=%s producer=%s",
+			divergentStr, localCid.String(), producerCidStr)
 	}
 
 	// CIDs match — sign

--- a/modules/block-producer/block_components.go
+++ b/modules/block-producer/block_components.go
@@ -1,0 +1,208 @@
+package blockproducer
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// maxWireCids bounds how many individual component CIDs are copied into the
+// gossip message. The full lists are always summarised by count+digest, so a
+// divergence past the cap is still detected — the cap only limits how much
+// detail travels over pubsub.
+const maxWireCids = 64
+
+// blockComponents captures every input that feeds the block header CID, so a
+// CID mismatch can name WHICH component diverged instead of printing two
+// opaque header CIDs.
+//
+// This is diagnostics only. Nothing here is signed, nothing here feeds the
+// header CID, and nothing here may ever gate accept/reject — see Diff, which
+// is only ever called on a path that has already decided to reject.
+type blockComponents struct {
+	Prevb      string   // previous block content CID ("" when nil)
+	Br         [2]int   // header block range
+	MerkleRoot string   // merkle root over the leaves
+	BlockCid   string   // CID of the block body object
+	Oplog      string   // oplog tx CID ("" when the block carries no oplog)
+	Outputs    []string // contract-output tx CIDs
+	Leaves     []string // every merkle leaf (input txs + oplog + outputs + gov ops)
+
+	// Populated only by parseComponents: the peer's FULL list sizes and
+	// digests, which may describe more entries than the wire cap carried.
+	outputsCount  int
+	outputsDigest string
+	leavesCount   int
+	leavesDigest  string
+}
+
+// digest returns a stable fingerprint of a CID list so two nodes can compare
+// arbitrarily long lists over a bounded-size gossip message.
+func digest(ids []string) string {
+	h := sha256.New()
+	for _, id := range ids {
+		h.Write([]byte(id))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+func capCids(ids []string) []string {
+	if len(ids) <= maxWireCids {
+		return ids
+	}
+	return ids[:maxWireCids]
+}
+
+// toMap renders the components for the block gossip message. Keys are additive:
+// peers running older code simply ignore them, and this node tolerates their
+// absence (see parseComponents).
+func (c *blockComponents) toMap() map[string]interface{} {
+	if c == nil {
+		return nil
+	}
+	return map[string]interface{}{
+		"prevb":         c.Prevb,
+		"br":            []int{c.Br[0], c.Br[1]},
+		"merkle_root":   c.MerkleRoot,
+		"block_cid":     c.BlockCid,
+		"oplog":         c.Oplog,
+		"outputs":       capCids(c.Outputs),
+		"outputs_count": len(c.Outputs),
+		"outputs_dig":   digest(c.Outputs),
+		"leaves":        capCids(c.Leaves),
+		"leaves_count":  len(c.Leaves),
+		"leaves_dig":    digest(c.Leaves),
+	}
+}
+
+// parseComponents reads a peer's components out of a gossip message. It returns
+// nil for any shape it does not recognise — an older peer that never sent the
+// field, or a malformed one. Callers must treat nil as "no peer detail
+// available" and never as evidence of anything.
+func parseComponents(v interface{}) *blockComponents {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	str := func(k string) string {
+		s, _ := m[k].(string)
+		return s
+	}
+	strs := func(k string) []string {
+		raw, _ := m[k].([]interface{})
+		out := make([]string, 0, len(raw))
+		for _, e := range raw {
+			s, _ := e.(string)
+			out = append(out, s)
+		}
+		return out
+	}
+	num := func(k string) int {
+		f, _ := m[k].(float64)
+		return int(f)
+	}
+	c := &blockComponents{
+		Prevb:      str("prevb"),
+		MerkleRoot: str("merkle_root"),
+		BlockCid:   str("block_cid"),
+		Oplog:      str("oplog"),
+		Outputs:    strs("outputs"),
+		Leaves:     strs("leaves"),
+	}
+	if br, ok := m["br"].([]interface{}); ok && len(br) == 2 {
+		a, _ := br[0].(float64)
+		b, _ := br[1].(float64)
+		c.Br = [2]int{int(a), int(b)}
+	}
+	// Counts/digests describe the FULL lists, which may exceed what the wire
+	// carried. Stash them so Diff compares the whole list, not just the cap.
+	c.outputsCount = num("outputs_count")
+	c.outputsDigest = str("outputs_dig")
+	c.leavesCount = num("leaves_count")
+	c.leavesDigest = str("leaves_dig")
+	return c
+}
+
+// Diff names the components that differ between the locally derived block and
+// the producer's. Returns nil when the peer sent no component detail.
+func (c *blockComponents) Diff(remote *blockComponents) []string {
+	if c == nil || remote == nil {
+		return nil
+	}
+	var out []string
+	if c.Prevb != remote.Prevb {
+		out = append(out, "prevb")
+	}
+	if c.Br != remote.Br {
+		out = append(out, "br")
+	}
+	if c.Oplog != remote.Oplog {
+		out = append(out, "oplog")
+	}
+	// Only compare the summarised lists when the peer actually supplied a
+	// digest. A peer that sent a partial payload must not be reported as
+	// divergent — a misleading diagnostic is worse than a missing one.
+	if remote.outputsDigest != "" &&
+		(len(c.Outputs) != remote.outputsCount || digest(c.Outputs) != remote.outputsDigest) {
+		out = append(out, "contract_outputs")
+	}
+	if remote.leavesDigest != "" &&
+		(len(c.Leaves) != remote.leavesCount || digest(c.Leaves) != remote.leavesDigest) {
+		out = append(out, "tx_list")
+	}
+	if c.MerkleRoot != remote.MerkleRoot {
+		out = append(out, "merkle_root")
+	}
+	if c.BlockCid != remote.BlockCid {
+		out = append(out, "block_body")
+	}
+	return out
+}
+
+// summary renders the components as a single compact log field.
+func (c *blockComponents) summary() string {
+	if c == nil {
+		return "<none>"
+	}
+	prevb := c.Prevb
+	if prevb == "" {
+		prevb = "<nil>"
+	}
+	oplog := c.Oplog
+	if oplog == "" {
+		oplog = "<none>"
+	}
+	return fmt.Sprintf(
+		"prevb=%s br=[%d %d] oplog=%s outputs=%d/%s leaves=%d/%s mr=%s body=%s",
+		prevb, c.Br[0], c.Br[1], oplog,
+		len(c.Outputs), digest(c.Outputs),
+		len(c.Leaves), digest(c.Leaves),
+		c.MerkleRoot, c.BlockCid,
+	)
+}
+
+// outputs and leaves are nil-safe accessors so the mismatch log can render a
+// peer's lists without a nil check at every call site.
+func (c *blockComponents) outputs() []string {
+	if c == nil {
+		return nil
+	}
+	return c.Outputs
+}
+
+func (c *blockComponents) leaves() []string {
+	if c == nil {
+		return nil
+	}
+	return c.Leaves
+}
+
+// joinCids renders up to maxWireCids CIDs for the mismatch log.
+func joinCids(ids []string) string {
+	if len(ids) == 0 {
+		return "<none>"
+	}
+	return strings.Join(capCids(ids), ",")
+}

--- a/modules/block-producer/block_components_test.go
+++ b/modules/block-producer/block_components_test.go
@@ -1,0 +1,254 @@
+package blockproducer
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// wireRoundTrip pushes components through the exact path a real gossip message
+// takes: toMap -> json.Marshal -> json.Unmarshal into map[string]interface{}
+// -> parseComponents. Testing Diff on a hand-built struct would pass even if
+// the wire encoding dropped every field, so the round trip is the part that
+// actually matters.
+func wireRoundTrip(t *testing.T, c *blockComponents) *blockComponents {
+	t.Helper()
+	msg := map[string]interface{}{"components": c.toMap()}
+	raw, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := parseComponents(decoded["components"])
+	if got == nil {
+		t.Fatal("parseComponents returned nil after a valid round trip")
+	}
+	return got
+}
+
+func baseComponents() *blockComponents {
+	return &blockComponents{
+		Prevb:      "bafyPREV",
+		Br:         [2]int{100, 200},
+		MerkleRoot: "bafyMERKLE",
+		BlockCid:   "bafyBODY",
+		Oplog:      "bafyOPLOG",
+		Outputs:    []string{"bafyOUT1", "bafyOUT2"},
+		Leaves:     []string{"bafyTX1", "bafyOPLOG", "bafyOUT1", "bafyOUT2"},
+	}
+}
+
+// TestWireRoundTripPreservesEveryField is the guard that the diagnostic
+// survives pubsub at all.
+func TestWireRoundTripPreservesEveryField(t *testing.T) {
+	local := baseComponents()
+	remote := wireRoundTrip(t, local)
+
+	if remote.Prevb != local.Prevb {
+		t.Errorf("prevb lost: got %q want %q", remote.Prevb, local.Prevb)
+	}
+	if remote.Br != local.Br {
+		t.Errorf("br lost: got %v want %v", remote.Br, local.Br)
+	}
+	if remote.Oplog != local.Oplog {
+		t.Errorf("oplog lost: got %q want %q", remote.Oplog, local.Oplog)
+	}
+	if remote.MerkleRoot != local.MerkleRoot || remote.BlockCid != local.BlockCid {
+		t.Errorf("merkle/body lost: %q %q", remote.MerkleRoot, remote.BlockCid)
+	}
+	if remote.outputsCount != len(local.Outputs) || remote.outputsDigest != digest(local.Outputs) {
+		t.Errorf("outputs summary lost: count=%d dig=%q", remote.outputsCount, remote.outputsDigest)
+	}
+	if remote.leavesCount != len(local.Leaves) || remote.leavesDigest != digest(local.Leaves) {
+		t.Errorf("leaves summary lost: count=%d dig=%q", remote.leavesCount, remote.leavesDigest)
+	}
+
+	// Identical components must report no divergence.
+	if d := local.Diff(remote); len(d) != 0 {
+		t.Errorf("identical components reported divergent: %v", d)
+	}
+}
+
+// TestDiffNamesDivergentComponent covers the shapes an operator will actually
+// hit. Each case mutates ONE input and asserts the diagnostic names it.
+func TestDiffNamesDivergentComponent(t *testing.T) {
+	contains := func(hay []string, needle string) bool {
+		for _, h := range hay {
+			if h == needle {
+				return true
+			}
+		}
+		return false
+	}
+
+	cases := []struct {
+		name    string
+		mutate  func(*blockComponents)
+		wantHas []string
+		wantNot []string
+	}{
+		{
+			// The mainnet shape: divergent chain history. prevb feeds the
+			// block body, so both are expected; the merkle root is built only
+			// from the leaves and must NOT be flagged.
+			name: "divergent_history_prevb",
+			mutate: func(c *blockComponents) {
+				c.Prevb = "bafyOTHERPREV"
+				c.BlockCid = "bafyOTHERBODY"
+			},
+			wantHas: []string{"prevb", "block_body"},
+			wantNot: []string{"oplog", "merkle_root", "contract_outputs"},
+		},
+		{
+			name: "divergent_block_range",
+			mutate: func(c *blockComponents) {
+				c.Br = [2]int{100, 201}
+			},
+			wantHas: []string{"br"},
+			wantNot: []string{"prevb", "oplog"},
+		},
+		{
+			// A ledger divergence surfaces as a different oplog CID, which is
+			// also a merkle leaf.
+			name: "divergent_oplog",
+			mutate: func(c *blockComponents) {
+				c.Oplog = "bafyOTHEROPLOG"
+				c.Leaves = []string{"bafyTX1", "bafyOTHEROPLOG", "bafyOUT1", "bafyOUT2"}
+				c.MerkleRoot = "bafyOTHERMERKLE"
+				c.BlockCid = "bafyOTHERBODY"
+			},
+			wantHas: []string{"oplog", "tx_list", "merkle_root", "block_body"},
+			wantNot: []string{"prevb", "br", "contract_outputs"},
+		},
+		{
+			name: "divergent_contract_output",
+			mutate: func(c *blockComponents) {
+				c.Outputs = []string{"bafyOUT1", "bafyOTHEROUT"}
+				c.Leaves = []string{"bafyTX1", "bafyOPLOG", "bafyOUT1", "bafyOTHEROUT"}
+				c.MerkleRoot = "bafyOTHERMERKLE"
+				c.BlockCid = "bafyOTHERBODY"
+			},
+			wantHas: []string{"contract_outputs", "tx_list"},
+			wantNot: []string{"prevb", "br", "oplog"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			local := baseComponents()
+			producer := baseComponents()
+			tc.mutate(producer)
+
+			remote := wireRoundTrip(t, producer)
+			got := local.Diff(remote)
+
+			for _, want := range tc.wantHas {
+				if !contains(got, want) {
+					t.Errorf("expected %q in divergent set, got %v", want, got)
+				}
+			}
+			for _, notWant := range tc.wantNot {
+				if contains(got, notWant) {
+					t.Errorf("did NOT expect %q in divergent set, got %v", notWant, got)
+				}
+			}
+			t.Logf("%s -> divergent=%v", tc.name, got)
+		})
+	}
+}
+
+// TestDiffTolerantOfOlderPeer proves the diagnostic degrades safely: a peer
+// running code without the components field must not crash the signer or be
+// reported as divergent.
+func TestDiffTolerantOfOlderPeer(t *testing.T) {
+	local := baseComponents()
+
+	// An older producer's message simply has no "components" key.
+	oldMsg := map[string]interface{}{
+		"producer":  "someone",
+		"block_cid": "bafyHEADER",
+	}
+	remote := parseComponents(oldMsg["components"])
+	if remote != nil {
+		t.Fatalf("expected nil for absent components, got %+v", remote)
+	}
+	if d := local.Diff(remote); d != nil {
+		t.Errorf("expected nil diff against older peer, got %v", d)
+	}
+	// summary() and the list accessors must be nil-safe — they are called
+	// unconditionally on the mismatch log line.
+	if s := remote.summary(); s != "<none>" {
+		t.Errorf("nil summary: %q", s)
+	}
+	if j := joinCids(remote.outputs()); j != "<none>" {
+		t.Errorf("nil outputs: %q", j)
+	}
+	if j := joinCids(remote.leaves()); j != "<none>" {
+		t.Errorf("nil leaves: %q", j)
+	}
+}
+
+// TestDiffIgnoresPartialPeerPayload guards the guard: a peer that supplied no
+// digests must not be reported as divergent on those lists.
+func TestDiffIgnoresPartialPeerPayload(t *testing.T) {
+	local := baseComponents()
+	partial := parseComponents(map[string]interface{}{
+		"prevb": "bafyPREV",
+		"br":    []interface{}{float64(100), float64(200)},
+		"oplog": "bafyOPLOG",
+		// no merkle_root/block_cid/digests at all
+	})
+	if partial == nil {
+		t.Fatal("expected non-nil for a partial map")
+	}
+	got := local.Diff(partial)
+	for _, name := range []string{"contract_outputs", "tx_list"} {
+		for _, g := range got {
+			if g == name {
+				t.Errorf("partial payload wrongly reported %q divergent (got %v)", name, got)
+			}
+		}
+	}
+	t.Logf("partial peer -> divergent=%v", got)
+}
+
+// TestDigestDetectsBeyondWireCap proves a divergence past the wire cap is still
+// caught: the cap truncates the copied list but the digest covers all of it.
+func TestDigestDetectsBeyondWireCap(t *testing.T) {
+	mk := func(n int, mutateAt int) *blockComponents {
+		c := &blockComponents{Prevb: "p", MerkleRoot: "m", BlockCid: "b", Oplog: "o"}
+		for i := 0; i < n; i++ {
+			id := "leaf" + string(rune('A'+i%26)) + string(rune('0'+i/26))
+			if i == mutateAt {
+				id = "MUTATED"
+			}
+			c.Leaves = append(c.Leaves, id)
+		}
+		return c
+	}
+	const n = maxWireCids + 40
+	local := mk(n, -1)
+	producer := mk(n, n-1) // differs only in the LAST leaf, well past the cap
+
+	remote := wireRoundTrip(t, producer)
+	if len(remote.Leaves) != maxWireCids {
+		t.Fatalf("expected wire list capped at %d, got %d", maxWireCids, len(remote.Leaves))
+	}
+	if remote.leavesCount != n {
+		t.Errorf("expected full count %d on the wire, got %d", n, remote.leavesCount)
+	}
+	got := local.Diff(remote)
+	found := false
+	for _, g := range got {
+		if g == "tx_list" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("divergence past the wire cap went undetected: %v", got)
+	}
+	t.Logf("beyond-cap divergence detected: %v (wire carried %d of %d leaves)",
+		got, len(remote.Leaves), remote.leavesCount)
+}

--- a/modules/db/vsc/hive_blocks/hive_blocks.go
+++ b/modules/db/vsc/hive_blocks/hive_blocks.go
@@ -416,10 +416,22 @@ func (h *hiveBlocks) ListenToBlockUpdates(ctx context.Context, startBlock uint64
 				}
 
 				// TODO mongo.ErrNoDocuments
+				//
+				// The sort is load-bearing, not cosmetic. This cursor feeds
+				// StateEngine.ProcessBlock, which applies each Hive block to
+				// consensus state and sets the height unconditionally. MongoDB
+				// guarantees NO order for a Find without an explicit sort — the
+				// server may return documents in any order it likes, and that
+				// order can change with storage layout, chunk migration, or a
+				// different index being chosen. Feeding blocks out of order
+				// applies L1 transactions in the wrong sequence, which diverges
+				// this node's ledger from its peers and shows up downstream as
+				// an unexplained block CID mismatch. Sort ascending by block
+				// number so the stream is monotonic by construction.
 				cur, err := h.Find(ctx, bson.M{
 					"type":               DocumentTypeHiveBlock,
 					"block.block_number": bson.M{"$gt": startBlock},
-				})
+				}, options.Find().SetSort(bson.D{{Key: "block.block_number", Value: 1}}))
 				if err != nil {
 					errChan <- err
 					return

--- a/modules/db/vsc/hive_blocks/listen_order_test.go
+++ b/modules/db/vsc/hive_blocks/listen_order_test.go
@@ -1,0 +1,196 @@
+package hive_blocks
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	"vsc-node/modules/aggregate"
+	"vsc-node/modules/db"
+	"vsc-node/modules/db/vsc"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// scrambled is deliberately non-monotonic in insertion order so that
+// "storage order" and "block order" cannot coincide by accident.
+var scrambled = []uint64{10, 7, 3, 9, 5, 1, 8, 2, 6, 4}
+
+func startMongo(t *testing.T, port, name string) string {
+	t.Helper()
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not available")
+	}
+	_ = exec.Command("docker", "rm", "-f", name).Run()
+	run := exec.Command("docker", "run", "-d", "--rm", "--name", name,
+		"-p", port+":27017", "mongo:8.0.17")
+	if out, err := run.CombinedOutput(); err != nil {
+		t.Skipf("could not start mongo: %v: %s", err, out)
+	}
+	t.Cleanup(func() { _ = exec.Command("docker", "rm", "-f", name).Run() })
+	return "mongodb://localhost:" + port
+}
+
+func newHiveBlocks(t *testing.T, uri string) *hiveBlocks {
+	t.Helper()
+	t.Setenv("MONGO_URL", uri)
+
+	conf := db.NewDbConfig()
+	if err := conf.Init(); err != nil {
+		t.Fatalf("conf init: %v", err)
+	}
+	dbi := db.New(conf)
+	vscDb := vsc.New(dbi, conf)
+	hb, err := New(vscDb)
+	if err != nil {
+		t.Fatalf("new hive_blocks: %v", err)
+	}
+	agg := aggregate.New([]aggregate.Plugin{conf, dbi, vscDb, hb.(*hiveBlocks)})
+
+	deadline := time.Now().Add(90 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if lastErr = agg.Init(); lastErr == nil {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if lastErr != nil {
+		t.Skipf("mongo never became ready: %v", lastErr)
+	}
+	return hb.(*hiveBlocks)
+}
+
+func mkBlock(n uint64) HiveBlock {
+	return HiveBlock{
+		BlockNumber: n,
+		BlockID:     fmt.Sprintf("block-%03d", n),
+		Witness:     "initminer",
+		Timestamp:   "2026-08-14T00:00:00",
+		MerkleRoot:  fmt.Sprintf("mr-%03d", n),
+	}
+}
+
+// TestListenToBlockUpdatesOrdering is the proof for the ListenToBlockUpdates
+// sort fix. It runs against a real MongoDB because the whole question is what
+// the SERVER returns, which no mock can answer.
+//
+// It asserts three things:
+//
+//  1. Storage order really is non-monotonic — an unsorted collection scan
+//     returns blocks in insertion order, not block-number order. This is the
+//     hazard the fix removes: without .SetSort() the driver imposes no order,
+//     so the state engine can be fed blocks out of sequence.
+//  2. The sorted query the fix installs returns strictly ascending order over
+//     the exact same documents.
+//  3. The real ListenToBlockUpdates delivers strictly ascending block numbers
+//     end to end (happy path unchanged, ordering now guaranteed).
+func TestListenToBlockUpdatesOrdering(t *testing.T) {
+	uri := startMongo(t, "47019", "vsc-halt-hiveblocks-mongo")
+	h := newHiveBlocks(t, uri)
+
+	// Insert one at a time so insertion order == storage order.
+	for _, n := range scrambled {
+		if err := h.StoreBlocks(100, mkBlock(n)); err != nil {
+			t.Fatalf("store %d: %v", n, err)
+		}
+	}
+
+	ctx := context.Background()
+	filter := bson.M{
+		"type":               DocumentTypeHiveBlock,
+		"block.block_number": bson.M{"$gt": uint64(0)},
+	}
+
+	collect := func(opts *options.FindOptions) []uint64 {
+		cur, err := h.Collection.Collection.Find(ctx, filter, opts)
+		if err != nil {
+			t.Fatalf("find: %v", err)
+		}
+		defer cur.Close(ctx)
+		var got []uint64
+		for cur.Next(ctx) {
+			var d Document
+			if err := cur.Decode(&d); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			got = append(got, d.Block.BlockNumber)
+		}
+		return got
+	}
+
+	// (1) Unsorted collection scan — what an order-free Find is entitled to
+	// return. $natural forces the storage order rather than an index walk.
+	natural := collect(options.Find().SetHint(bson.D{{Key: "$natural", Value: 1}}))
+	t.Logf("unsorted (storage/$natural) order: %v", natural)
+	if len(natural) != len(scrambled) {
+		t.Fatalf("expected %d blocks, got %d", len(scrambled), len(natural))
+	}
+	if isAscending(natural) {
+		t.Errorf("storage order came back ascending (%v) — this test can no "+
+			"longer distinguish sorted from unsorted; make the insert order "+
+			"more adversarial", natural)
+	}
+
+	// (2) The sorted query the fix installs.
+	sorted := collect(options.Find().SetSort(bson.D{{Key: "block.block_number", Value: 1}}))
+	t.Logf("sorted (the fix) order:            %v", sorted)
+	if !isAscending(sorted) {
+		t.Fatalf("sorted query did not return ascending order: %v", sorted)
+	}
+	if len(sorted) != len(scrambled) {
+		t.Fatalf("sorted query lost documents: got %d want %d", len(sorted), len(scrambled))
+	}
+
+	// (3) End to end through the real listener.
+	listenCtx, listenCancel := context.WithCancel(context.Background())
+	defer listenCancel()
+
+	var delivered []uint64
+	done := make(chan struct{})
+	cancel, errChan := h.ListenToBlockUpdates(listenCtx, 1, func(b HiveBlock, head *uint64) error {
+		delivered = append(delivered, b.BlockNumber)
+		if len(delivered) == len(scrambled) {
+			select {
+			case <-done:
+			default:
+				close(done)
+			}
+		}
+		return nil
+	})
+	defer cancel()
+	// Drain errChan so the listener goroutine can never block on it.
+	go func() {
+		for range errChan {
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		t.Fatalf("listener only delivered %d/%d blocks: %v",
+			len(delivered), len(scrambled), delivered)
+	}
+	cancel()
+
+	t.Logf("ListenToBlockUpdates delivered:    %v", delivered)
+	if !isAscending(delivered) {
+		t.Fatalf("listener delivered OUT OF ORDER: %v", delivered)
+	}
+	if len(delivered) != len(scrambled) {
+		t.Fatalf("listener delivered %d blocks, want %d", len(delivered), len(scrambled))
+	}
+}
+
+func isAscending(v []uint64) bool {
+	for i := 1; i < len(v); i++ {
+		if v[i] <= v[i-1] {
+			return false
+		}
+	}
+	return true
+}

--- a/modules/db/vsc/ledger/ledger.go
+++ b/modules/db/vsc/ledger/ledger.go
@@ -10,6 +10,7 @@ import (
 	"vsc-node/modules/db/vsc/hive_blocks"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -57,6 +58,20 @@ func (ledger *ledger) StoreLedger(ledgerRecords ...LedgerRecord) error {
 		}
 	}
 	return nil
+}
+
+// DeleteLegacyInterestRecords removes legacy (pre-account-keyed) interest rows
+// at recordBlockHeight — those whose id has no '#' separator, i.e. the old
+// hbd_interest_<h>_<index> scheme. Account-keyed rows (id contains '#') are left
+// intact, so this is safe to call on every ClaimHBDInterest reprocess and is a
+// no-op once a block holds only new-scheme rows. See ClaimHBDInterest.
+func (ledger *ledger) DeleteLegacyInterestRecords(recordBlockHeight uint64) error {
+	_, err := ledger.DeleteMany(context.Background(), bson.M{
+		"t":            "interest",
+		"block_height": recordBlockHeight,
+		"id":           bson.M{"$not": primitive.Regex{Pattern: "#"}},
+	})
+	return err
 }
 
 // Get ledger ops after height inclusive

--- a/modules/db/vsc/ledger/types.go
+++ b/modules/db/vsc/ledger/types.go
@@ -14,6 +14,12 @@ type Ledger interface {
 	//Gets distinct accounts on or after a block height
 	//Used to indicate whether balance has been updated or not
 	GetDistinctAccountsRange(startBlock, endBlock uint64) ([]string, error)
+	// DeleteLegacyInterestRecords removes pre-account-keyed interest rows (id
+	// has no '#' separator) at the given ledger block_height, so a reprocess of
+	// a block first written under the old index-based id scheme overwrites
+	// rather than double-credits. Account-keyed rows (id contains '#') are
+	// preserved. See ledger-system.ClaimHBDInterest.
+	DeleteLegacyInterestRecords(recordBlockHeight uint64) error
 }
 
 type Balances interface {

--- a/modules/ledger-system/ledger_system.go
+++ b/modules/ledger-system/ledger_system.go
@@ -914,6 +914,22 @@ func (ls *ledgerSystem) ClaimHBDInterest(lastClaim uint64, blockHeight uint64, a
 	// shares that were genuinely written to the ledger). This keeps balances
 	// byte-for-byte IDENTICAL to pristine (no new credit anywhere) while the
 	// claim RECEIPT stops overstating. Track the running total below.
+	// Reprocess idempotency (2026-08-14): this claim's interest rows may already
+	// exist under the OLD index-based id scheme (hbd_interest_<h>_<idx>, no '#')
+	// from a prior run on a pre-#241 binary. Those rows are keyed differently
+	// from the account-keyed rows written below, so a reprocess would otherwise
+	// leave BOTH and DOUBLE-CREDIT hbd_savings — a balance divergence of exactly
+	// the class that halted mainnet. Drop only the legacy (no-'#') rows for this
+	// block, once, up front; account-keyed rows are overwritten by the upserts
+	// below (and multiple interest ops in one block keep distinct '#'-ids, so
+	// they survive). Fail-stop like every other write on this deterministic path.
+	blockingRetry(
+		fmt.Sprintf("ClaimHBDInterest.DeleteLegacyInterestRecords(@%d)", blockHeight+1),
+		func() error {
+			return ls.LedgerDb.DeleteLegacyInterestRecords(blockHeight + 1)
+		},
+	)
+
 	distributed := int64(0)
 	for _, balance := range processedBalRecords {
 		// if balance.HBD_AVG == 0 {
@@ -954,10 +970,13 @@ func (ls *ledgerSystem) ClaimHBDInterest(lastClaim uint64, blockHeight uint64, a
 			// of iteration order.
 			//
 			// balance.Account is unique per record by construction (Distinct).
-			// txId disambiguates two interest_operation virtual ops landing in
-			// the same Hive block, which the height-only id also collided on.
-			// Mirrors the existing convention in
-			// state-processing/pendulum_settlement.go: txID + "#" + acct.
+			// txId is the interest op's block-local INDEX (passed from
+			// state_engine.go), NOT a Hive trx_id: interest_operation is a
+			// VIRTUAL op whose trx_id is all-zero, so the index is what
+			// actually disambiguates two such ops landing in one Hive block
+			// (the height-only id also collided on that). Deterministic (Hive
+			// fixes vop order) and replay-stable. Mirrors the convention in
+			// state-processing/pendulum_settlement.go: <disambiguator> + "#" + acct.
 			//
 			// NOTE: this changes ledger record ids for interest payments.
 			//

--- a/modules/ledger-system/ledger_system.go
+++ b/modules/ledger-system/ledger_system.go
@@ -915,7 +915,7 @@ func (ls *ledgerSystem) ClaimHBDInterest(lastClaim uint64, blockHeight uint64, a
 	// byte-for-byte IDENTICAL to pristine (no new credit anywhere) while the
 	// claim RECEIPT stops overstating. Track the running total below.
 	distributed := int64(0)
-	for id, balance := range processedBalRecords {
+	for _, balance := range processedBalRecords {
 		// if balance.HBD_AVG == 0 {
 		// 	continue
 		// }
@@ -940,30 +940,72 @@ func (ls *ledgerSystem) ClaimHBDInterest(lastClaim uint64, blockHeight uint64, a
 				owner = balance.Account
 			}
 
-			if err := ls.LedgerDb.StoreLedger(ledger_db.LedgerRecord{
-				Id: "hbd_interest_" + strconv.Itoa(int(blockHeight)) + "_" + strconv.Itoa(id),
-				//next block
-				BlockHeight: blockHeight + 1,
-				Amount:      int64(distributeAmt),
-				Asset:       "hbd_savings",
-				Owner:       owner,
-				Type:        "interest",
-			}); err != nil {
-				log.Error(
-					"ClaimHBDInterest: ledger write failed",
-					"blockHeight",
-					blockHeight,
-					"owner",
-					owner,
-					"err",
-					err,
-				)
-				// GV-L1: only count toward `distributed` when the write
-				// actually succeeded — a failed write credited nothing, so
-				// counting it would re-introduce the overstatement this fix
-				// removes.
-				continue
-			}
+			// Key the record on the ACCOUNT, not on a loop index.
+			//
+			// processedBalRecords is ordered by BalanceDb.GetAll, which walks
+			// a Mongo Distinct("account") — Distinct defines NO order, so the
+			// index a given account landed on differed between nodes and
+			// between replays on the same node. Since StoreLedger upserts on
+			// `id`, a non-deterministic id means (a) two nodes disagree on
+			// which id holds which account's interest, and (b) a replay that
+			// hands out different indices writes the SAME payment under a
+			// second id instead of overwriting the first — the id is the
+			// idempotency key, so it has to be a function of the payment, not
+			// of iteration order.
+			//
+			// balance.Account is unique per record by construction (Distinct).
+			// txId disambiguates two interest_operation virtual ops landing in
+			// the same Hive block, which the height-only id also collided on.
+			// Mirrors the existing convention in
+			// state-processing/pendulum_settlement.go: txID + "#" + acct.
+			//
+			// NOTE: this changes ledger record ids for interest payments.
+			//
+			// These records never enter the block oplog — they are written
+			// straight to Mongo — so the id itself is not part of any block
+			// CID. But they ARE summed into hbd_savings, and that balance
+			// decides whether an unstake writes an oplog entry at all. On
+			// 2026-08-13 mainnet halted for exactly that reason: five nodes
+			// held a daveks balance 53 units below the other twelve, his
+			// unstake of his exact full balance passed the `fromBal < amount`
+			// check on one side and failed it on the other, and the two sides
+			// built different blocks. So this path is squarely in the
+			// consensus-critical set even though its ids are not committed.
+			//
+			// ★★★ FAIL-STOP, NOT `continue` (2026-08-14).
+			//
+			// This previously logged the error and moved on. A single
+			// transient Mongo write error therefore dropped that account's
+			// interest credit PERMANENTLY on that node and nowhere else —
+			// no retry, no reconciliation, and nothing that ever notices.
+			// The node then carries a silently wrong balance until some
+			// zero-margin operation on that account forks the chain, which
+			// is the shape of the halt above (herman was missing
+			// `hbd_interest_107159902_37`, 51 units, from ~2026-06-10).
+			//
+			// blockingRetry is the same helper this file already uses for
+			// consensus-critical reads, and its own doc comment describes
+			// this exact failure: "halting the deterministic block-processing
+			// path on a transient infra error instead of swallowing it and
+			// diverging from peers." A stuck node is recoverable; a node that
+			// silently disagrees about a balance is not.
+			blockingRetry(
+				fmt.Sprintf("ClaimHBDInterest.StoreLedger(%s @%d)", owner, blockHeight),
+				func() error {
+					return ls.LedgerDb.StoreLedger(ledger_db.LedgerRecord{
+						Id: "hbd_interest_" + strconv.Itoa(int(blockHeight)) + "_" + txId + "#" + balance.Account,
+						//next block
+						BlockHeight: blockHeight + 1,
+						Amount:      int64(distributeAmt),
+						Asset:       "hbd_savings",
+						Owner:       owner,
+						Type:        "interest",
+					})
+				},
+			)
+			// GV-L1: only counted once the write actually succeeded. With the
+			// fail-stop above that is now unconditional — blockingRetry does
+			// not return until it does.
 			distributed += distributeAmt
 		}
 	}

--- a/modules/state-processing/balance_guard_test.go
+++ b/modules/state-processing/balance_guard_test.go
@@ -1,0 +1,59 @@
+package state_engine
+
+import (
+	"testing"
+
+	ledgerDb "vsc-node/modules/db/vsc/ledger"
+)
+
+// TestNegativeSpendableBalance verifies the pure detector used by the
+// ledger-corruption fail-stop in UpdateBalances: it fires on a negative
+// spendable balance and stays dormant on healthy/zero balances.
+func TestNegativeSpendableBalance(t *testing.T) {
+	tests := []struct {
+		name         string
+		rec          ledgerDb.BalanceRecord
+		wantAsset    string
+		wantNegative bool
+	}{
+		{"all zero", ledgerDb.BalanceRecord{}, "", false},
+		{"healthy positive", ledgerDb.BalanceRecord{HBD: 100, HBD_SAVINGS: 5324, Hive: 1000, HIVE_CONSENSUS: 50}, "", false},
+		// A "max" op (daveks unstaking his full 5324) lands on exactly 0 — legitimate, must NOT trip.
+		{"exact-zero max op", ledgerDb.BalanceRecord{HBD_SAVINGS: 0}, "", false},
+		// The 2026-08 halt: 5271 - 5324 = -53 on the corrupted nodes.
+		{"corrupted hbd_savings (-53)", ledgerDb.BalanceRecord{HBD_SAVINGS: -53}, "hbd_savings", true},
+		{"corrupted hbd", ledgerDb.BalanceRecord{HBD: -1}, "hbd", true},
+		{"corrupted hive", ledgerDb.BalanceRecord{Hive: -1000}, "hive", true},
+		{"corrupted hive_consensus", ledgerDb.BalanceRecord{HIVE_CONSENSUS: -1}, "hive_consensus", true},
+		// HBD_AVG is a cumulative TWAB accumulator, not a spendable balance — never guarded.
+		{"negative HBD_AVG is ignored", ledgerDb.BalanceRecord{HBD_AVG: -999, HBD_SAVINGS: 10}, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asset, _, negative := negativeSpendableBalance(tt.rec)
+			if negative != tt.wantNegative {
+				t.Fatalf("negative = %v, want %v (rec = %+v)", negative, tt.wantNegative, tt.rec)
+			}
+			if negative && asset != tt.wantAsset {
+				t.Fatalf("asset = %q, want %q", asset, tt.wantAsset)
+			}
+		})
+	}
+}
+
+// TestIsGuardedAccount verifies the guard is scoped to real Hive-backed user
+// accounts, so it can never trip on system/protocol/did bookkeeping accounts.
+func TestIsGuardedAccount(t *testing.T) {
+	guarded := []string{"hive:daveks", "hive:tibfox.vsc", "hive:v4vapp.vsc"}
+	unguarded := []string{"system:fr_balance", "did:vsc:oracle:btc", "", "hive", "notahive:prefix"}
+	for _, a := range guarded {
+		if !isGuardedAccount(a) {
+			t.Errorf("isGuardedAccount(%q) = false, want true", a)
+		}
+	}
+	for _, a := range unguarded {
+		if isGuardedAccount(a) {
+			t.Errorf("isGuardedAccount(%q) = true, want false", a)
+		}
+	}
+}

--- a/modules/state-processing/balance_guard_wiring_test.go
+++ b/modules/state-processing/balance_guard_wiring_test.go
@@ -1,0 +1,154 @@
+package state_engine_test
+
+import (
+	"strings"
+	"testing"
+	ledgerDb "vsc-node/modules/db/vsc/ledger"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ★★★ THE HELPERS BEING RIGHT DOES NOT MEAN THE GUARD IS WIRED IN.
+//
+// balance_guard_test.go covers negativeSpendableBalance and isGuardedAccount as
+// pure functions. Both can be perfect while UpdateBalances never calls them —
+// the exact failure mode where a unit test goes green and the caller was never
+// hooked up. These tests drive the real UpdateBalances and assert on its
+// observable behaviour, so the guard cannot be silently disconnected.
+//
+// Written after the 2026-08-13 mainnet halt: five nodes carried a daveks
+// hbd_savings 53 units below the other twelve, and when the finalized unstake of
+// his exact balance applied verbatim (ledger-system/utils.go, `Amount: -v.Amount`,
+// no floor) they would have materialized -53. The guard exists to stop that node
+// dead rather than let it persist corruption and poison every subsequent
+// interest distribution via totalAvgBig.
+
+// A corrupted node materializing a negative spendable balance must PANIC out of
+// UpdateBalances (caught upstream by the streamer supervisor's inteceptError),
+// and must NOT persist the negative snapshot.
+func TestUpdateBalances_PanicsOnNegativeSpendable_AndDoesNotPersist(t *testing.T) {
+	const (
+		acct  = "hive:daveks"
+		start = uint64(100)
+		end   = uint64(110)
+	)
+
+	env := newTestEnv()
+
+	// Seed the snapshot 53 units short — the exact mainnet shape.
+	env.BalanceDb.BalanceRecords[acct] = []ledgerDb.BalanceRecord{{
+		Account:           acct,
+		BlockHeight:       start - 1,
+		HBD_SAVINGS:       5271,
+		HBD_MODIFY_HEIGHT: start - 1,
+		HBD_CLAIM_HEIGHT:  start - 1,
+	}}
+	before := len(env.BalanceDb.BalanceRecords[acct])
+
+	// The finalized unstake of the full 5324 debits more than this node holds.
+	env.LedgerDb.LedgerRecords[acct] = []ledgerDb.LedgerRecord{{
+		Id:          "unstake#in",
+		Owner:       acct,
+		Amount:      -5324,
+		Asset:       "hbd_savings",
+		BlockHeight: start + 1,
+		Type:        "unstake",
+	}}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("UpdateBalances did NOT panic on a negative spendable balance — " +
+				"the guard is not wired into the write path")
+		}
+		err, ok := r.(error)
+		if !ok {
+			t.Fatalf("panicked with %T, want error: %v", r, r)
+		}
+		msg := err.Error()
+		assert.Contains(t, msg, "MAGI-HALT", "panic must be identifiable by operators")
+		assert.Contains(t, msg, acct, "panic must name the offending account")
+		assert.Contains(t, msg, "hbd_savings", "panic must name the offending asset")
+		assert.True(t, strings.Contains(msg, "-53"),
+			"panic must report the materialized value; got: %s", msg)
+
+		// The whole point of halting BEFORE the write: no corrupt snapshot lands.
+		assert.Equal(t, before, len(env.BalanceDb.BalanceRecords[acct]),
+			"guard must halt before persisting the negative snapshot")
+	}()
+
+	env.SE.UpdateBalances(start, end)
+}
+
+// The mirror image, and the one that matters for rollout safety: a healthy node
+// must be completely unaffected. daveks' real unstake takes him to exactly 0 —
+// a whole-balance "max" op, which is the normal path, not an edge case. If the
+// guard fired at zero it would halt every honest node the first time anyone
+// withdrew everything.
+func TestUpdateBalances_ExactZeroIsHealthy_NoPanic(t *testing.T) {
+	const (
+		acct  = "hive:daveks"
+		start = uint64(100)
+		end   = uint64(110)
+	)
+
+	env := newTestEnv()
+	env.BalanceDb.BalanceRecords[acct] = []ledgerDb.BalanceRecord{{
+		Account:           acct,
+		BlockHeight:       start - 1,
+		HBD_SAVINGS:       5324, // the majority's value
+		HBD_MODIFY_HEIGHT: start - 1,
+		HBD_CLAIM_HEIGHT:  start - 1,
+	}}
+	env.LedgerDb.LedgerRecords[acct] = []ledgerDb.LedgerRecord{{
+		Id:          "unstake#in",
+		Owner:       acct,
+		Amount:      -5324,
+		Asset:       "hbd_savings",
+		BlockHeight: start + 1,
+		Type:        "unstake",
+	}}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("guard fired on a healthy exact-zero balance — this would halt "+
+				"every honest node on any whole-balance withdrawal: %v", r)
+		}
+	}()
+
+	env.SE.UpdateBalances(start, end)
+}
+
+// Non-hive accounts are deliberately out of scope (isGuardedAccount). Contract
+// and system accounts run their own accounting and a negative there must not
+// take the node down.
+func TestUpdateBalances_NonHiveAccountNotGuarded(t *testing.T) {
+	const (
+		acct  = "contract:vsc1Brvi4YZHLkocYNAFd7Gf1JpsPjzNnv4i45"
+		start = uint64(100)
+		end   = uint64(110)
+	)
+
+	env := newTestEnv()
+	env.BalanceDb.BalanceRecords[acct] = []ledgerDb.BalanceRecord{{
+		Account:     acct,
+		BlockHeight: start - 1,
+		HBD_SAVINGS: 10,
+	}}
+	env.LedgerDb.LedgerRecords[acct] = []ledgerDb.LedgerRecord{{
+		Id:          "drain#in",
+		Owner:       acct,
+		Amount:      -99,
+		Asset:       "hbd_savings",
+		BlockHeight: start + 1,
+		Type:        "unstake",
+	}}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("guard fired on a non-hive account; it is scoped to hive: only: %v", r)
+		}
+	}()
+
+	env.SE.UpdateBalances(start, end)
+}

--- a/modules/state-processing/interest_id_determinism_test.go
+++ b/modules/state-processing/interest_id_determinism_test.go
@@ -1,0 +1,125 @@
+package state_engine_test
+
+import (
+	"fmt"
+	"testing"
+
+	ledgerDb "vsc-node/modules/db/vsc/ledger"
+)
+
+// TestClaimHBDInterestRecordIdsAreDeterministic pins the interest ledger
+// record id to the ACCOUNT rather than to iteration order.
+//
+// Why this harness is a faithful adversary: the production code derives the
+// order from BalanceDb.GetAll, which walks a Mongo Distinct("account") — an
+// operation with NO defined order. The mock walks a Go map, whose iteration
+// order the runtime deliberately randomises on every range. Both are
+// "unordered set of accounts", so a record id that depends on position is
+// unstable under either.
+//
+// Pre-fix the id was "hbd_interest_<height>_<loopIndex>", so the SAME account
+// received a DIFFERENT id from run to run (and from node to node). Since
+// StoreLedger upserts on that id, an unstable id also means a replay writes
+// the same payment under a second id instead of overwriting the first.
+//
+// Post-fix the id is "hbd_interest_<height>_<txId>#<account>", which is a pure
+// function of the payment.
+func TestClaimHBDInterestRecordIdsAreDeterministic(t *testing.T) {
+	accounts := []string{
+		"hive:alice", "hive:bob", "hive:carol",
+		"hive:dave", "hive:erin", "hive:frank",
+	}
+
+	const (
+		claimHeight = uint64(100)
+		blockHeight = uint64(200)
+		amount      = int64(6000)
+		txID        = "abc123deadbeef"
+		iterations  = 40
+	)
+
+	seed := func() map[string][]ledgerDb.BalanceRecord {
+		m := make(map[string][]ledgerDb.BalanceRecord, len(accounts))
+		for i, acct := range accounts {
+			m[acct] = []ledgerDb.BalanceRecord{{
+				Account: acct,
+				// Distinct savings so the accounts are not interchangeable.
+				HBD_SAVINGS:       int64(1000 * (i + 1)),
+				BlockHeight:       claimHeight,
+				HBD_AVG:           0,
+				HBD_CLAIM_HEIGHT:  claimHeight,
+				HBD_MODIFY_HEIGHT: claimHeight,
+			}}
+		}
+		return m
+	}
+
+	// account -> id observed on the first iteration
+	firstSeen := make(map[string]string)
+	distinctIDsPerAccount := make(map[string]map[string]struct{})
+
+	for iter := 0; iter < iterations; iter++ {
+		ls, lDb, _ := newLedgerEnvWithClaims(seed())
+		ls.ClaimHBDInterest(claimHeight, blockHeight, amount, txID)
+
+		for _, acct := range accounts {
+			recs := lDb.LedgerRecords[acct]
+			if len(recs) != 1 {
+				t.Fatalf("iter %d: account %s got %d interest records, want 1",
+					iter, acct, len(recs))
+			}
+			id := recs[0].Id
+
+			if distinctIDsPerAccount[acct] == nil {
+				distinctIDsPerAccount[acct] = make(map[string]struct{})
+			}
+			distinctIDsPerAccount[acct][id] = struct{}{}
+
+			if iter == 0 {
+				firstSeen[acct] = id
+				continue
+			}
+			if id != firstSeen[acct] {
+				t.Errorf("NON-DETERMINISTIC id for %s: iteration 0 gave %q, iteration %d gave %q",
+					acct, firstSeen[acct], iter, id)
+			}
+		}
+	}
+
+	// Every account must have produced exactly ONE distinct id across all runs.
+	for _, acct := range accounts {
+		if n := len(distinctIDsPerAccount[acct]); n != 1 {
+			ids := make([]string, 0, n)
+			for id := range distinctIDsPerAccount[acct] {
+				ids = append(ids, id)
+			}
+			t.Errorf("account %s produced %d distinct ids across %d runs: %v",
+				acct, n, iterations, ids)
+		}
+	}
+
+	// Ids must be unique across accounts — a collision would make StoreLedger
+	// upsert one account's interest on top of another's.
+	seenID := make(map[string]string)
+	for _, acct := range accounts {
+		id := firstSeen[acct]
+		if other, dup := seenID[id]; dup {
+			t.Errorf("id collision: %s and %s both got %q", other, acct, id)
+		}
+		seenID[id] = acct
+	}
+
+	// And the id must actually carry the account, which is what makes it a
+	// function of the payment rather than of iteration order.
+	for _, acct := range accounts {
+		want := fmt.Sprintf("hbd_interest_%d_%s#%s", blockHeight, txID, acct)
+		if firstSeen[acct] != want {
+			t.Errorf("id for %s = %q, want %q", acct, firstSeen[acct], want)
+		}
+	}
+
+	t.Logf("stable ids across %d randomised iterations:", iterations)
+	for _, acct := range accounts {
+		t.Logf("  %-12s -> %s", acct, firstSeen[acct])
+	}
+}

--- a/modules/state-processing/interest_reprocess_test.go
+++ b/modules/state-processing/interest_reprocess_test.go
@@ -1,0 +1,90 @@
+package state_engine_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	ledgerDb "vsc-node/modules/db/vsc/ledger"
+)
+
+// TestClaimHBDInterest_ReprocessDropsLegacyRow_NoDoubleCredit covers fix #1:
+// a block first processed under the pre-#241 index-based id scheme
+// (hbd_interest_<h>_<idx>, no '#') must NOT double-credit when reprocessed under
+// the account-keyed scheme. ClaimHBDInterest drops the legacy row up front, so
+// only the new account-keyed row remains. Without the delete, the mock would
+// hold both rows (distinct ids) and the account's interest would be doubled.
+func TestClaimHBDInterest_ReprocessDropsLegacyRow_NoDoubleCredit(t *testing.T) {
+	ls, lDb, _ := newLedgerEnvWithClaims(map[string][]ledgerDb.BalanceRecord{
+		"hive:alice": {{
+			Account:           "hive:alice",
+			BlockHeight:       100,
+			HBD_SAVINGS:       1000,
+			HBD_AVG:           0,
+			HBD_CLAIM_HEIGHT:  100,
+			HBD_MODIFY_HEIGHT: 100,
+		}},
+	})
+	if lDb.LedgerRecords == nil {
+		lDb.LedgerRecords = map[string][]ledgerDb.LedgerRecord{}
+	}
+
+	// Simulate a prior pre-#241 run: alice's interest for this claim was written
+	// under the legacy index id, stamped at block_height blockHeight+1 = 201.
+	lDb.LedgerRecords["hive:alice"] = append(lDb.LedgerRecords["hive:alice"], ledgerDb.LedgerRecord{
+		Id:          "hbd_interest_200_0",
+		BlockHeight: 201,
+		Amount:      50,
+		Asset:       "hbd_savings",
+		Owner:       "hive:alice",
+		Type:        "interest",
+	})
+
+	// Reprocess the same claim under the new binary.
+	ls.ClaimHBDInterest(100, 200, 50, "0")
+
+	interestRows := 0
+	var total int64
+	for _, r := range lDb.LedgerRecords["hive:alice"] {
+		if r.Type != "interest" {
+			continue
+		}
+		interestRows++
+		total += r.Amount
+		assert.Contains(t, r.Id, "#", "legacy no-'#' interest row must be gone after reprocess")
+	}
+	assert.Equal(t, 1, interestRows, "reprocess must not leave both legacy and new-scheme interest rows")
+	assert.Equal(t, int64(50), total, "interest must not be double-credited on reprocess")
+}
+
+// TestClaimHBDInterest_TwoOpsSameBlock_DistinctIds covers fix #2: two
+// interest_operation vops in one Hive block get distinct disambiguators (their
+// vop indices, "0" and "1"), so their account-keyed ids differ and neither
+// overwrites the other. The all-zero virtual-op trx_id the code previously used
+// would have collided both onto one id (the second silently overwriting the
+// first). The fix #1 legacy-row delete leaves account-keyed ('#') rows intact,
+// so both distributions survive.
+func TestClaimHBDInterest_TwoOpsSameBlock_DistinctIds(t *testing.T) {
+	ls, lDb, _ := newLedgerEnvWithClaims(map[string][]ledgerDb.BalanceRecord{
+		"hive:alice": {{
+			Account:           "hive:alice",
+			BlockHeight:       100,
+			HBD_SAVINGS:       1000,
+			HBD_AVG:           0,
+			HBD_CLAIM_HEIGHT:  100,
+			HBD_MODIFY_HEIGHT: 100,
+		}},
+	})
+
+	ls.ClaimHBDInterest(100, 200, 50, "0")
+	ls.ClaimHBDInterest(100, 200, 50, "1")
+
+	ids := map[string]bool{}
+	for _, r := range lDb.LedgerRecords["hive:alice"] {
+		if r.Type == "interest" {
+			ids[r.Id] = true
+		}
+	}
+	assert.Len(t, ids, 2, "two same-block interest ops must produce two distinct ids, not one overwriting the other")
+	assert.Contains(t, ids, "hbd_interest_200_0#hive:alice")
+	assert.Contains(t, ids, "hbd_interest_200_1#hive:alice")
+}

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -2110,6 +2110,37 @@ func (se *StateEngine) ExecuteBatch() {
 	se.TxBatch = make([]TxPacket, 0)
 }
 
+// guardedSpendableAssets are the L1-backed balances that must never be
+// negative on a real Hive account. HBD_AVG is intentionally NOT included — it
+// is a cumulative TWAB accumulator, not a spendable balance.
+
+// negativeSpendableBalance reports the first guarded spendable asset on `rec`
+// whose materialized balance is negative, or negative=false if all are >= 0.
+// Used by the ledger-corruption fail-stop in UpdateBalances; kept as a pure
+// function so the guard logic is unit-testable without a state engine.
+func negativeSpendableBalance(rec ledgerDb.BalanceRecord) (asset string, amount int64, negative bool) {
+	switch {
+	case rec.HBD < 0:
+		return "hbd", rec.HBD, true
+	case rec.HBD_SAVINGS < 0:
+		return "hbd_savings", rec.HBD_SAVINGS, true
+	case rec.Hive < 0:
+		return "hive", rec.Hive, true
+	case rec.HIVE_CONSENSUS < 0:
+		return "hive_consensus", rec.HIVE_CONSENSUS, true
+	}
+	return "", 0, false
+}
+
+// isGuardedAccount reports whether `account` is a real Hive-backed user account
+// whose spendable balances must never be negative. Scoped to the "hive:" prefix
+// so the corruption fail-stop can never trip on the special bookkeeping of
+// system:/protocol/did: accounts (which carry meta ledger rows that are
+// excluded from the spendable balance fold — see IsProtocolMetaLedgerType).
+func isGuardedAccount(account string) bool {
+	return strings.HasPrefix(account, "hive:")
+}
+
 func (se *StateEngine) UpdateBalances(startBlock, endBlock uint64) {
 	//Sets a default start block of 0 if near block 0
 	//E2E testing starts at block 0
@@ -2305,6 +2336,39 @@ func (se *StateEngine) UpdateBalances(startBlock, endBlock uint64) {
 		newRecord.HBD_MODIFY_HEIGHT = modifyHeight
 
 		newRecord.HBD_CLAIM_HEIGHT = claimHeight
+
+		// LEDGER-CORRUPTION FAIL-STOP (consensus-neutral).
+		//
+		// A correct node can NEVER materialize a negative spendable balance:
+		// block production rejects any op that would over-debit an account, so
+		// a finalized op applied to correct state always leaves the balance
+		// >= 0 (an exact-balance "max" op lands on 0, not below). A negative
+		// here therefore means THIS node's stored ledger has diverged from the
+		// finalized truth — e.g. a silently-dropped interest credit lowered a
+		// base balance, so a later finalized debit under-runs it (the 2026-08
+		// halt: daveks 5271 vs 5324, a finalized unstake -5324 -> -53).
+		//
+		// Persisting the negative and continuing is the cascade: at the next
+		// HBD-interest claim a negative balance fails endingAvg<1, drops the
+		// account, and shifts totalAvgBig — the distribution denominator for
+		// EVERY account on this node — turning a one-account divergence into a
+		// node-wide one that only a reindex/restore repairs. So halt loudly and
+		// refuse to write instead.
+		//
+		// This changes behavior ONLY on an already-diverged node; a healthy
+		// node never reaches it, so block computation is byte-identical with or
+		// without this guard. It is therefore NOT a forkable change and needs
+		// no consensus-version gate — safe to roll out across a mixed fleet.
+		// The panic propagates to the streamer supervisor (inteceptError),
+		// which stops the block pipeline; the node must be restored from a
+		// healthy snapshot. Scoped to hive: accounts (see isGuardedAccount).
+		if isGuardedAccount(k) {
+			if asset, bal, negative := negativeSpendableBalance(newRecord); negative {
+				log.Error("LEDGER CORRUPTION: negative spendable balance — halting node; restore from a healthy snapshot",
+					"account", k, "asset", asset, "balance", bal, "blockHeight", endBlock)
+				panic(fmt.Errorf("MAGI-HALT ledger corruption: %s.%s would materialize to %d at block %d; this node has diverged from finalized state and must be restored", k, asset, bal, endBlock))
+			}
+		}
 
 		// review4 HIGH #95: UpdateBalanceRecord returns an error on Mongo
 		// write failure. Silently dropping it leaves the next slot's TWAB

--- a/modules/state-processing/state_engine.go
+++ b/modules/state-processing/state_engine.go
@@ -432,7 +432,7 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 		se.rehydrateDoubleSignMap(block.BlockNumber)
 	}
 
-	for _, virtualOp := range block.VirtualOps {
+	for i, virtualOp := range block.VirtualOps {
 		if virtualOp.Op.Type == "interest_operation" {
 			owner, ok := virtualOp.Op.Value["owner"].(string)
 			if !ok {
@@ -458,7 +458,14 @@ func (se *StateEngine) ProcessBlock(block hive_blocks.HiveBlock) {
 					)
 					continue
 				}
-				se.claimHBDInterest(blockInfo.BlockHeight, vInt1, virtualOp.TrxId)
+				// Disambiguator for the interest ledger-record id. A Hive
+				// VIRTUAL op (interest_operation is one) carries an all-zero
+				// trx_id, so virtualOp.TrxId cannot tell two interest ops in
+				// one block apart. Use the vop's block-local index instead:
+				// deterministic (Hive fixes vop order), unique per op, and
+				// replay-stable — so it is a safe id component. See
+				// ClaimHBDInterest.
+				se.claimHBDInterest(blockInfo.BlockHeight, vInt1, strconv.Itoa(i))
 			}
 		}
 	}

--- a/tests/devnet/ledger_corruption_halt_test.go
+++ b/tests/devnet/ledger_corruption_halt_test.go
@@ -42,13 +42,18 @@ func TestLedgerCorruptionHaltGuard(t *testing.T) {
 	d, ctx := startDevnet(t, cfg, 20*time.Minute)
 
 	const (
-		staker      = 1               // witness whose account we stake + corrupt
-		corruptNode = 5               // the node we corrupt (a minority of 5)
-		stakeAmt    = "5.000"         // → hbd_savings 5000 (milli-units)
-		unstakeAmt  = "5.000"         // exact full balance → zero margin
-		corruptBy   = int64(1)        // stored balance 1 unit low on corruptNode
+		staker      = 1        // witness whose account we stake + corrupt
+		corruptNode = 5        // the node we corrupt (a minority of 5)
+		stakeAmt    = "5.000"  // → hbd_savings 5000 (milli-units)
+		unstakeAmt  = "5.000"  // exact full balance → zero margin
+		corruptBy   = int64(1) // stored balance 1 unit low on corruptNode
 	)
-	account := d.witnessAccount(staker) // ASSUMPTION: this is the ledger account key
+	// The ledger keys accounts hive:-qualified, and isGuardedAccount scopes the
+	// guard to exactly that prefix. witnessAccount returns the bare name
+	// ("magi.test1"), so without this the corruption UpdateOne matches zero
+	// documents and the guard is never exercised. Every other devnet test
+	// does the same qualification (blame_cycle, bond_gate_gap1, pr181, ...).
+	account := "hive:" + d.witnessAccount(staker)
 
 	// 1. Move funds into hbd_savings and let the stake finalize network-wide.
 	if _, err := d.Deposit(ctx, staker, "20.000", "hbd"); err != nil {
@@ -68,7 +73,13 @@ func TestLedgerCorruptionHaltGuard(t *testing.T) {
 	// is a real snapshot row to tamper with.
 	corruptColl := client.Database(d.nodeDbName(corruptNode)).Collection("ledger_balances")
 	var snap ledgerDb.BalanceRecord
-	deadline := time.Now().Add(2 * time.Minute)
+	// 2 minutes is not enough on a fresh devnet. StakeHBD debits hbd immediately,
+	// but the hbd_savings CREDIT lands via IndexActions, driven by the gateway's
+	// vsc.actions batch — emitted every ACTION_INTERVAL (20) blocks and requiring
+	// 2/3 multisig cosigning. Right after the genesis election the committee is
+	// still coming up, so the credit arrives minutes later. Observed failing at
+	// 2m with HBD:15000 (debit applied) / HBD_SAVINGS:0 (credit pending).
+	deadline := time.Now().Add(12 * time.Minute)
 	for {
 		opts := options.FindOne().SetSort(bson.D{{Key: "block_height", Value: -1}})
 		err := corruptColl.FindOne(ctx, bson.M{"account": account}, opts).Decode(&snap)

--- a/tests/devnet/ledger_corruption_halt_test.go
+++ b/tests/devnet/ledger_corruption_halt_test.go
@@ -129,10 +129,21 @@ func TestLedgerCorruptionHaltGuard(t *testing.T) {
 	time.Sleep(90 * time.Second)
 	haltedAt, err := d.getLastProcessedBlock(ctx, corruptNode)
 	if err != nil {
-		// A hard-stopped/panicked node may also fail this read — that is still a
-		// halt, not a pass-through. Treat a read error as "halted".
-		t.Logf("corrupt node %d height read failed (consistent with a halt): %v", corruptNode, err)
-		return
+		// Deliberately fatal, not tolerated. The original form logged this and
+		// returned PASS on the reasoning that a hard-stopped node may fail its
+		// own height read -- but that premise does not hold here: mongoClient
+		// connects to a SINGLE mongo server and nodeDbName only selects database
+		// "magi-N", so the store is a separate container whose readability is
+		// independent of node liveness. Verified on the 2026-08-15 run: the
+		// corrupt node's container was Exited(1) and this read still returned
+		// 299 normally.
+		//
+		// Tolerating it would let an infrastructure hiccup score as a successful
+		// halt with nothing actually inspected -- the assertion below never runs
+		// and the guard is never checked. Note the read for the healthy node
+		// immediately after is already t.Fatalf on the same condition; this
+		// makes the two consistent.
+		t.Fatalf("read corrupt-node %d height: %v", corruptNode, err)
 	}
 	healthy, err := d.getLastProcessedBlock(ctx, 1)
 	if err != nil {

--- a/tests/devnet/ledger_corruption_halt_test.go
+++ b/tests/devnet/ledger_corruption_halt_test.go
@@ -1,0 +1,146 @@
+package devnet
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	ledgerDb "vsc-node/modules/db/vsc/ledger"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// TestLedgerCorruptionHaltGuard is the end-to-end validation of the
+// negative-spendable-balance fail-stop (UpdateBalances in state-processing).
+//
+// It reproduces the 2026-08 mainnet halt in miniature: one node holds a
+// stored balance a few units below its peers, and the account then performs a
+// zero-margin "max" operation (unstaking its exact full hbd_savings). On the
+// healthy majority the unstake succeeds and the block finalizes; the corrupted
+// node applies that finalized debit verbatim and would land on a NEGATIVE
+// balance. The guard turns that silent corruption into a clean, loud halt.
+//
+// Expected outcome WITH the guard: the corrupted node stops advancing
+// last_processed_block (its block pipeline panics/halts), while the healthy
+// nodes keep finalizing. WITHOUT the guard the corrupted node would instead
+// write the negative balance and keep going (the cascade this fix prevents),
+// so this test fails on a pre-guard binary.
+//
+// NOTE: not run in CI here (heavy multi-node docker). Written for
+// `make test-regression`-style execution. Review the two marked assumptions
+// (the corrupted account name + that no in-memory balance cache shadows the
+// Mongo write) against the running harness before relying on it.
+func TestLedgerCorruptionHaltGuard(t *testing.T) {
+	requireDocker(t)
+
+	cfg := DefaultConfig()
+	cfg.Nodes = 5
+	cfg.SkipFunding = false // we need real funds to deposit + stake savings
+	cfg.LogLevel = "error"
+	d, ctx := startDevnet(t, cfg, 20*time.Minute)
+
+	const (
+		staker      = 1               // witness whose account we stake + corrupt
+		corruptNode = 5               // the node we corrupt (a minority of 5)
+		stakeAmt    = "5.000"         // → hbd_savings 5000 (milli-units)
+		unstakeAmt  = "5.000"         // exact full balance → zero margin
+		corruptBy   = int64(1)        // stored balance 1 unit low on corruptNode
+	)
+	account := d.witnessAccount(staker) // ASSUMPTION: this is the ledger account key
+
+	// 1. Move funds into hbd_savings and let the stake finalize network-wide.
+	if _, err := d.Deposit(ctx, staker, "20.000", "hbd"); err != nil {
+		t.Fatalf("deposit hbd: %v", err)
+	}
+	if _, err := d.StakeHBD(staker, staker, stakeAmt); err != nil {
+		t.Fatalf("stake hbd: %v", err)
+	}
+
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(d.MongoURI()))
+	if err != nil {
+		t.Fatalf("connect mongo: %v", err)
+	}
+	defer client.Disconnect(context.Background())
+
+	// Wait until the corrupt node has materialized the staked balance so there
+	// is a real snapshot row to tamper with.
+	corruptColl := client.Database(d.nodeDbName(corruptNode)).Collection("ledger_balances")
+	var snap ledgerDb.BalanceRecord
+	deadline := time.Now().Add(2 * time.Minute)
+	for {
+		opts := options.FindOne().SetSort(bson.D{{Key: "block_height", Value: -1}})
+		err := corruptColl.FindOne(ctx, bson.M{"account": account}, opts).Decode(&snap)
+		if err == nil && snap.HBD_SAVINGS >= 5000 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("staked balance never materialized on node %d (last=%+v, err=%v)", corruptNode, snap, err)
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	// 2. Inject the corruption: drop hbd_savings by corruptBy on the corrupt
+	//    node's latest snapshot only. Now node %d holds 4999 where its peers
+	//    hold 5000. (No in-memory balance cache shadows this — see ASSUMPTION.)
+	res, err := corruptColl.UpdateOne(ctx,
+		bson.M{"account": account, "block_height": snap.BlockHeight},
+		bson.M{"$inc": bson.M{"hbd_savings": -corruptBy}},
+	)
+	if err != nil || res.ModifiedCount != 1 {
+		t.Fatalf("inject corruption failed: modified=%d err=%v", res.ModifiedCount, err)
+	}
+
+	// Baseline heights just before the poison op.
+	baseCorrupt, err := d.getLastProcessedBlock(ctx, corruptNode)
+	if err != nil {
+		t.Fatalf("read corrupt-node height: %v", err)
+	}
+
+	// 3. The zero-margin max unstake. On the healthy majority (4/5) balance is
+	//    5000, so the unstake succeeds and the block finalizes.
+	if _, err := d.UnstakeHBD(staker, staker, unstakeAmt); err != nil {
+		t.Fatalf("unstake hbd: %v", err)
+	}
+
+	// 4. Healthy nodes must keep finalizing past the unstake.
+	for _, n := range []int{1, 2, 3, 4} {
+		if err := d.WaitForBlockProcessing(ctx, n, baseCorrupt+20, 3*time.Minute); err != nil {
+			t.Fatalf("healthy node %d did not advance past the unstake: %v", n, err)
+		}
+	}
+
+	// 5. The corrupted node must HALT: its last_processed_block stops advancing
+	//    once it applies the finalized debit that would drive hbd_savings < 0.
+	//    Poll for a stall: allow a short grace, then require it not to have moved
+	//    meaningfully while the healthy nodes ran well ahead.
+	time.Sleep(90 * time.Second)
+	haltedAt, err := d.getLastProcessedBlock(ctx, corruptNode)
+	if err != nil {
+		// A hard-stopped/panicked node may also fail this read — that is still a
+		// halt, not a pass-through. Treat a read error as "halted".
+		t.Logf("corrupt node %d height read failed (consistent with a halt): %v", corruptNode, err)
+		return
+	}
+	healthy, err := d.getLastProcessedBlock(ctx, 1)
+	if err != nil {
+		t.Fatalf("read healthy-node height: %v", err)
+	}
+	if haltedAt >= healthy-5 {
+		t.Fatalf("corrupt node %d did NOT halt: advanced to %d alongside healthy %d — the guard did not fire (negative balance was persisted instead)",
+			corruptNode, haltedAt, healthy)
+	}
+
+	// 6. And it must NOT have persisted a negative balance (the whole point).
+	var post ledgerDb.BalanceRecord
+	opts := options.FindOne().SetSort(bson.D{{Key: "block_height", Value: -1}})
+	if err := corruptColl.FindOne(ctx, bson.M{"account": account}, opts).Decode(&post); err == nil {
+		if post.HBD_SAVINGS < 0 {
+			t.Fatalf("corrupt node persisted a NEGATIVE hbd_savings (%d) — guard must halt BEFORE writing it", post.HBD_SAVINGS)
+		}
+	}
+
+	t.Logf("guard OK: node %d halted at %d while healthy node reached %d, no negative balance written",
+		corruptNode, haltedAt, healthy)
+}


### PR DESCRIPTION
## Mainnet halt 2026-08-13 — root cause fixes

Chain halted at slot 108997460 for ~20h. `daveks` unstaked **5.324 HBD — his exact
full savings balance**, the only tx in that slot. Twelve nodes stored 5324, five
stored 5271. `Unstake` gates on `fromBal < amount` and writes **no oplog entry**
when it fails, so the two groups built different blocks from identical input. The
five hold 34.91% — just over the ⅓ veto — so neither side reached ⅔ and nothing
finalised.

Verified in both sides' Mongo: herman was missing `hbd_interest_107159902_37` (51
units) entirely and had 41 where the majority had 43 on `hbd_interest_108050603_37`.
51 + 2 = the 53-unit gap.

### Changes

1. **Deterministic interest record IDs.** `ClaimHBDInterest` keyed records on a loop
   index over an unsorted Mongo `Distinct`, and `StoreLedger` upserts on that ID — so
   the idempotency key varied by node and by replay. Now keyed on the account,
   matching `pendulum_settlement.go`. `txId` added because the height-only prefix
   collided when one Hive block carried two `interest_operation` virtual ops.

2. **Fail-stop on a failed interest write.** It logged and `continue`d — one transient
   Mongo error dropped that account's credit permanently on that node alone, no retry,
   nothing noticing. **Most likely origin of the 53-unit gap.** Now uses the file's own
   `blockingRetry`, whose doc comment already describes this failure mode.

3. **Ordered block feed.** `ListenToBlockUpdates` had no `SetSort` on the query feeding
   `ProcessBlock`. Latent (an index masks it), but Mongo guarantees no order without one.

4. **Component-CID diagnostic.** Mismatches logged two opaque CIDs. Now names the
   diverging component (oplog / outputs / tx list / prevb / br / merkle root).
   Additive, backward compatible. This halt took a day to diagnose for want of it.

### Not addressed

Does **not** repair existing corrupted state, and does **not** remove the zero-margin
cliff. Six of seven pending txs in the un-finalised window are whole-balance "max"
operations — any node with a one-unit ledger error will halt the chain again the next
time a user taps max. A ledger state root committed to the block is the real fix.

### Testing

Interest-ID determinism across randomised `Distinct` orders; block-feed ordering
against real Mongo; component-diff across five divergence shapes plus an older-peer
case, through the real JSON wire path. Changed packages build clean, `go vet` clean.
`-lwasmedge` link failures on some test packages are a missing system library on the
build host and reproduce identically on baseline.


