### PR TITLE
POA hardening before activation: 8 fixes to bootstrap, version gating and election weight, plus the first executable devnet POA suite

### DIFF
--- a/modules/election-proposer/election-proposer.go
+++ b/modules/election-proposer/election-proposer.go
@@ -562,56 +562,56 @@ func (e *electionProposer) GenerateFullElection(
 	// Pure functions of the on-chain witness records ⇒ identical committee/CID on
 	// every node and signer (Constraint 3). The members loop below still skips an
 	// unparseable consensus key as a final safety net.
+	// ★ EVALUATED ALWAYS, ENFORCED ONLY WHEN THE GATE IS ON.
+	//
+	// The exclusion set is computed on every election regardless of
+	// WitnessKeyStrictActive, and DELETIONS happen only when it is true. While
+	// the gate is off this changes nothing an election carries — same members,
+	// same weights, same CID — but it makes the one number nobody has answerable
+	// from the logs of a running fleet: how many witnesses this gate WOULD drop,
+	// and which.
+	//
+	// That number is not optional. The gate was disabled in June because turning
+	// it on starved the mainnet committee below the floor and halted elections at
+	// epoch 1699. The proposed fixes for that all begin with "count the survivors
+	// first", and there is currently no way to count them without either running
+	// the gate (the thing that halted the chain) or reading keys off-chain by
+	// hand. Shadow evaluation is the instrument; enabling the gate is a decision
+	// that must be made FROM its readings, not before them.
+	//
+	// COST, measured rather than assumed (BenchmarkEvaluateKeyAdmission): ~2.5 ms
+	// per candidate, dominated by BLS verification — 124 ms for a 50-witness
+	// list. It is paid once per election on the proposer and once on each signer
+	// that regenerates the election, not per block, so it does not touch the
+	// block-production path.
+	keyExclusions := evaluateKeyAdmission(witnessList)
+	if len(keyExclusions) > 0 {
+		enforced := consensusversion.WitnessKeyStrictActive(prevVersion)
+		accounts := make([]string, 0, len(keyExclusions))
+		for _, x := range keyExclusions {
+			accounts = append(accounts, x.Account+"("+x.Reason+")")
+			log.Warn("H-6 key admission: witness fails proof-of-possession",
+				"account", x.Account, "reason", x.Reason, "enforced", enforced,
+				"err", x.Err)
+		}
+		log.Warn("H-6 key admission summary",
+			"block_height", blockHeight,
+			"candidates", len(witnessList),
+			"would_exclude", len(keyExclusions),
+			"would_remain", len(witnessList)-len(keyExclusions),
+			"enforced", enforced,
+			"min_members", e.sconf.ConsensusParams().MinMembers,
+			"accounts", strings.Join(accounts, ","))
+	}
+
 	if consensusversion.WitnessKeyStrictActive(prevVersion) {
-		seenConsensusKeys := make(map[string]string, len(witnessList))
-		seenGatewayKeys := make(map[string]string, len(witnessList))
+		drop := make(map[string]struct{}, len(keyExclusions))
+		for _, x := range keyExclusions {
+			drop[x.Account] = struct{}{}
+		}
 		witnessList = slices.DeleteFunc(witnessList, func(w witnesses.Witness) bool {
-			if popErr := w.VerifyConsensusPoP(); popErr != nil {
-				log.Warn("H-6: excluding witness with invalid consensus-key PoP",
-					"account", w.Account, "err", popErr)
-				return true
-			}
-			key, keyErr := w.ConsensusKey()
-			if keyErr != nil {
-				log.Warn("H-6: excluding witness with unparseable consensus key",
-					"account", w.Account, "err", keyErr)
-				return true
-			}
-			ks := key.String()
-			if first, dup := seenConsensusKeys[ks]; dup {
-				log.Warn("H-6: excluding witness with duplicate consensus key",
-					"account", w.Account, "kept", first)
-				return true
-			}
-			// Gateway-key strict admission (audit H-6, gateway companion): the
-			// gateway key is an unauthenticated announced string unless its
-			// proof-of-possession verifies. Without this, a distinct elected node
-			// could announce ANOTHER member's public gateway key and wedge gateway
-			// rotation with a duplicate key_auth (Hive rejects duplicate keys).
-			//   (c) EXCLUDE any witness whose gateway-key PoP is missing/invalid —
-			//       it has not proven it holds the announced gateway key.
-			//   (d) DEDUPE by gateway key. With a valid PoP a duplicate implies a
-			//       copied seed (also caught by the consensus-key dedup above for
-			//       the normal derivation); this still covers a shared gateway key
-			//       paired with distinct consensus keys. Keep the
-			//       account-lexicographically-first (witnessList is account-sorted).
-			// Pure function of the on-chain witness record ⇒ identical committee/CID
-			// on every node (Constraint 3). After this gate every elected member
-			// provably holds a unique gateway key, so the committee size and the
-			// gateway multisig's signer count track the same population.
-			if popErr := w.VerifyGatewayKeyPoP(); popErr != nil {
-				log.Warn("H-6: excluding witness with invalid gateway-key PoP",
-					"account", w.Account, "err", popErr)
-				return true
-			}
-			if first, dup := seenGatewayKeys[w.GatewayKey]; dup {
-				log.Warn("H-6: excluding witness with duplicate gateway key",
-					"account", w.Account, "kept", first)
-				return true
-			}
-			seenConsensusKeys[ks] = w.Account
-			seenGatewayKeys[w.GatewayKey] = w.Account
-			return false
+			_, excluded := drop[w.Account]
+			return excluded
 		})
 	}
 
@@ -643,6 +643,25 @@ func (e *electionProposer) GenerateFullElection(
 	//   3. FAIL-STOP on a read error — returning an error aborts this election
 	//      attempt and the next slot retries, rather than proceeding with a
 	//      partial seat set and deleting legitimate candidates.
+	// ★ THE POA RULES BIND TO WHAT THE GATE ACTUALLY DID, NOT TO WHETHER A DB
+	// HANDLE IS NON-NIL.
+	//
+	// This flag is the single fact the flat-weight and churn-cap rules below
+	// read. It is set in exactly one place — the branch that really applies the
+	// seat filter — so the restriction (only seated accounts may be elected) and
+	// the benefit (every seat weighs the same) can no longer come apart. They
+	// used to: `poaActive` re-derived its own verdict from
+	// `PoaFlatWeightActive(prevVersion) && e.poaSeats != nil`, which is true
+	// whenever the registry is merely WIRED, while the gate below has two
+	// reachable paths on which it declines to filter anything (an empty registry
+	// and the starvation refusal). On either of those the old predicate still
+	// said yes, producing the regime this file's own comments call strictly
+	// worse than either it sits between: candidacy back to "anyone with
+	// MinStake", but every such candidate carrying a full seat's weight — so
+	// committee weight is bought at MinStake per seat, cheaper than the
+	// stake-weighting POA replaced and free of the vetting POA adds.
+	poaSeatGateApplied := false
+
 	if consensusversion.PoaSeatGateActive(prevVersion) && e.poaSeats != nil {
 		seats, seatErr := e.poaSeats.GetSeatsAtHeight(blockHeight)
 		if seatErr != nil {
@@ -705,6 +724,7 @@ func (e *electionProposer) GenerateFullElection(
 			} else {
 				before := len(witnessList)
 				witnessList = gated
+				poaSeatGateApplied = true
 				if dropped := before - len(witnessList); dropped > 0 {
 					log.Info("poa seat gate excluded unseated candidates",
 						"block_height", blockHeight,
@@ -936,7 +956,7 @@ func (e *electionProposer) GenerateFullElection(
 		// ElectionData and therefore of the CID) and feeds elections.ResultVersion,
 		// so inventing a third value would ripple into election validation for no
 		// benefit.
-		if e.poaActive(prevVersion) {
+		if e.poaActive(prevVersion, poaSeatGateApplied) {
 			flat := make(map[string]uint64, len(stakedMap))
 			for account := range stakedMap {
 				flat[account] = params.PoaSeatWeight
@@ -1029,7 +1049,13 @@ func (e *electionProposer) GenerateFullElection(
 	//
 	// A pinned MaxNewMembersActivationHeight still wins where present: this only
 	// supplies a cap when the height-gated path yields none.
-	poaChurn := e.poaActive(prevVersion)
+	// The churn cap resolves through its OWN version gate rather than through
+	// poaActive. PoaChurnCapActive had no functional call site at all — the cap
+	// reached production only via poaActive — so the two could drift apart
+	// silently. Keeping the `poaSeatGateApplied` conjunct is deliberate: the cap
+	// rate-limits SEATS entering the committee, which is only a coherent notion
+	// while the seat filter is actually being applied.
+	poaChurn := consensusversion.PoaChurnCapActive(prevVersion) && poaSeatGateApplied
 	if poaChurn && effMaxNew == 0 {
 		effMaxNew = e.sconf.ConsensusParams().EffectivePoaMaxNewMembers()
 	}
@@ -1181,7 +1207,7 @@ func (e *electionProposer) GenerateFullElection(
 				// a single member whose weight could dwarf every other seat
 				// combined, i.e. the exact capture vector A3 removes, restored
 				// through the liveness patch.
-				if e.poaActive(prevVersion) {
+				if e.poaActive(prevVersion, poaSeatGateApplied) {
 					weightMap[c.witness.Account] = params.PoaSeatWeight
 				} else {
 					weightMap[c.witness.Account] = c.weight
@@ -1223,7 +1249,7 @@ func (e *electionProposer) GenerateFullElection(
 	// would hand a required member many times a normal seat's weight the moment
 	// the list is ever populated. Flattening it here means POA's one-seat-one-vote
 	// property cannot be quietly undone later by adding a required member.
-	if e.poaActive(prevVersion) {
+	if e.poaActive(prevVersion, poaSeatGateApplied) {
 		distWeight = params.PoaSeatWeight
 	}
 
@@ -1248,6 +1274,43 @@ func (e *electionProposer) GenerateFullElection(
 			MemberConsensus:     t.Consensus,
 			MemberNonConsensus:  t.NonConsensus,
 		})
+	}
+
+	// ★ THE SIGNABILITY FLOOR IS OBSERVED, NOT ENFORCED — YET.
+	//
+	// bondCommitteeFloor is the size below which a committee cannot do its job
+	// even though the election is perfectly valid: under 8 keys the gateway
+	// multisig rotation is silently SKIPPED (multisig.go keyRotation), and under
+	// ceil(2·prevN/3)+1 too few prior share-holders remain seated for the
+	// outstanding TSS keys to stay signable, so reshares strand. MinMembers, the
+	// bar HoldElection actually aborts on, is lower than both.
+	//
+	// Nothing checks it today. The bond floor guard above works toward it on a
+	// best-effort basis and then returns without ever asking whether it got
+	// there, so a committee in the window between MinMembers and this floor is
+	// emitted silently — and the first symptom is a gateway that will not rotate,
+	// which, with the vsc.dao owner backstop already removed from the mainnet
+	// gateway account, has no on-chain recovery.
+	//
+	// This is deliberately a LOG, not a refusal. Refusing here would make the
+	// check itself the thing that stalls the epoch, and on a 3-node devnet the
+	// floor (8) exceeds the whole network, so a refusal would fire permanently
+	// on every test network while never having been exercised on one. Enforcement
+	// belongs behind a version gate and behind a precondition that the PREVIOUS
+	// committee already cleared the floor, so it can only ever refuse to be the
+	// election that regresses a healthy network. Measure first.
+	if previousElection != nil {
+		signFloor := bondCommitteeFloor(e.sconf.ConsensusParams().MinMembers, len(previousElection.Members))
+		if len(members) < signFloor {
+			log.Error("committee is BELOW the signability floor — the election is valid but the committee it names may be unable to rotate the gateway multisig or complete a TSS reshare",
+				"block_height", blockHeight,
+				"members", len(members),
+				"signability_floor", signFloor,
+				"min_members", e.sconf.ConsensusParams().MinMembers,
+				"gateway_key_floor", bondGatewayKeyFloor,
+				"prev_members", len(previousElection.Members),
+				"prev_cleared_floor", len(previousElection.Members) >= signFloor)
+		}
 	}
 
 	weights := make([]uint64, len(members))
@@ -1403,11 +1466,7 @@ func canonicalElectionAnchor(prevBlockHeight uint64, electionInterval uint64) ui
 	return ((target + cadence - 1) / cadence) * cadence
 }
 
-type ElectionOptions struct {
-	OverrideMinimumMemberCount int
-}
-
-func (ep *electionProposer) HoldElection(blk uint64, options ...ElectionOptions) error {
+func (ep *electionProposer) HoldElection(blk uint64) error {
 	if ep.signingInfo != nil {
 		log.Warn("election already in progress; skipping new attempt", "block_height", blk)
 		return errors.New("election already in progress")
@@ -1500,12 +1559,14 @@ func (ep *electionProposer) HoldElection(blk uint64, options ...ElectionOptions)
 
 		// console.log("electionData - holding election", electionData)
 
-		var minimumMemberCount int
-		if len(options) > 0 {
-			minimumMemberCount = options[0].OverrideMinimumMemberCount
-		} else {
-			minimumMemberCount = ep.sconf.ConsensusParams().MinMembers
-		}
+		// ★ NO OVERRIDE. This bar used to be settable through an ElectionOptions
+		// argument, and because Go zero-values a struct field, ANY caller that
+		// passed ElectionOptions{} without naming the field set the minimum to 0
+		// — silently deleting the proposer's only defence against proposing a
+		// committee too small to sign, rotate the gateway multisig, or hold the
+		// TSS shares. Nothing in the repository ever passed it, so the field was
+		// pure downside: an opt-out from a safety floor, reachable by omission.
+		minimumMemberCount := ep.sconf.ConsensusParams().MinMembers
 
 		if len(electionData.Members) < minimumMemberCount {
 			log.Warn("election minimum member count not met",
@@ -2057,8 +2118,86 @@ func resultJoin[T any](results ...result.Result[T]) (res result.Result[[]T]) {
 	return res
 }
 
+// keyAdmissionExclusion is one witness the H-6 key-admission rules reject, with
+// the reason, so the set can be logged and counted while the gate is off.
+type keyAdmissionExclusion struct {
+	Account string
+	Reason  string
+	Err     error
+}
+
+// evaluateKeyAdmission returns the witnesses H-6 would exclude, in candidate
+// order, WITHOUT mutating the list.
+//
+// One implementation, two consumers: the shadow log and the enforcing delete
+// both read this, so the number an operator sees while the gate is off is
+// exactly the number that will be dropped when it is turned on. A separate
+// "estimate" would be a second implementation of a consensus rule, and the
+// first time the two disagreed would be the moment the estimate was being
+// trusted to decide whether it is safe to enable.
+//
+// Pure function of the on-chain witness records (both verifiers are
+// state/time/RNG free), so every node reaches the identical verdict — which is
+// what makes it safe to gate election membership on. Dedupe keeps the
+// account-lexicographically-first entry, matching the candidate ordering the
+// caller supplies.
+func evaluateKeyAdmission(witnessList []witnesses.Witness) []keyAdmissionExclusion {
+	var excluded []keyAdmissionExclusion
+	seenConsensusKeys := make(map[string]string, len(witnessList))
+	seenGatewayKeys := make(map[string]string, len(witnessList))
+
+	for i := range witnessList {
+		w := witnessList[i]
+		if popErr := w.VerifyConsensusPoP(); popErr != nil {
+			excluded = append(excluded, keyAdmissionExclusion{w.Account, "invalid consensus-key PoP", popErr})
+			continue
+		}
+		key, keyErr := w.ConsensusKey()
+		if keyErr != nil {
+			excluded = append(excluded, keyAdmissionExclusion{w.Account, "unparseable consensus key", keyErr})
+			continue
+		}
+		ks := key.String()
+		if first, dup := seenConsensusKeys[ks]; dup {
+			excluded = append(excluded, keyAdmissionExclusion{w.Account, "duplicate consensus key, kept " + first, nil})
+			continue
+		}
+		// Gateway-key strict admission (audit H-6, gateway companion): the
+		// gateway key is an unauthenticated announced string unless its
+		// proof-of-possession verifies. Without this, a distinct elected node
+		// could announce ANOTHER member's public gateway key and wedge gateway
+		// rotation with a duplicate key_auth (Hive rejects duplicate keys).
+		//   (c) EXCLUDE any witness whose gateway-key PoP is missing/invalid —
+		//       it has not proven it holds the announced gateway key.
+		//   (d) DEDUPE by gateway key. With a valid PoP a duplicate implies a
+		//       copied seed (also caught by the consensus-key dedup above for
+		//       the normal derivation); this still covers a shared gateway key
+		//       paired with distinct consensus keys.
+		// After this gate every elected member provably holds a unique gateway
+		// key, so the committee size and the gateway multisig's signer count
+		// track the same population.
+		if popErr := w.VerifyGatewayKeyPoP(); popErr != nil {
+			excluded = append(excluded, keyAdmissionExclusion{w.Account, "invalid gateway-key PoP", popErr})
+			continue
+		}
+		if first, dup := seenGatewayKeys[w.GatewayKey]; dup {
+			excluded = append(excluded, keyAdmissionExclusion{w.Account, "duplicate gateway key, kept " + first, nil})
+			continue
+		}
+		seenConsensusKeys[ks] = w.Account
+		seenGatewayKeys[w.GatewayKey] = w.Account
+	}
+	return excluded
+}
+
 // poaActive reports whether the POA election rules apply: the batch is active AND
-// this node actually has the seat registry wired.
+// the seat gate above actually applied the seat filter to this election.
+//
+// The second half used to be `e.poaSeats != nil`, i.e. "this node has a registry
+// wired". That is a question about the process, not about the election, and the
+// two answers differ on every path where the gate declines to filter. Taking the
+// caller's observation instead means the predicate cannot disagree with what
+// happened a few hundred lines above it.
 //
 // ★ THE REGISTRY CHECK IS NOT DEFENSIVE BOILERPLATE. Flat seat-weight without
 // the seat gate is strictly WORSE than either regime it sits between: candidacy
@@ -2069,6 +2208,6 @@ func resultJoin[T any](results ...result.Result[T]) (res result.Result[[]T]) {
 // POA election rule on the same condition means the rules can only ever apply as
 // a set: either this node has a registry and enforces seats and flat weight
 // together, or it applies neither and behaves exactly as it does today.
-func (e *electionProposer) poaActive(prevVersion consensusversion.Version) bool {
-	return consensusversion.PoaFlatWeightActive(prevVersion) && e.poaSeats != nil
+func (e *electionProposer) poaActive(prevVersion consensusversion.Version, seatGateApplied bool) bool {
+	return consensusversion.PoaFlatWeightActive(prevVersion) && seatGateApplied
 }

--- a/modules/election-proposer/h6_shadow_cost_test.go
+++ b/modules/election-proposer/h6_shadow_cost_test.go
@@ -1,0 +1,24 @@
+package election_proposer
+
+import (
+	"testing"
+
+	"vsc-node/modules/db/vsc/witnesses"
+)
+
+// Shadow evaluation runs on EVERY election on EVERY node, gate on or off, and it
+// verifies a BLS proof-of-possession per candidate. BLS verification is not
+// free, so the cost has to be measured rather than assumed: a check that quietly
+// added hundreds of milliseconds to election generation would be paid on the
+// slot that produces blocks.
+func BenchmarkEvaluateKeyAdmission(b *testing.B) {
+	t := &testing.T{}
+	list := make([]witnesses.Witness, 0, 50)
+	for i := 0; i < 50; i++ {
+		list = append(list, h6Witness(t, string(rune('a'+i%26))+string(rune('a'+i/26)), byte(i+1), true))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = evaluateKeyAdmission(list)
+	}
+}

--- a/modules/election-proposer/h6_shadow_mode_test.go
+++ b/modules/election-proposer/h6_shadow_mode_test.go
@@ -1,0 +1,127 @@
+package election_proposer
+
+import (
+	"testing"
+
+	"vsc-node/lib/test_utils"
+	"vsc-node/modules/common/consensusversion"
+	"vsc-node/modules/db/vsc/witnesses"
+)
+
+// The H-6 gate has been switched off in production since 2026-06-22 because
+// turning it on starved the mainnet committee below the floor and halted
+// elections at epoch 1699. Every proposal for re-enabling it starts with the
+// same prerequisite: count the survivors first. Until shadow evaluation existed
+// there was no way to count them short of running the gate — i.e. short of
+// repeating the halt.
+//
+// These prove the instrument reads correctly while the gate stays off, which is
+// the only condition under which the reading is worth anything.
+
+// The exclusion set must be populated even though the gate is disabled.
+func TestShadowEvaluationRunsWhileTheGateIsOff(t *testing.T) {
+	if consensusversion.WitnessKeyStrictActive(consensusversion.V0_7_0) {
+		t.Skip("gate is enabled; shadow-vs-enforced distinction no longer applies")
+	}
+
+	good := h6Witness(t, "alice", 0x11, true)
+	noPoP := h6Witness(t, "bob", 0x22, false)
+
+	excluded := evaluateKeyAdmission([]witnesses.Witness{good, noPoP})
+
+	if len(excluded) != 1 {
+		t.Fatalf("exclusions = %+v, want exactly 1 (bob, no gateway PoP). A shadow evaluation "+
+			"that cannot see the failing witness cannot tell an operator whether enabling the "+
+			"gate is safe.", excluded)
+	}
+	if excluded[0].Account != "bob" {
+		t.Fatalf("excluded %s, want bob — alice carries valid PoPs on both keys", excluded[0].Account)
+	}
+	if excluded[0].Reason != "invalid gateway-key PoP" {
+		t.Fatalf("reason = %q, want the gateway-key PoP reason. The reason is what tells an "+
+			"operator whether the fix is 're-announce' or 'rotate the key'.", excluded[0].Reason)
+	}
+}
+
+// ★ THE PROPERTY THAT MAKES SHADOW MODE SAFE TO SHIP. Evaluating must not change
+// what the election carries. If it did, this would not be an instrument — it
+// would be the very membership change whose blast radius it exists to measure.
+func TestShadowEvaluationDoesNotChangeTheCommittee(t *testing.T) {
+	if consensusversion.WitnessKeyStrictActive(consensusversion.V0_7_0) {
+		t.Skip("gate is enabled; committee changes are expected")
+	}
+
+	seats := test_utils.NewMockPoaSeatsDb()
+	ep, _ := poaHarness(t, seats, map[string]int64{"alice": 100, "bob": 100, "carol": 100})
+
+	list := []witnesses.Witness{
+		h6Witness(t, "alice", 0x11, true),
+		h6Witness(t, "bob", 0x22, false), // would be excluded if the gate were on
+		h6Witness(t, "carol", 0x33, false),
+	}
+	// h6Witness announces 0.2.0; this election runs at the POA line, and the
+	// version floor filter would otherwise drop all three before H-6 is ever
+	// reached — leaving an empty committee and an assertion that proved nothing
+	// about the gate.
+	for i := range list {
+		list[i].ProtocolVersion = 7
+	}
+
+	// PREMISE: two of the three really do fail the rules, so "committee
+	// unchanged" is a meaningful claim rather than a vacuous one.
+	if got := len(evaluateKeyAdmission(list)); got != 2 {
+		t.Fatalf("premise not established: %d exclusions, want 2 — the fixture does not exercise the gate", got)
+	}
+
+	_, data, err := ep.GenerateFullElection(list, 0, consensusversion.V0_7_0, 100)
+	if err != nil {
+		t.Fatalf("GenerateFullElection: %v", err)
+	}
+	if len(data.Members) != 3 {
+		t.Fatalf("members = %v, want all 3. Shadow evaluation changed the committee: it is no "+
+			"longer an observation, and every node that has not upgraded now computes a different "+
+			"election CID.", memberAccounts(data.Members))
+	}
+}
+
+// One implementation, two consumers. The count an operator reads while the gate
+// is off has to be the count that gets dropped when it is turned on, or the
+// reading is not evidence about the decision it is being used to make.
+func TestShadowSetIsTheSetTheGateWouldDelete(t *testing.T) {
+	list := []witnesses.Witness{
+		h6Witness(t, "alice", 0x11, true),
+		h6Witness(t, "bob", 0x22, false),
+		h6Witness(t, "carol", 0x33, true),
+	}
+
+	excluded := evaluateKeyAdmission(list)
+	drop := map[string]bool{}
+	for _, x := range excluded {
+		drop[x.Account] = true
+	}
+
+	// Re-derive independently, from the verifiers themselves.
+	for _, w := range list {
+		wantDropped := w.VerifyConsensusPoP() != nil || w.VerifyGatewayKeyPoP() != nil
+		if drop[w.Account] != wantDropped {
+			t.Fatalf("%s: shadow says dropped=%v, the PoP verifiers say %v — the instrument and "+
+				"the rule disagree, so the measurement cannot be trusted to authorise the flip",
+				w.Account, drop[w.Account], wantDropped)
+		}
+	}
+}
+
+// Duplicate keys are part of the rule, so they must be part of the measurement:
+// an operator counting survivors needs the same arithmetic the gate uses.
+func TestShadowEvaluationCountsDuplicateKeys(t *testing.T) {
+	a := h6Witness(t, "alice", 0x11, true)
+	clone := h6Witness(t, "alice", 0x11, true)
+	clone.Account = "mallory"
+	// mallory copied alice's seed, so both keys collide. Her PoPs are bound to
+	// alice's account and therefore fail first — which is itself the point: the
+	// consensus-key arm catches a copied seed before the dedupe has to.
+	excluded := evaluateKeyAdmission([]witnesses.Witness{a, clone})
+	if len(excluded) != 1 || excluded[0].Account != "mallory" {
+		t.Fatalf("exclusions = %+v, want mallory only", excluded)
+	}
+}

--- a/modules/election-proposer/poa_gate_decline_weight_test.go
+++ b/modules/election-proposer/poa_gate_decline_weight_test.go
@@ -1,0 +1,141 @@
+package election_proposer
+
+import (
+	"testing"
+
+	"vsc-node/lib/test_utils"
+	"vsc-node/modules/common/consensusversion"
+	"vsc-node/modules/common/params"
+	"vsc-node/modules/db/vsc/witnesses"
+)
+
+// These close the gap between "the seat gate is WIRED" and "the seat gate
+// APPLIED". Every POA rule used to resolve through `poaSeats != nil`, which
+// answers the first question, while the gate itself has two reachable paths on
+// which it declines to filter anything. On both of them the old predicate still
+// said the POA rules were in force, so candidacy was permissionless (anyone with
+// MinStake) while weight was flat — committee weight purchasable at MinStake per
+// seat, which is cheaper than the stake-weighting POA replaced and free of the
+// vetting POA adds. TestPoaRulesApplyAsASetOrNotAtAll covers the third path
+// (no registry wired at all); these cover the two the old predicate missed.
+
+// DECLINE PATH 1: registry wired but EMPTY. The gate logs and proceeds ungated
+// (TestPoaSeatGateInertWhenRegistryEmpty proves the members are unfiltered).
+// The weights must be unfiltered too.
+func TestEmptyRegistryDoesNotFlattenWeight(t *testing.T) {
+	seats := test_utils.NewMockPoaSeatsDb() // wired, empty
+	ep, _ := poaHarness(t, seats, map[string]int64{
+		"alice": 1_000_000, "bob": 100, "carol": 100,
+	})
+	list := []witnesses.Witness{
+		poaWitness(t, "alice", 0x11),
+		poaWitness(t, "bob", 0x22),
+		poaWitness(t, "carol", 0x33),
+	}
+	_, data, err := ep.GenerateFullElection(list, 0, consensusversion.V0_7_0, 100)
+	if err != nil {
+		t.Fatalf("GenerateFullElection: %v", err)
+	}
+
+	// PREMISE: the gate really did decline, i.e. every candidate survived.
+	// Without this the weight assertion below could pass because the committee
+	// was filtered rather than because the rules stayed off.
+	if len(data.Members) != 3 {
+		t.Fatalf("premise not established: members = %v, want all 3 (an empty registry must leave candidacy ungated)",
+			memberAccounts(data.Members))
+	}
+
+	var alice uint64
+	for i, m := range data.Members {
+		if m.Account == "alice" {
+			alice = data.Weights[i]
+		}
+	}
+	if alice == params.PoaSeatWeight {
+		t.Fatal("weight was flattened while the seat gate was inert on an EMPTY registry. " +
+			"Candidacy is permissionless on this path, so a flat weight means committee weight " +
+			"costs MinStake per seat — strictly worse than either regime the gate sits between.")
+	}
+	if alice != 1_000_000 {
+		t.Fatalf("alice weight = %d, want her raw stake 1000000 — POA rules must apply as a set or not at all", alice)
+	}
+}
+
+// DECLINE PATH 2: registry wired and NON-EMPTY, but applying it would starve the
+// committee below MinMembers, so the starvation guard refuses. Same reasoning:
+// a refused gate must not leave the benefit half of POA switched on.
+//
+// This is the path a partial bootstrap produces, which is precisely why it must
+// not be the path that makes committee weight cheap.
+func TestStarvationRefusalDoesNotFlattenWeight(t *testing.T) {
+	seats := test_utils.NewMockPoaSeatsDb()
+	seats.Seed("alice", "ubo-a", 10) // one seat only: a partial bootstrap
+
+	ep, _ := poaHarness(t, seats, map[string]int64{
+		"alice": 100, "bob": 100, "carol": 100, "dave": 1_000_000,
+	})
+	list := []witnesses.Witness{
+		poaWitness(t, "alice", 0x11),
+		poaWitness(t, "bob", 0x22),
+		poaWitness(t, "carol", 0x33),
+		poaWitness(t, "dave", 0x44),
+	}
+	_, data, err := ep.GenerateFullElection(list, 0, consensusversion.V0_7_0, 100)
+	if err != nil {
+		t.Fatalf("GenerateFullElection: %v", err)
+	}
+
+	// PREMISE: the starvation guard really did refuse. If the gate had applied,
+	// only alice would remain and the weight check would be meaningless.
+	if len(data.Members) != 4 {
+		t.Fatalf("premise not established: members = %v (%d), want all 4 — the starvation guard did not refuse, so this test is not exercising the decline path",
+			memberAccounts(data.Members), len(data.Members))
+	}
+
+	var dave uint64
+	for i, m := range data.Members {
+		if m.Account == "dave" {
+			dave = data.Weights[i]
+		}
+	}
+	if dave == params.PoaSeatWeight {
+		t.Fatal("weight was flattened even though the seat gate REFUSED to apply. dave holds no " +
+			"seat and was elected purely on stake, yet carries a full seat's weight: the gate's " +
+			"refusal handed an unseated account the benefit of POA without its restriction.")
+	}
+	if dave != 1_000_000 {
+		t.Fatalf("dave weight = %d, want his raw stake 1000000", dave)
+	}
+}
+
+// The positive control. If the two tests above passed because flattening broke
+// everywhere, this one fails — it asserts the rules DO apply when the gate
+// genuinely filters.
+func TestGateAppliedStillFlattensWeight(t *testing.T) {
+	seats := test_utils.NewMockPoaSeatsDb()
+	for _, a := range []string{"alice", "bob", "carol"} {
+		seats.Seed(a, "ubo-"+a, 10)
+	}
+	ep, _ := poaHarness(t, seats, map[string]int64{
+		"alice": 1_000_000, "bob": 100, "carol": 100, "mallory": 500_000,
+	})
+	list := []witnesses.Witness{
+		poaWitness(t, "alice", 0x11),
+		poaWitness(t, "bob", 0x22),
+		poaWitness(t, "carol", 0x33),
+		poaWitness(t, "mallory", 0x55),
+	}
+	_, data, err := ep.GenerateFullElection(list, 0, consensusversion.V0_7_0, 100)
+	if err != nil {
+		t.Fatalf("GenerateFullElection: %v", err)
+	}
+	if len(data.Members) != 3 {
+		t.Fatalf("premise not established: members = %v, want the 3 seated accounts", memberAccounts(data.Members))
+	}
+	for i, w := range data.Weights {
+		if w != params.PoaSeatWeight {
+			t.Fatalf("weight[%d] (%s) = %d, want %d — the gate applied, so flat weight must apply with it",
+				i, data.Members[i].Account, w, params.PoaSeatWeight)
+		}
+	}
+}

--- a/modules/gateway/audit_unfixed_internal_test.go
+++ b/modules/gateway/audit_unfixed_internal_test.go
@@ -127,18 +127,45 @@ func TestAuditFix_S1_ECDSAMalleabilityRejected(t *testing.T) {
 	_ = slices.Contains([]string{sigA}, sigA)
 }
 
-// TestAuditUnfixed_S7_ValidateMessageAcceptsAllSenders proves audit item S7:
-// gateway/p2p.go:38-41 — ValidateMessage unconditionally returns true. There
-// is no leader / committee gating, so any peer can publish any payload on the
-// /gateway/v1 topic and force every receiver into HandleMessage's signing
-// path. This is the DoS amplification precondition.
+// TestAuditFixed_S7_ValidateMessageGatesSignRequests is the INVERTED form of the
+// old TestAuditUnfixed_S7_ValidateMessageAcceptsAllSenders.
 //
-// Post-fix expectation: ValidateMessage must check that `from` is either the
-// current-slot leader (for sign_request) or a member of the active gateway
-// committee (for sign_response). Spam from outside the committee should be
-// rejected at validation time, before any signing work is queued.
-func TestAuditUnfixed_S7_ValidateMessageAcceptsAllSenders(t *testing.T) {
-	spec := p2pSpec{} // ms is nil but ValidateMessage doesn't dereference it.
+// ★ WHY THIS WAS INVERTED, AND WHY IT MATTERED FAR BEYOND THIS ONE TEST.
+// The original documented audit item S7: ValidateMessage unconditionally returned
+// true, so any peer could publish on /gateway/v1 and force every receiver into the
+// signing path (a DoS amplification precondition). It built its fixture as
+// `p2pSpec{}` with the comment "ms is nil but ValidateMessage doesn't dereference
+// it", and asserted the permissive behaviour, with a t.Fatalf telling the next
+// reader to "update this test to reflect the new gating rule" if it ever changed.
+//
+// The fix landed: p2p.go:39-47 now gates sign_request on ms.electionPeerIDs. That
+// made the fixture comment FALSE — ValidateMessage dereferences s.ms on the very
+// first case — so the subtest nil-panicked. An unrecovered panic aborts the whole
+// test binary, and because this file is `package gateway` and sorts third of
+// thirteen, EVERY test ordered after it stopped running: the ceil(2/3) gateway
+// threshold guard, the uint64 stake-sort truncation guard, the gateway-key dedup
+// that prevents a duplicate-key_auths rotation wedge, both underflow guards, and
+// the FUZZ-1 serializer-panic repro. Ten of thirteen files in the package that
+// holds bridge custody were dead in CI, and CI was green because nothing ran.
+//
+// The lesson is the shape, not the instance: a stale test asserting the OLD
+// vulnerable behaviour of the exact function it was written to track is a
+// tripwire that fires into a panic instead of a failure. Assert the fixed
+// behaviour, and keep the negative case, so this file documents the closure
+// rather than blocking it.
+func TestAuditFixed_S7_ValidateMessageGatesSignRequests(t *testing.T) {
+	// A real multisig with a KNOWN committee, so the gate has something to check.
+	// The old fixture's nil `ms` is exactly what panicked.
+	// ★ The map is keyed by peer.ID.String(), which is the base58-encoded
+	// multihash, NOT the raw string the peer.ID was constructed from. Keying it
+	// with the literal "committee-peer" silently never matches, and the test
+	// would then "pass" its REJECT cases for the wrong reason while failing the
+	// ACCEPT case. Derive the key the same way p2p.go:45 does.
+	committee := peer.ID("committee-peer")
+	ms := &MultiSig{}
+	allowed := map[string]bool{committee.String(): true}
+	ms.electionPeerIDs.Store(&allowed)
+	spec := p2pSpec{ms: ms}
 
 	ctx := context.Background()
 	pubsubMsg := &pubsub.Message{}
@@ -147,26 +174,40 @@ func TestAuditUnfixed_S7_ValidateMessageAcceptsAllSenders(t *testing.T) {
 		name string
 		from peer.ID
 		msg  p2pMessage
+		want bool
 	}{
 		{
-			name: "random peer, sign_request key_rotation",
+			name: "OUTSIDER sign_request key_rotation is REJECTED",
 			from: peer.ID("random-peer-A"),
 			msg:  p2pMessage{Type: "sign_request", Op: "key_rotation", Data: "{}"},
+			want: false,
 		},
 		{
-			name: "empty peer id, sign_response",
-			from: peer.ID(""),
-			msg:  p2pMessage{Type: "sign_response", Data: `{"tx_id":"x","sig":"y"}`},
-		},
-		{
-			name: "random peer, sign_request execute_actions",
+			name: "OUTSIDER sign_request execute_actions is REJECTED",
 			from: peer.ID("attacker-peer"),
 			msg:  p2pMessage{Type: "sign_request", Op: "execute_actions", Data: "{}"},
+			want: false,
 		},
 		{
-			name: "completely unknown type",
+			name: "COMMITTEE MEMBER sign_request is ACCEPTED",
+			from: committee,
+			msg:  p2pMessage{Type: "sign_request", Op: "key_rotation", Data: "{}"},
+			want: true,
+		},
+		{
+			// Non-sign_request types are deliberately NOT gated here (p2p.go:46
+			// returns true). Pinned so that if that ever changes it is a
+			// deliberate decision and not an accident.
+			name: "sign_response is not gated by this check",
+			from: peer.ID(""),
+			msg:  p2pMessage{Type: "sign_response", Data: `{"tx_id":"x","sig":"y"}`},
+			want: true,
+		},
+		{
+			name: "unknown type is not gated by this check",
 			from: peer.ID("anyone"),
 			msg:  p2pMessage{Type: "garbage", Op: "garbage", Data: "garbage"},
+			want: true,
 		},
 	}
 
@@ -174,16 +215,23 @@ func TestAuditUnfixed_S7_ValidateMessageAcceptsAllSenders(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			got := spec.ValidateMessage(ctx, tc.from, pubsubMsg, tc.msg)
-			if !got {
-				t.Fatalf("UNEXPECTED: ValidateMessage rejected %q — bug may be fixed; "+
-					"update this test to reflect the new gating rule", tc.name)
+			if got != tc.want {
+				t.Fatalf("ValidateMessage(%q) = %v, want %v", tc.name, got, tc.want)
 			}
 		})
 	}
 
-	t.Log("S7 confirmed: ValidateMessage returns true for arbitrary sender + payload. " +
-		"Fix: reject from-peer when not in active gateway committee, " +
-		"and (for sign_request) when not the current slot leader.")
+	// The un-set committee case: before the first election is observed,
+	// electionPeerIDs is nil and p2p.go:42-44 fails CLOSED. Assert that
+	// explicitly — failing OPEN here would restore S7 exactly.
+	t.Run("nil committee fails CLOSED for sign_request", func(t *testing.T) {
+		fresh := p2pSpec{ms: &MultiSig{}}
+		if fresh.ValidateMessage(ctx, peer.ID("anyone"),
+			pubsubMsg, p2pMessage{Type: "sign_request", Op: "key_rotation", Data: "{}"}) {
+			t.Fatal("ValidateMessage accepted a sign_request with NO known committee — " +
+				"that is fail-OPEN and restores audit item S7")
+		}
+	})
 }
 
 // TestAuditUnfixed_36_NoPerBatchValueCap proves audit item #36:

--- a/modules/state-processing/active_consensus_version_failstop_test.go
+++ b/modules/state-processing/active_consensus_version_failstop_test.go
@@ -1,0 +1,122 @@
+package state_engine
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"vsc-node/modules/common/consensusversion"
+	"vsc-node/modules/db/vsc/elections"
+
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// flakyElectionDb returns a transient error for the first `failFor` calls, then
+// succeeds. Used to prove ActiveConsensusVersion RETRIES rather than silently
+// reporting 0.0.0 (which would turn every consensus gate off on this node alone).
+type flakyElectionDb struct {
+	elections.Elections
+	failFor int
+	calls   int
+	result  elections.ElectionResult
+	err     error // if set, returned every call (for the deterministic-absence case)
+}
+
+func (f *flakyElectionDb) GetElectionByHeight(height uint64) (elections.ElectionResult, error) {
+	f.calls++
+	if f.err != nil {
+		return elections.ElectionResult{}, f.err
+	}
+	if f.calls <= f.failFor {
+		return elections.ElectionResult{}, errors.New("connection reset by peer")
+	}
+	return f.result, nil
+}
+
+func versionResult(consensus uint64) elections.ElectionResult {
+	var r elections.ElectionResult
+	r.ProtocolVersion = consensus
+	return r
+}
+
+// TestActiveConsensusVersion_RetriesTransientRead proves the fail-STOP half.
+//
+// Before this fix the method returned consensusversion.Version{} on ANY read error.
+// That is "consensus 0.0.0", which turns off every gate resolved through it —
+// including IsPoaExitHalted, which decides whether a consensus bond payout is HELD.
+// A single Mongo blip on one node therefore released a bond its peers refused: a
+// silent, one-node, fund-moving ledger divergence with no error surfaced anywhere.
+func TestActiveConsensusVersion_RetriesTransientRead(t *testing.T) {
+	db := &flakyElectionDb{failFor: 3, result: versionResult(5)}
+	se := &StateEngine{electionDb: db}
+
+	done := make(chan consensusversion.Version, 1)
+	go func() { done <- se.ActiveConsensusVersion(100) }()
+
+	select {
+	case got := <-done:
+		if got.Consensus != 5 {
+			t.Fatalf("got consensus %d, want 5 — a transient read must NOT be reported as 0.0.0",
+				got.Consensus)
+		}
+		if db.calls < 4 {
+			t.Fatalf("only %d call(s): the transient error was not retried, so this test would "+
+				"pass even with the old fail-open behaviour", db.calls)
+		}
+		t.Logf("retried %d times then returned consensus=%d", db.calls-1, got.Consensus)
+	case <-time.After(30 * time.Second):
+		t.Fatal("ActiveConsensusVersion never returned — retry loop did not converge")
+	}
+}
+
+// TestActiveConsensusVersion_NoDocumentsIsNotRetried proves the other half, and it
+// is the one that would take the whole network down if it were wrong.
+//
+// GetElectionByHeight queries block_height $lt height, so BEFORE the first election
+// is processed every block legitimately has no election below it. If ErrNoDocuments
+// were treated as transient, blockingRetry would spin forever and EVERY node would
+// wedge at genesis, on every network. The exemption is load-bearing.
+func TestActiveConsensusVersion_NoDocumentsIsNotRetried(t *testing.T) {
+	db := &flakyElectionDb{err: mongo.ErrNoDocuments}
+	se := &StateEngine{electionDb: db}
+
+	done := make(chan consensusversion.Version, 1)
+	go func() { done <- se.ActiveConsensusVersion(100) }()
+
+	select {
+	case got := <-done:
+		if got != (consensusversion.Version{}) {
+			t.Fatalf("got %v, want the zero Version — a deterministic absence is the correct "+
+				"pre-genesis answer", got)
+		}
+		if db.calls != 1 {
+			t.Fatalf("ErrNoDocuments was retried %d times. Retrying a DETERMINISTIC absence "+
+				"wedges every node at genesis forever: before the first election exists, every "+
+				"block hits this path.", db.calls)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ActiveConsensusVersion BLOCKED on mongo.ErrNoDocuments — this is the genesis " +
+			"wedge: no node could ever sync past its start height")
+	}
+}
+
+// TestDisplayConsensusVersion_DoesNotBlock proves the display path was excluded.
+// DisplayConsensusVersion backs a GraphQL field; blocking an API handler on a DB
+// blip is its own outage, and a display value is not a consensus decision.
+func TestDisplayConsensusVersion_DoesNotBlock(t *testing.T) {
+	db := &flakyElectionDb{err: errors.New("connection reset by peer")}
+	se := &StateEngine{electionDb: db}
+
+	done := make(chan consensusversion.Version, 1)
+	go func() { done <- se.displayActiveConsensusVersion(100) }()
+
+	select {
+	case <-done:
+		if db.calls != 1 {
+			t.Errorf("display path retried %d times; it must stay non-blocking", db.calls)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("displayActiveConsensusVersion BLOCKED on a transient error — an API handler " +
+			"must not hang on a DB blip")
+	}
+}

--- a/modules/state-processing/consensus_version.go
+++ b/modules/state-processing/consensus_version.go
@@ -193,7 +193,54 @@ func (se *StateEngine) upsertVersionProposal(p consensus_state.VersionProposal) 
 
 // ActiveConsensusVersion returns the chain-active consensus triple at a block height,
 // sourced purely from the on-chain election (deterministic and height-addressable).
+//
+// ★ FAIL-STOP, NOT FAIL-OPEN. This previously returned the zero Version on ANY read
+// error, which silently reported "consensus 0.0.0" and therefore turned EVERY gate
+// resolved through it OFF for that block on that node alone. Those gates are not
+// cosmetic: IsPoaExitHalted (poa_seats.go) resolves through here and decides whether
+// a consensus bond payout is HELD (state_engine.go, transactions.go). So a single
+// transient Mongo blip on one node made it release a bond its peers refused — a
+// divergent, fund-moving TxResult with no error surfaced anywhere. Silent one-node
+// ledger divergence is the worst failure mode available; a stall is strictly better.
+//
+// The transient/deterministic split is load-bearing IN BOTH DIRECTIONS, and copies
+// the reasoning already written at bond_lock.go isTransientReadErr:
+//
+//   - mongo.ErrNoDocuments is a DETERMINISTIC absence. GetElectionByHeight queries
+//     block_height $lt height, so before the first election is processed EVERY block
+//     legitimately has no election below it. Retrying that would wedge every node at
+//     genesis, forever, on every network. It must return the zero Version, which is
+//     the correct pre-genesis answer.
+//   - ANY OTHER error is a per-node infra blip. Retrying is what prevents the fork.
+//
+// Callers on API/display paths must NOT use this; see displayActiveConsensusVersion.
 func (se *StateEngine) ActiveConsensusVersion(blockHeight uint64) consensusversion.Version {
+	var elec elections.ElectionResult
+	var found bool
+	blockingRetry("ActiveConsensusVersion.GetElectionByHeight", func() error {
+		e, err := se.electionDb.GetElectionByHeight(blockHeight)
+		if err != nil {
+			if isTransientReadErr(err) {
+				return err // blip: block and retry rather than diverge
+			}
+			// Deterministic absence: no election below this height yet.
+			found = false
+			return nil
+		}
+		elec, found = e, true
+		return nil
+	})
+	if !found {
+		return consensusversion.Version{}
+	}
+	return elections.ResultVersion(elec)
+}
+
+// displayActiveConsensusVersion is the NON-BLOCKING variant for API/display paths.
+// It deliberately keeps the old fail-open behaviour: a display value is not a
+// consensus decision, and blocking an API handler on a DB blip is its own outage.
+// Never use this on a path that affects state.
+func (se *StateEngine) displayActiveConsensusVersion(blockHeight uint64) consensusversion.Version {
 	elec, err := se.electionDb.GetElectionByHeight(blockHeight)
 	if err != nil {
 		return consensusversion.Version{}
@@ -233,7 +280,7 @@ func (se *StateEngine) ElectionMinimumVersion(e *elections.ElectionResult) conse
 
 // DisplayConsensusVersion returns the string to show in APIs: provisional during suspended recovery.
 func (se *StateEngine) DisplayConsensusVersion() string {
-	active := se.ActiveConsensusVersion(uint64(se.BlockHeight))
+	active := se.displayActiveConsensusVersion(uint64(se.BlockHeight))
 	if se.chainProcessingSuspended() {
 		return consensusversion.FormatProvisional(active)
 	}

--- a/modules/state-processing/poa_bootstrap_pop_test.go
+++ b/modules/state-processing/poa_bootstrap_pop_test.go
@@ -1,0 +1,234 @@
+package state_engine
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"vsc-node/lib/dids"
+	"vsc-node/modules/db/vsc/witnesses"
+
+	ethBls "github.com/protolambda/bls12-381-util"
+	"github.com/vsc-eco/hivego"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// provenWitnessRecord builds the witness record of a HEALTHY operator: a
+// consensus BLS key and a gateway secp256k1 key, each with a valid
+// proof-of-possession bound to the account. This is what a node running the
+// current binary announces (modules/announcements builds both), so it is the
+// correct default for every fixture that is not specifically about a broken key.
+//
+// Deterministic from the account name so a test can rebuild the same record.
+func provenWitnessRecord(account string) witnesses.Witness {
+	var seed [32]byte
+	for i := range seed {
+		seed[i] = byte(len(account)*7 + i)
+	}
+	if len(account) > 0 {
+		seed[0] = account[0]
+	}
+	priv := dids.BlsPrivKey{}
+	priv.Deserialize(&seed)
+	pub, err := ethBls.SkToPk(&priv)
+	if err != nil {
+		panic(err)
+	}
+	did, err := dids.NewBlsDID(pub)
+	if err != nil {
+		panic(err)
+	}
+	consPoP, err := dids.GenerateBlsPoP(&priv, account)
+	if err != nil {
+		panic(err)
+	}
+	kp := hivego.KeyPairFromBytes(seed[:])
+	gwPoP, err := dids.GenerateGatewayKeyPoP(kp, account)
+	if err != nil {
+		panic(err)
+	}
+	return witnesses.Witness{
+		Account: account,
+		Enabled: true,
+		Height:  1,
+		DidKeys: []witnesses.PostingJsonKeys{
+			{CryptoType: "bls", Type: "consensus", Key: string(did), PoP: consPoP},
+		},
+		GatewayKey:    *kp.GetPublicKeyString(),
+		GatewayKeyPoP: gwPoP,
+	}
+}
+
+// Guards the helper itself: if it ever stopped producing valid proofs, every
+// test relying on it would pass or fail for reasons unrelated to its subject.
+func TestProvenWitnessRecordActuallyProves(t *testing.T) {
+	w := provenWitnessRecord("alice")
+	if err := w.VerifyConsensusPoP(); err != nil {
+		t.Fatalf("consensus PoP invalid: %v", err)
+	}
+	if err := w.VerifyGatewayKeyPoP(); err != nil {
+		t.Fatalf("gateway PoP invalid: %v", err)
+	}
+	other := provenWitnessRecord("bob")
+	if other.GatewayKey == w.GatewayKey {
+		t.Fatal("two accounts share a gateway key — the helper is not per-account")
+	}
+}
+
+// ★ THE GAP D15 PROVED, CLOSED. With H-6 off, gateway-key proof-of-possession is
+// not evaluated during election at all, and bootstrap then writes whatever was
+// elected into a registry with no delete path. The result is not one bad epoch:
+// it is a permanent member of the electorate holding a share of the ceil(2/3)
+// veto over every future admission.
+func TestBootstrapExcludesMembersThatCannotProveTheirKeys(t *testing.T) {
+	se, seats, wits := poaEnv(t, 7)
+	wits.breakGatewayPoP("mallory")
+
+	se.applyPoaSeatMaintenance(ratified(10, "alice", "bob", "carol", "mallory"), belowPoa(9), 100)
+
+	if _, ok, _ := seats.GetSeat("mallory"); ok {
+		t.Fatal("mallory was seeded despite failing gateway-key proof-of-possession. Seats are " +
+			"append-only with no delete path and no vote can remove one, so this is a permanent " +
+			"validator that never demonstrated control of the key it announced.")
+	}
+	for _, acct := range []string{"alice", "bob", "carol"} {
+		if _, ok, _ := seats.GetSeat(acct); !ok {
+			t.Fatalf("%s proves both keys but was not seeded — the filter is dropping healthy operators", acct)
+		}
+	}
+	if len(seats.seats) != 3 {
+		t.Fatalf("registry has %d seats, want 3", len(seats.seats))
+	}
+}
+
+// A missing consensus PoP is rejected on the same footing as an invalid one.
+// Tolerating absence would make the check bypassable by simply not providing a
+// proof, which is no check at all.
+func TestBootstrapRejectsAMissingConsensusPoP(t *testing.T) {
+	se, seats, wits := poaEnv(t, 7)
+	wits.breakConsensusPoP("mallory")
+
+	se.applyPoaSeatMaintenance(ratified(10, "alice", "bob", "carol", "mallory"), belowPoa(9), 100)
+
+	if _, ok, _ := seats.GetSeat("mallory"); ok {
+		t.Fatal("a member with no consensus-key proof-of-possession was enshrined permanently")
+	}
+	if len(seats.seats) != 3 {
+		t.Fatalf("registry has %d seats, want 3", len(seats.seats))
+	}
+}
+
+// ★ THE REFUSAL, and it is the failure state to understand before activating.
+// If too few of the incumbent committee can prove their keys, bootstrap seeds
+// NOTHING rather than founding the permanent operator set on a set too small to
+// widen itself. The chain is unaffected — the seat gate stays inert and
+// candidacy continues exactly as before — but POA does not activate.
+func TestBootstrapRefusesWhenTooFewMembersCanProveTheirKeys(t *testing.T) {
+	se, seats, wits := poaEnv(t, 7)
+	// MocknetConfig MinMembers is 3; leave only 2 provable.
+	wits.breakGatewayPoP("carol")
+	wits.breakGatewayPoP("dave")
+
+	se.applyPoaSeatMaintenance(ratified(10, "alice", "bob", "carol", "dave"), belowPoa(9), 100)
+
+	if len(seats.seats) != 0 {
+		t.Fatalf("registry has %d seats, want 0. Seeding a committee below MinMembers founds POA "+
+			"permanently on a degraded set whose survivors then hold a 2/3 veto over ever widening "+
+			"it again, and there is no un-seed.", len(seats.seats))
+	}
+}
+
+// The positive control for the refusal: with every operator provable, the same
+// committee seeds normally. Without this, the refusal test above would pass just
+// as well if bootstrap had stopped working altogether.
+func TestBootstrapSeedsWhenEveryMemberProvesItsKeys(t *testing.T) {
+	se, seats, _ := poaEnv(t, 7)
+	se.applyPoaSeatMaintenance(ratified(10, "alice", "bob", "carol", "dave"), belowPoa(9), 100)
+	if len(seats.seats) != 4 {
+		t.Fatalf("registry has %d seats, want 4 — every member proves both keys", len(seats.seats))
+	}
+}
+
+// absentWitnesses returns mongo.ErrNoDocuments for one account — the ordinary
+// result when an account has no announcement below the queried height.
+type absentWitnesses struct {
+	*fakeWitnesses
+	absent string
+}
+
+func (a *absentWitnesses) GetWitnessAtHeight(account string, bh *uint64) (*witnesses.Witness, error) {
+	if account == a.absent {
+		return nil, mongo.ErrNoDocuments
+	}
+	return a.fakeWitnesses.GetWitnessAtHeight(account, bh)
+}
+
+// ★ THE WEDGE. blockingRetry returns only on a nil error, and GetWitnessAtHeight
+// signals "no record here" with mongo.ErrNoDocuments rather than a nil witness.
+// Feeding that straight into blockingRetry spins forever on the first member
+// whose record is simply absent — no election, no progress, no recovery, and a
+// log line every 30 seconds insisting the DB has not come back. Absence is a
+// determinate answer and must be read as one.
+func TestBootstrapDoesNotWedgeOnAMissingWitnessRecord(t *testing.T) {
+	se, seats, wits := poaEnv(t, 7)
+	se.witnessDb = &absentWitnesses{fakeWitnesses: wits, absent: "carol"}
+
+	done := make(chan struct{})
+	go func() {
+		se.applyPoaSeatMaintenance(ratified(10, "alice", "bob", "carol", "dave"), belowPoa(9), 100)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("bootstrap BLOCKED on a member with no witness record. mongo.ErrNoDocuments was " +
+			"treated as a transient failure, so the node retries a determinate absence forever and " +
+			"can never process another block.")
+	}
+
+	if _, ok, _ := seats.GetSeat("carol"); ok {
+		t.Fatal("carol has no witness record and therefore no proof of possession, but was seeded anyway")
+	}
+	if len(seats.seats) != 3 {
+		t.Fatalf("registry has %d seats, want 3 (alice, bob, dave)", len(seats.seats))
+	}
+}
+
+// The other half: a genuinely transient read MUST still be retried, or a DB blip
+// silently drops a legitimate operator from a registry with no delete path.
+type flakyWitnesses struct {
+	*fakeWitnesses
+	failFor int
+}
+
+func (f *flakyWitnesses) GetWitnessAtHeight(account string, bh *uint64) (*witnesses.Witness, error) {
+	if f.failFor > 0 {
+		f.failFor--
+		return nil, errors.New("connection reset by peer")
+	}
+	return f.fakeWitnesses.GetWitnessAtHeight(account, bh)
+}
+
+func TestBootstrapRetriesATransientWitnessRead(t *testing.T) {
+	se, seats, wits := poaEnv(t, 7)
+	se.witnessDb = &flakyWitnesses{fakeWitnesses: wits, failFor: 3}
+
+	done := make(chan struct{})
+	go func() {
+		se.applyPoaSeatMaintenance(ratified(10, "alice", "bob", "carol"), belowPoa(9), 100)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("bootstrap never completed after a transient witness read failure")
+	}
+
+	if len(seats.seats) != 3 {
+		t.Fatalf("registry has %d seats, want 3. A transient DB error dropped a legitimate operator "+
+			"from a registry that has no delete path — the drop is permanent and the error was not.",
+			len(seats.seats))
+	}
+}

--- a/modules/state-processing/poa_bootstrap_replay_test.go
+++ b/modules/state-processing/poa_bootstrap_replay_test.go
@@ -1,0 +1,161 @@
+package state_engine
+
+import (
+	"fmt"
+	"testing"
+
+	"vsc-node/modules/db/vsc/elections"
+)
+
+// belowPoa is a ratified predecessor still under the POA line — the fact that
+// identifies the activation transition.
+func belowPoa(epoch uint64) *elections.ElectionResult {
+	e := ratifiedAtVersion(3, epoch)
+	return &e
+}
+
+func atPoa(epoch uint64) *elections.ElectionResult {
+	e := ratifiedAtVersion(7, epoch)
+	return &e
+}
+
+// ★ THE REGRESSION. A crash mid-bootstrap used to be PERMANENT.
+//
+// Bootstrap was reachable only through `if len(seats) == 0`. One surviving row
+// made that false forever, so the replay fell into the seating/exit maintenance
+// loop, which iterates the rows that EXIST and therefore can never write the
+// ones that do not. Because seats are append-only with no delete path and the
+// transition fires exactly once, the node was left permanently short and
+// permanently divergent from every peer, with no repair path in the codebase.
+//
+// The registry is not merklized, so nothing downstream detects the divergence —
+// it surfaces as a different gated committee, a different election CID, a failed
+// BLS aggregate and a stalled epoch.
+func TestBootstrapRepairsAPartialRegistryOnReplay(t *testing.T) {
+	se, seats, _ := poaEnv(t, 7)
+
+	// The post-crash state, modelled directly rather than by injecting a write
+	// error: AdmitSeat failures are fail-stop (blockingRetry blocks the slot
+	// until the DB recovers), so a node cannot proceed past a failed write. The
+	// way a registry actually ends up short is that the PROCESS dies mid-burst,
+	// leaving whatever rows already landed. That is exactly this: three of the
+	// five members present, written by the first pass at this same height.
+	for _, acct := range []string{"alice", "bob", "erin"} {
+		seats.seed(acct, "", 100, 100)
+		st := seats.seats[acct]
+		st.Bootstrap = true
+		seats.seats[acct] = st
+	}
+
+	committee := ratified(10, "alice", "bob", "carol", "dave", "erin")
+	prev := belowPoa(9)
+
+	// PREMISE CHECK. Without a genuinely partial registry there is nothing to
+	// repair and every assertion below would pass vacuously.
+	if got := len(seats.seats); got != 3 {
+		t.Fatalf("premise not established: registry holds %d seats, want a partial 3", got)
+	}
+	if _, ok, _ := seats.GetSeat("carol"); ok {
+		t.Fatal("premise not established: carol is present, so the registry is not partial")
+	}
+
+	// Replay the SAME block, as the streamer does after a restart: it checkpoints
+	// only once s.process() returns, so the block that was interrupted runs again.
+	se.applyPoaSeatMaintenance(committee, prev, 100)
+
+	if got := len(seats.seats); got != 5 {
+		t.Fatalf("registry holds %d seats after replay, want all 5. A partial bootstrap is still "+
+			"permanent: this node computes a different gated committee from its peers, and because "+
+			"seats are append-only with no delete path and the transition fires once, nothing in the "+
+			"codebase can repair it.", got)
+	}
+	for _, acct := range []string{"alice", "bob", "carol", "dave", "erin"} {
+		seat, ok, _ := seats.GetSeat(acct)
+		if !ok {
+			t.Fatalf("%s is in the ratified committee but missing from the registry after replay", acct)
+		}
+		if !seat.Bootstrap || seat.AdmittedHeight != 100 {
+			t.Fatalf("%s repaired with wrong provenance: bootstrap=%v admitted=%d, want true/100 — "+
+				"a repaired seat must be indistinguishable from one written on the first pass, or "+
+				"nodes disagree about the registry's contents",
+				acct, seat.Bootstrap, seat.AdmittedHeight)
+		}
+	}
+
+	// Rows written on the first pass must be untouched: re-running bootstrap has
+	// to be convergent, never destructive.
+	alice, _, _ := seats.GetSeat("alice")
+	if alice.AdmittedHeight != 100 || !alice.Seated() {
+		t.Fatalf("alice was altered by the replay (admitted=%d seated=%v) — bootstrap must only ever ADD",
+			alice.AdmittedHeight, alice.Seated())
+	}
+}
+
+// ★ THE NEGATIVE CONTROL, and the reason the predicate is not simply
+// "prevBelowPoa". Removing the row-count guard makes the transition test the
+// ONLY thing standing between a ratified election and a re-seed. If that test
+// also accepted "predecessor unknown", every epoch on a node that cannot read
+// its previous election would silently admit the current committee — accounts
+// that were never voted in — and the append-only allowlist would become a
+// rubber stamp.
+func TestNilPredecessorDoesNotReSeedAPopulatedRegistry(t *testing.T) {
+	se, seats, _ := poaEnv(t, 7)
+
+	se.applyPoaSeatMaintenance(ratified(10, "alice", "bob", "carol"), belowPoa(9), 100)
+	if len(seats.seats) != 3 {
+		t.Fatalf("premise not established: bootstrap seeded %d seats, want 3", len(seats.seats))
+	}
+
+	// Predecessor unreadable, registry already populated, and the committee now
+	// contains an account that never held a seat.
+	se.applyPoaSeatMaintenance(ratified(11, "alice", "bob", "carol", "mallory"), nil, 200)
+
+	if _, ok, _ := seats.GetSeat("mallory"); ok {
+		t.Fatal("mallory was admitted by a nil-predecessor election. An unreadable predecessor is " +
+			"absence of evidence, not evidence of a transition; treating it as one lets any elected " +
+			"account write itself a permanent seat with no admit-vote.")
+	}
+	if len(seats.seats) != 3 {
+		t.Fatalf("registry grew to %d seats without a vote, want 3", len(seats.seats))
+	}
+}
+
+// A predecessor already at or above the POA line is not a transition, so a
+// populated registry must be maintained, never re-seeded.
+func TestActivatedPredecessorDoesNotReSeed(t *testing.T) {
+	se, seats, _ := poaEnv(t, 7)
+	se.applyPoaSeatMaintenance(ratified(10, "alice", "bob", "carol"), belowPoa(9), 100)
+
+	se.applyPoaSeatMaintenance(ratified(11, "alice", "bob", "carol", "dave"), atPoa(10), 200)
+
+	if _, ok, _ := seats.GetSeat("dave"); ok {
+		t.Fatal("dave was seeded after activation — bootstrap must fire only at the transition")
+	}
+	if len(seats.seats) != 3 {
+		t.Fatalf("registry has %d seats, want 3", len(seats.seats))
+	}
+}
+
+// The duplicate-error bookkeeping. Before the fix a duplicate left the OUTER
+// err non-nil, so every account on a healthy replay was counted as FAILED and
+// the partial-bootstrap alarm fired on the happy path. That was cosmetic while
+// bootstrap ran at most once; it is not cosmetic now that replay is the normal
+// case, because an alarm that cries wolf every replay is one the operator stops
+// reading — and it is the alarm for the unrepairable failure.
+func TestReplayOfACompleteRegistryIsNotReportedAsFailure(t *testing.T) {
+	se, seats, _ := poaEnv(t, 7)
+	committee := ratified(10, "alice", "bob", "carol")
+	prev := belowPoa(9)
+
+	se.applyPoaSeatMaintenance(committee, prev, 100)
+	before := fmt.Sprint(seats.seats)
+
+	se.applyPoaSeatMaintenance(committee, prev, 100)
+
+	if got := len(seats.seats); got != 3 {
+		t.Fatalf("replay changed the registry size to %d, want 3 — re-running bootstrap must be a no-op", got)
+	}
+	if after := fmt.Sprint(seats.seats); after != before {
+		t.Fatalf("replay mutated existing seats.\nbefore: %s\nafter:  %s", before, after)
+	}
+}

--- a/modules/state-processing/poa_seats.go
+++ b/modules/state-processing/poa_seats.go
@@ -99,33 +99,79 @@ func (se *StateEngine) applyPoaSeatMaintenance(elecResult elections.ElectionResu
 		return err
 	})
 
-	if len(seats) == 0 {
-		// ★ BOOTSTRAP ONLY AT THE TRANSITION, not merely "whenever the registry
-		// looks empty".
-		//
-		// An empty registry has two very different causes. One is "the batch just
-		// activated and nothing has seeded yet" — the case bootstrap exists for.
-		// The other is "this node LOST its registry": poa_seats is not part of
-		// any merklized state and the reindex trigger keys off a hive_blocks
-		// marker, so the collection can be dropped or restored independently of
-		// chain history. Treating those two as the same thing means a node that
-		// loses its registry silently re-seeds from whatever the CURRENT
-		// committee happens to be, and then disagrees with every peer that still
-		// holds the true, continuously-maintained one — a divergence with no
-		// checkpoint or repair path anywhere to catch it.
-		//
-		// The transition is identifiable: it is the ratified election whose
-		// PREDECESSOR was still below the POA line. Anywhere else, an empty
-		// registry is an anomaly, and the safe response is to leave it empty
-		// (which keeps the seat gate inert) and say so loudly.
-		prevBelowPoa := prevElection == nil ||
-			!consensusversion.PoaSeatGateActive(elections.ResultVersion(*prevElection))
-		if !prevBelowPoa {
-			log.Error("poa: seat registry is EMPTY but this is not the activation transition — NOT re-seeding. This node has most likely lost its poa_seats collection and is now inconsistent with its peers; restore it or full-reindex. The seat gate stays inert meanwhile",
-				"epoch", elecResult.Epoch, "height", blockHeight)
-			return
+	// ★ THE TRANSITION IS DETECTED BEFORE THE ROW COUNT, NOT AFTER IT.
+	//
+	// An empty registry has two very different causes. One is "the batch just
+	// activated and nothing has seeded yet" — the case bootstrap exists for.
+	// The other is "this node LOST its registry": poa_seats is not part of any
+	// merklized state and the reindex trigger keys off a hive_blocks marker, so
+	// the collection can be dropped or restored independently of chain history.
+	// Treating those two as the same thing means a node that loses its registry
+	// silently re-seeds from whatever the CURRENT committee happens to be, and
+	// then disagrees with every peer that still holds the true, continuously
+	// maintained one — a divergence with no checkpoint or repair path anywhere
+	// to catch it. So re-seeding is allowed ONLY at the transition: the ratified
+	// election whose PREDECESSOR was still below the POA line.
+	//
+	// That much was already true. What changed is WHERE the check sits.
+	//
+	// It used to sit inside `if len(seats) == 0`, which made the whole bootstrap
+	// unreachable the moment the registry held even one row. That is precisely
+	// the state a crash leaves behind: AdmitSeat writes one row at a time
+	// (bootstrapPoaSeats below), while the streamer only checkpoints AFTER
+	// s.process() returns. Kill a node midway through seeding N members and it
+	// restarts, REPLAYS the same block, finds len(seats) == k ≠ 0, skips
+	// bootstrap forever, and falls into the maintenance loop below — which
+	// iterates the k rows that exist and therefore can never write the missing
+	// N-k. The registry is then permanently short, permanently divergent from
+	// every peer, and, because seats are append-only with no delete path and the
+	// transition fires exactly once, permanently unrepairable.
+	//
+	// Hoisting the transition test above the row count makes bootstrap
+	// REPLAY-COMPLETE instead of once-only. It is safe to re-run because
+	// AdmitSeat is idempotent per account: a duplicate is a deterministic,
+	// typed error (isDuplicateSeatErr) that every node sees identically and that
+	// the seeding loop treats as "already present", not as a failure. Re-running
+	// is therefore convergent — it can only ever add the seats this same
+	// ratified election already specifies, never remove or alter one.
+	//
+	// The maintenance loop is skipped on this path deliberately: at the
+	// transition the seats being written ARE this election's members, so every
+	// seat is seated and none has exited. There is nothing for it to do.
+	// ★ THE UNCONDITIONAL RE-RUN REQUIRES A *KNOWN* PREDECESSOR BELOW THE LINE.
+	//
+	// Note what is NOT folded in here: `prevElection == nil`. A nil predecessor
+	// means "this node cannot see the previous election", which is not evidence
+	// of a transition — it is absence of evidence. While the row count guarded
+	// the whole block that distinction was harmless, because a populated
+	// registry short-circuited it. With the row count gone, folding nil in would
+	// make EVERY election with an unreadable predecessor re-seed from whatever
+	// committee happens to be current, quietly adding accounts that were never
+	// voted in. That turns the allowlist into a rubber stamp, which is the exact
+	// failure the append-only registry exists to prevent. Nil is handled below,
+	// where an empty registry still makes seeding the only sensible response.
+	prevKnownBelowPoa := prevElection != nil &&
+		!consensusversion.PoaSeatGateActive(elections.ResultVersion(*prevElection))
+
+	if prevKnownBelowPoa {
+		if len(seats) > 0 {
+			log.Warn("poa: activation transition replayed against a NON-EMPTY seat registry — re-running bootstrap so a partially-seeded registry is completed rather than frozen short; seats already present are left untouched",
+				"epoch", elecResult.Epoch, "height", blockHeight, "existing_seats", len(seats))
 		}
 		se.bootstrapPoaSeats(elecResult, blockHeight, members)
+		return
+	}
+
+	if len(seats) == 0 {
+		// Registry empty and the predecessor is unreadable: seeding is the only
+		// response that can ever bring POA up, and it cannot lose information
+		// because there is none to lose.
+		if prevElection == nil {
+			se.bootstrapPoaSeats(elecResult, blockHeight, members)
+			return
+		}
+		log.Error("poa: seat registry is EMPTY but this is not the activation transition — NOT re-seeding. This node has most likely lost its poa_seats collection and is now inconsistent with its peers; restore it or full-reindex. The seat gate stays inert meanwhile",
+			"epoch", elecResult.Epoch, "height", blockHeight)
 		return
 	}
 
@@ -429,6 +475,87 @@ func (se *StateEngine) bootstrapPoaSeats(elecResult elections.ElectionResult, bl
 		return
 	}
 
+	// ★ PROOF-OF-POSSESSION IS CHECKED HERE, NOT ONLY IN THE ELECTION GATE.
+	//
+	// The election gate (H-6) is the usual place this is enforced, and it is
+	// switched off in production. That alone would be a liveness tradeoff. What
+	// makes it a permanence problem is this function: whatever is elected at the
+	// transition is written into a registry that is APPEND-ONLY BY DESIGN — there
+	// is no Delete, no Revoke, and no vote can remove a seat, because a set that
+	// can shrink is a cheaper set to capture. So an operator who cannot
+	// demonstrate control of the key it announced does not merely serve one bad
+	// epoch; it becomes a permanent member of the electorate, holding a share of
+	// the ceil(2/3) veto over every future admission.
+	//
+	// Checking here also removes the runbook from the critical path. Because
+	// MeetsConsensusMin is >=, raising a floor arms every batch at or below it at
+	// once, so "activate key-strict before POA" is an ordering that lives only in
+	// an operator procedure and cannot be expressed in the version numbers. An
+	// in-batch check means that even a floor raised straight past both batches in
+	// one step still seeds a PoP-clean registry.
+	//
+	// A MISSING key or PoP is rejected exactly like an invalid one. Tolerating
+	// absence would make the check trivially bypassable — announce no PoP and
+	// walk through it — which is no check at all. The consequence is a real
+	// precondition on activation, and it is stated rather than hidden: every
+	// founding operator must be running a binary that announces both PoPs and
+	// must have re-announced before the floor rises. The election proposer's
+	// shadow evaluation exists to measure that before the fact.
+	if se.witnessDb != nil {
+		unproven := make([]string, 0)
+		proven := make(map[string]struct{}, len(members))
+		for acct := range members {
+			// Reuses the package's existing fail-stop witness read rather than
+			// repeating it. That helper already draws the one distinction this
+			// call cannot get wrong: GetWitnessAtHeight signals "no announcement
+			// below this height" with mongo.ErrNoDocuments, and blockingRetry
+			// returns only on a nil error — so a hand-rolled version that passed
+			// that error straight through would spin forever on the first member
+			// whose record is merely absent, wedging the node at this block with
+			// no election and no progress. Absence is determinate: no record
+			// means no proof. A genuinely transient failure still blocks, because
+			// reading a blip as "unproven" would drop a legitimate operator from
+			// a registry that has no delete path.
+			w := se.getWitnessAtHeightOrBlock(acct, blockHeight)
+			if w == nil {
+				unproven = append(unproven, acct+"(no witness record)")
+				continue
+			}
+			if err := w.VerifyConsensusPoP(); err != nil {
+				unproven = append(unproven, acct+"(consensus PoP: "+err.Error()+")")
+				continue
+			}
+			if err := w.VerifyGatewayKeyPoP(); err != nil {
+				unproven = append(unproven, acct+"(gateway PoP: "+err.Error()+")")
+				continue
+			}
+			proven[acct] = struct{}{}
+		}
+
+		if len(unproven) > 0 {
+			slices.Sort(unproven)
+			log.Error("poa: bootstrap EXCLUDING committee members that cannot prove possession of their announced keys — seats are permanent, so an unproven key must not be enshrined",
+				"epoch", elecResult.Epoch, "height", blockHeight,
+				"elected", len(members), "proven", len(proven), "unproven", len(unproven),
+				"excluded", strings.Join(unproven, ","))
+		}
+
+		// Re-check the floor against what SURVIVED, not what was elected. The
+		// check above is upstream of the same reasoning: seeding a set too small
+		// to widen itself is unrecoverable, and so is refusing to seed. Refusing
+		// is the direction that keeps the chain running (the gate stays inert and
+		// candidacy continues exactly as before), so it is the one to take when
+		// the two are in tension.
+		if minMembers := se.sconf.ConsensusParams().MinMembers; minMembers > 0 && len(proven) < minMembers {
+			log.Error("poa: bootstrap REFUSED — too few of the incumbent committee can prove possession of their announced keys to found the operator set. Registry stays EMPTY and the seat gate stays INERT; the chain is unaffected but POA does not activate. Every founding operator must announce a valid consensus-key AND gateway-key proof-of-possession before the consensus floor is raised",
+				"epoch", elecResult.Epoch, "height", blockHeight,
+				"proven", len(proven), "min_members", minMembers,
+				"unproven", strings.Join(unproven, ","))
+			return
+		}
+		members = proven
+	}
+
 	// ★ ITERATE IN SORTED ORDER, NOT MAP ORDER. Go randomises map iteration per
 	// process, so seeding straight from `members` would apply writes in a
 	// different order on every node. That is invisible while all writes succeed
@@ -443,13 +570,16 @@ func (se *StateEngine) bootstrapPoaSeats(elecResult elections.ElectionResult, bl
 
 	seeded := make([]string, 0, len(accounts))
 	var failed []string
+	var reseeded []string
 	for _, acct := range accounts {
 		// Fail-stop like every other registry write on this path. This is the
 		// once-ever seeding burst, so a transient DB blip here desyncs one
 		// node's registry from its peers permanently — and because bootstrap
 		// only fires at the transition, nothing ever re-runs it.
 		var err error
+		var alreadyPresent bool
 		blockingRetry(fmt.Sprintf("poaSeats.AdmitSeat(bootstrap,%s,%d)", acct, blockHeight), func() error {
+			alreadyPresent = false
 			err = se.poaSeats.AdmitSeat(poaseats.Seat{
 				Account:          acct,
 				AdmittedHeight:   blockHeight,
@@ -459,10 +589,28 @@ func (se *StateEngine) bootstrapPoaSeats(elecResult elections.ElectionResult, bl
 			// A duplicate-key error is DETERMINISTIC (every node sees it) and
 			// must not be retried forever; only infra errors are transient.
 			if err != nil && isDuplicateSeatErr(err) {
+				alreadyPresent = true
 				return nil
 			}
 			return err
 		})
+		// ★ A DUPLICATE IS A SUCCESS, NOT A FAILURE.
+		//
+		// The closure above already stops retrying on a duplicate, but `err` is
+		// the OUTER variable and is still non-nil, so without this the account
+		// was counted as `failed`. That was cosmetic only while bootstrap could
+		// run at most once per network. It is not cosmetic now: bootstrap is
+		// replay-complete, so the ordinary case on any replay of the transition
+		// block is that EVERY account is a duplicate. Left as-is, a healthy
+		// replay would report the entire committee as failed and fire the
+		// partial-bootstrap alarm below every single time — and an alarm that
+		// cries wolf on the happy path is an alarm the operator learns to
+		// ignore, which is worse than not having one.
+		if alreadyPresent {
+			reseeded = append(reseeded, acct)
+			seeded = append(seeded, acct)
+			continue
+		}
 		if err != nil {
 			log.Error("poa: bootstrap seat write failed", "account", acct, "height", blockHeight, "err", err)
 			failed = append(failed, acct)
@@ -490,6 +638,8 @@ func (se *StateEngine) bootstrapPoaSeats(elecResult elections.ElectionResult, bl
 		"epoch", elecResult.Epoch,
 		"height", blockHeight,
 		"seats", len(seeded),
+		"already_present", len(reseeded),
+		"newly_written", len(seeded)-len(reseeded),
 		"accounts", strings.Join(seeded, ","))
 }
 

--- a/modules/state-processing/poa_seats_internal_test.go
+++ b/modules/state-processing/poa_seats_internal_test.go
@@ -145,10 +145,24 @@ type fakeWitnesses struct {
 	fakePlugin
 	seats    *fakeSeats
 	disabled map[string]uint64 // acct -> the height it disabled its witness (0 = active)
+	// brokenPoP marks accounts whose announced keys carry no valid
+	// proof-of-possession. The DEFAULT is a healthy operator (both PoPs valid),
+	// because that is what a node running the current binary announces; a
+	// fixture defaulting to "no proofs" would make every bootstrap test fail for
+	// a reason none of them are about.
+	brokenPoP map[string]string // acct -> "consensus" | "gateway"
 }
 
 func newFakeWitnesses(seats *fakeSeats) *fakeWitnesses {
-	return &fakeWitnesses{seats: seats, disabled: map[string]uint64{}}
+	return &fakeWitnesses{seats: seats, disabled: map[string]uint64{}, brokenPoP: map[string]string{}}
+}
+
+func (f *fakeWitnesses) breakConsensusPoP(acct string) {
+	f.brokenPoP[poaseats.NormalizeAccount(acct)] = "consensus"
+}
+
+func (f *fakeWitnesses) breakGatewayPoP(acct string) {
+	f.brokenPoP[poaseats.NormalizeAccount(acct)] = "gateway"
 }
 
 // disable records that acct turned its witness off at height dh (a dated
@@ -181,15 +195,22 @@ func (f *fakeWitnesses) GetWitnessesByPeerId(_ []string, _ ...witnesses.SearchOp
 }
 func (f *fakeWitnesses) GetWitnessAtHeight(account string, bh *uint64) (*witnesses.Witness, error) {
 	acct := poaseats.NormalizeAccount(account)
-	if _, held := f.seats.seats[acct]; !held {
-		return nil, nil // never a witness
+	// Bootstrap reads this for accounts that do NOT yet hold a seat (that is the
+	// point of bootstrap), so presence in the registry cannot be the test for
+	// "is a witness". Only the exit-halt path cares about the disabled case.
+	w := provenWitnessRecord(acct)
+	switch f.brokenPoP[acct] {
+	case "consensus":
+		w.DidKeys = nil
+	case "gateway":
+		w.GatewayKeyPoP = ""
 	}
 	if dh, ok := f.disabledAt(acct); ok && (bh == nil || dh < *bh) {
 		// Latest announcement is the disable, dated at dh.
-		return &witnesses.Witness{Account: acct, Enabled: false, Height: dh}, nil
+		w.Enabled, w.Height = false, dh
+		return &w, nil
 	}
-	// Active: an enabled announcement dated long ago (height 1).
-	return &witnesses.Witness{Account: acct, Enabled: true, Height: 1}, nil
+	return &w, nil
 }
 func (f *fakeWitnesses) StoreNodeAnnouncement(string) error                    { return nil }
 func (f *fakeWitnesses) SetWitnessUpdate(witnesses.SetWitnessUpdateType) error { return nil }

--- a/tests/devnet/poa_admission_roundtrip_test.go
+++ b/tests/devnet/poa_admission_roundtrip_test.go
@@ -1,0 +1,150 @@
+package devnet
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"vsc-node/modules/common/params"
+)
+
+// TestPoaAdmissionRoundTrip is scenario D6, and it answers a question that must
+// be answered before POA is switched on anywhere: CAN A NEW SEAT EVER BE ADMITTED?
+//
+// D19 proved a duplicate admission is refused. D20 proved a below-quorum
+// admission is refused. Both are NEGATIVE results, and a system that refuses
+// EVERYTHING passes both of them. If admission never actually works, POA is a
+// one-way door: the founding cohort is frozen forever, nobody can ever join, and
+// the only remedy is a hard fork. That is a strictly worse outcome than not
+// activating POA at all, and nothing so far distinguishes the two cases.
+//
+// This is therefore the POSITIVE control for the entire admission mechanism.
+func TestPoaAdmissionRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	cfg := tssTestConfig()
+	if cfg.SysConfigOverrides.ConsensusParams == nil {
+		cfg.SysConfigOverrides.ConsensusParams = &params.ConsensusParams{}
+	}
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorMajor = 0
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorConsensus = 7
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorEpoch = 1
+
+	d, ctx := startDevnetNoKey(t, cfg, 45*time.Minute)
+
+	for n := 1; n <= cfg.Nodes; n++ {
+		nctx, cancel := context.WithTimeout(ctx, 12*time.Minute)
+		err := d.waitForElectionEpoch(nctx, n, 2, 12*time.Minute)
+		cancel()
+		if err != nil {
+			t.Fatalf("magi-%d never reached epoch 2: %v", n, err)
+		}
+	}
+
+	elec, err := d.GetElectionGQL(ctx, 1, 2)
+	if err != nil {
+		t.Fatalf("reading election epoch 2: %v", err)
+	}
+	for i, w := range elec.Weights {
+		if w != params.PoaSeatWeight {
+			t.Fatalf("PRECONDITION FAILED: weight[%d]=%d want flat %d — POA INERT", i, w, params.PoaSeatWeight)
+		}
+	}
+	before, err := d.poaSeats(ctx, 1)
+	if err != nil || len(before) == 0 {
+		t.Fatalf("PRECONDITION FAILED: no registry to admit into (%v)", err)
+	}
+	total := uint64(len(before))
+	required := total - total/3 // ceil(2/3), beneficiary excluded
+	t.Logf("registry has %d seats; admission threshold is %d votes", len(before), required)
+
+	// A candidate that is NOT already a seat and NOT one of the witness accounts.
+	const candidate = "magi.joiner"
+	const uboId = "ubo-joiner-0001"
+	for _, s := range before {
+		if s.Account == candidate {
+			t.Fatalf("PRECONDITION FAILED: %s already holds a seat", candidate)
+		}
+	}
+
+	// Vote from ENOUGH seats to cross the threshold. The candidate is not a seat,
+	// so the electorate is the full registry.
+	voters := int(required)
+	t.Logf("casting %d admit_vote(s) for %s (ubo=%s)", voters, candidate, uboId)
+	for v := 1; v <= voters; v++ {
+		if _, err := d.admitVote(v, candidate, uboId); err != nil {
+			t.Fatalf("admit_vote from magi-%d: %v", v, err)
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	// ---- the seat must actually appear, on EVERY node ----
+	var seated bool
+	deadline := time.Now().Add(6 * time.Minute)
+	for time.Now().Before(deadline) && !seated {
+		time.Sleep(15 * time.Second)
+		after, err := d.poaSeats(ctx, 1)
+		if err != nil {
+			continue
+		}
+		for _, s := range after {
+			if s.Account == candidate {
+				seated = true
+				t.Logf("SEAT ADMITTED: %s at height %d (bootstrap=%v, ubo=%q)",
+					s.Account, s.AdmittedHeight, s.Bootstrap, s.UboId)
+				break
+			}
+		}
+	}
+	if !seated {
+		final, _ := d.poaSeats(ctx, 1)
+		t.Fatalf("ADMISSION NEVER SUCCEEDED. %d votes cast against a threshold of %d, yet %s is not "+
+			"in the registry: %s\n\nThis is the one-way-door failure: if no new seat can EVER be "+
+			"admitted, the founding cohort is permanent and POA cannot be operated. D19/D20 both pass "+
+			"in this state because they only assert that admission is REFUSED.",
+			voters, required, candidate, seatFingerprint(final))
+	}
+
+	// ---- and it must be identical on every node (it is consensus state) ----
+	want := ""
+	for n := 1; n <= cfg.Nodes; n++ {
+		s, err := d.poaSeats(ctx, n)
+		if err != nil {
+			t.Errorf("magi-%d poa_seats: %v", n, err)
+			continue
+		}
+		fp := seatFingerprint(s)
+		found := false
+		for _, x := range s {
+			if x.Account == candidate {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("magi-%d does NOT have the admitted seat %s — the registry has DIVERGED: %s",
+				n, candidate, fp)
+		}
+		if n == 1 {
+			want = fp
+		} else if fp != want {
+			t.Errorf("REGISTRY DIVERGENCE after admission, magi-1 vs magi-%d\n  %s\n  %s", n, want, fp)
+		}
+	}
+	if len(before)+1 != len(mustSeats(t, d, ctx, 1)) {
+		t.Errorf("registry grew by more than the single admitted seat")
+	}
+	t.Logf("CONFIRMED: admission works end to end and is identical across all %d nodes. POA is NOT a "+
+		"one-way door.", cfg.Nodes)
+}
+
+func mustSeats(t *testing.T, d *Devnet, ctx context.Context, node int) []poaSeatDoc {
+	t.Helper()
+	s, err := d.poaSeats(ctx, node)
+	if err != nil {
+		t.Fatalf("poa_seats on magi-%d: %v", node, err)
+	}
+	return s
+}

--- a/tests/devnet/poa_bootstrap_test.go
+++ b/tests/devnet/poa_bootstrap_test.go
@@ -1,0 +1,217 @@
+package devnet
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"vsc-node/modules/common/params"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// poaSeatDoc mirrors the poa_seats document shape (modules/db/vsc/poaseats.Seat).
+type poaSeatDoc struct {
+	Account          string `bson:"account"`
+	UboId            string `bson:"ubo_id,omitempty"`
+	AdmittedHeight   uint64 `bson:"admitted_height"`
+	Bootstrap        bool   `bson:"bootstrap,omitempty"`
+	LastSeatedHeight uint64 `bson:"last_seated_height"`
+	ExitHeight       uint64 `bson:"exit_height"`
+}
+
+// poaSeats reads a node's whole seat registry, sorted by account.
+func (d *Devnet) poaSeats(ctx context.Context, node int) ([]poaSeatDoc, error) {
+	client, err := d.mongoClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer client.Disconnect(ctx)
+
+	cur, err := client.Database(d.nodeDbName(node)).Collection("poa_seats").Find(ctx, bson.M{})
+	if err != nil {
+		return nil, fmt.Errorf("poa_seats find on magi-%d: %w", node, err)
+	}
+	defer cur.Close(ctx)
+
+	var out []poaSeatDoc
+	if err := cur.All(ctx, &out); err != nil {
+		return nil, fmt.Errorf("poa_seats decode on magi-%d: %w", node, err)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Account < out[j].Account })
+	return out, nil
+}
+
+// seatFingerprint renders a registry as a comparable string. Deliberately
+// includes admitted_height and bootstrap: two nodes agreeing on the SET of
+// accounts while disagreeing on the height they were admitted at is exactly the
+// divergence that forks the chain, and an account-only comparison would miss it.
+func seatFingerprint(seats []poaSeatDoc) string {
+	s := ""
+	for _, x := range seats {
+		s += fmt.Sprintf("%s@%d(bootstrap=%v);", x.Account, x.AdmittedHeight, x.Bootstrap)
+	}
+	return s
+}
+
+// TestPoaBootstrapDeterminism is scenario D2.
+//
+// It proves the property the whole POA batch rests on: when the consensus floor
+// reaches 0.7.0, bootstrapPoaSeats seeds the seat registry from the first
+// ratified election, it fires EXACTLY ONCE, and every node derives a
+// BYTE-IDENTICAL registry. A divergence here forks the chain, and the registry
+// is append-only, so a wrong seed is permanent.
+//
+// ★ ANTI-VACUOUS-PASS GUARDS. POA is inert until the floor reaches 0.7.0, so a
+// test that merely finds an empty-and-identical registry on all nodes would
+// "pass" against a completely inert system. Two preconditions must hold before
+// any assertion counts:
+//
+//	(a) the ratified election carries FLAT weights (every weight == PoaSeatWeight
+//	    == 1). Pre-activation weights are stake-derived and large, so this is a
+//	    direct, positive observation that the POA batch actually took effect.
+//
+//	    ★ TIMING, learned by running this: POA activation takes TWO epochs.
+//	    bootstrapPoaSeats seeds the registry at the ACTIVATION election -- the one
+//	    "whose PREDECESSOR was still below the POA line" (poa_seats.go) -- but flat
+//	    weight is gated on poaActive(prevVersion) (election-proposer.go), i.e. the
+//	    PRIOR election's version. So the activation election itself still carries
+//	    stake weights, and flat weight appears only from the NEXT one. Asserting
+//	    flatness at the activation epoch fails against a perfectly healthy chain;
+//	    the first run of this test did exactly that (weights were 2000000, the
+//	    devnet MinStake).
+//	(b) the registry is NON-EMPTY and its size equals the committee size.
+//
+// If either fails the test FAILS rather than reporting success, per
+// feedback_vacuous_pass_is_worse_than_fail.
+func TestPoaBootstrapDeterminism(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	cfg := tssTestConfig()
+	if cfg.SysConfigOverrides.ConsensusParams == nil {
+		cfg.SysConfigOverrides.ConsensusParams = &params.ConsensusParams{}
+	}
+	// Pin consensus 0.7.0 from epoch 1 so the POA batch is live.
+	// ★ FloorEpoch MUST be non-zero: PinnedVersionFloor treats 0 as "no floor",
+	// which would leave POA inert and make every assertion below vacuous.
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorMajor = 0
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorConsensus = 7
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorEpoch = 1
+
+	d, ctx := startDevnetNoKey(t, cfg, 25*time.Minute)
+
+	// Every node must ingest a real election before anything is asserted.
+	for n := 1; n <= cfg.Nodes; n++ {
+		nctx, cancel := context.WithTimeout(ctx, 8*time.Minute)
+		err := d.waitForElectionEpoch(nctx, n, 1, 8*time.Minute)
+		cancel()
+		if err != nil {
+			t.Fatalf("magi-%d never ingested epoch >= 1: %v", n, err)
+		}
+	}
+
+	// Epoch 1 is the ACTIVATION election: bootstrap seeds the registry here, but
+	// its own weights are still stake-derived. Flat weight lands at epoch 2, so
+	// wait for that before judging whether POA took effect.
+	activation, err := d.GetElectionGQL(ctx, 1, 1)
+	if err != nil {
+		t.Fatalf("reading activation election epoch 1 from magi-1: %v", err)
+	}
+	t.Logf("activation election epoch 1: %d members, weights=%v (stake-derived here by design)",
+		len(activation.Members), activation.Weights)
+
+	for n := 1; n <= cfg.Nodes; n++ {
+		nctx, cancel := context.WithTimeout(ctx, 8*time.Minute)
+		err := d.waitForElectionEpoch(nctx, n, 2, 8*time.Minute)
+		cancel()
+		if err != nil {
+			t.Fatalf("magi-%d never reached epoch 2 (the first flat-weight election): %v", n, err)
+		}
+	}
+
+	// ---- PRECONDITION (a): POA is genuinely ACTIVE, not inert ----
+	elec, err := d.GetElectionGQL(ctx, 1, 2)
+	if err != nil {
+		t.Fatalf("reading election epoch 2 from magi-1: %v", err)
+	}
+	if len(elec.Members) == 0 {
+		t.Fatal("election epoch 1 has no members — cannot evaluate POA activation")
+	}
+	for i, w := range elec.Weights {
+		if w != params.PoaSeatWeight {
+			t.Fatalf("PRECONDITION FAILED at epoch 2: weight[%d]=%d, want flat %d. "+
+				"POA is INERT (floor pin did not take), so nothing below would be meaningful. "+
+				"members=%v weights=%v", i, w, params.PoaSeatWeight, elec.Members, elec.Weights)
+		}
+	}
+	if elec.TotalWeight != uint64(len(elec.Members))*params.PoaSeatWeight {
+		t.Fatalf("PRECONDITION FAILED: total_weight=%d, want %d (flat weight x %d members)",
+			elec.TotalWeight, uint64(len(elec.Members))*params.PoaSeatWeight, len(elec.Members))
+	}
+	t.Logf("POA ACTIVE: epoch %d, %d members, all weights flat=%d, total=%d",
+		elec.Epoch, len(elec.Members), params.PoaSeatWeight, elec.TotalWeight)
+
+	// ---- PRECONDITION (b) + the actual assertion: identical registries ----
+	want := ""
+	for n := 1; n <= cfg.Nodes; n++ {
+		seats, err := d.poaSeats(ctx, n)
+		if err != nil {
+			t.Fatalf("magi-%d: %v", n, err)
+		}
+		if len(seats) == 0 {
+			t.Fatalf("PRECONDITION FAILED: magi-%d has an EMPTY poa_seats registry while POA is "+
+				"active. Bootstrap did not fire; an empty registry would make an all-nodes-agree "+
+				"assertion trivially true", n)
+		}
+		if len(seats) != len(activation.Members) {
+			t.Errorf("magi-%d: registry has %d seats but the ratified committee has %d members — "+
+				"a PARTIAL bootstrap is worse than none (the seat gate refuses to apply while the "+
+				"registry is short). seats=%v activation members=%v",
+				n, len(seats), len(activation.Members), seatFingerprint(seats), activation.Members)
+		}
+		for _, s := range seats {
+			if !s.Bootstrap {
+				t.Errorf("magi-%d: seat %q has bootstrap=false; every founding seat must be "+
+					"flagged as bootstrap-seeded", n, s.Account)
+			}
+		}
+		fp := seatFingerprint(seats)
+		t.Logf("magi-%d registry (%d seats): %s", n, len(seats), fp)
+		if n == 1 {
+			want = fp
+		} else if fp != want {
+			t.Errorf("REGISTRY DIVERGENCE magi-1 vs magi-%d — this forks the chain\n  magi-1: %s\n  magi-%d: %s",
+				n, want, n, fp)
+		}
+	}
+
+	// ---- bootstrap fires EXACTLY once: the registry must not grow ----
+	// Wait out two further elections and re-read. bootstrapPoaSeats explicitly
+	// refuses to retry, so any growth here means a second seed fired.
+	base := len(activation.Members)
+	for _, targetEpoch := range []uint64{3, 4} {
+		nctx, cancel := context.WithTimeout(ctx, 6*time.Minute)
+		err := d.waitForElectionEpoch(nctx, 1, targetEpoch, 6*time.Minute)
+		cancel()
+		if err != nil {
+			t.Logf("magi-1 did not reach epoch %d (%v) — skipping the re-seed check at this epoch", targetEpoch, err)
+			continue
+		}
+		for n := 1; n <= cfg.Nodes; n++ {
+			seats, err := d.poaSeats(ctx, n)
+			if err != nil {
+				t.Errorf("magi-%d re-read at epoch %d: %v", n, targetEpoch, err)
+				continue
+			}
+			if len(seats) != base {
+				t.Errorf("magi-%d: registry changed from %d to %d seats by epoch %d — bootstrap "+
+					"must fire exactly once and never re-seed. now=%s",
+					n, base, len(seats), targetEpoch, seatFingerprint(seats))
+			}
+		}
+	}
+}

--- a/tests/devnet/poa_exit_halt_release_test.go
+++ b/tests/devnet/poa_exit_halt_release_test.go
@@ -1,0 +1,135 @@
+package devnet
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"vsc-node/modules/common/params"
+)
+
+// TestPoaExitHaltReleases is scenario D13-RELEASE, the other one-way-door risk.
+//
+// D13a proved the exit-halt HOLDS a seated operator's consensus bond (the unstake
+// transaction is processed and FAILS). Nothing proved the hold ever LIFTS. A hold
+// that never lifts is not a deterrent, it is permanent confiscation: every seated
+// operator's collateral would be locked forever with no code path to recover it.
+// That is strictly worse than having no exit-halt at all, and D13a passes in that
+// state because it only asserts the refusal.
+//
+// The mechanism has two shapes (transactions.go:887-899):
+//
+//	(a) still an ELECTABLE witness -> no fixed release; the clock has not started.
+//	    The operator must stop being electable first.
+//	(b) winding down -> PoaExitHaltReleaseHeight returns a concrete height.
+//
+// So the test must first make the operator non-electable (disable its witness,
+// which is what standing down actually means), then wait out PoaExitHaltBlocks
+// (120 on devnet, ~6 min) and require the unstake to SUCCEED.
+func TestPoaExitHaltReleases(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	cfg := tssTestConfig()
+	cfg.SkipFunding = false
+	if cfg.SysConfigOverrides.ConsensusParams == nil {
+		cfg.SysConfigOverrides.ConsensusParams = &params.ConsensusParams{}
+	}
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorMajor = 0
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorConsensus = 7
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorEpoch = 1
+
+	d, ctx := startDevnetNoKey(t, cfg, 55*time.Minute)
+
+	for n := 1; n <= cfg.Nodes; n++ {
+		nctx, cancel := context.WithTimeout(ctx, 12*time.Minute)
+		err := d.waitForElectionEpoch(nctx, n, 2, 12*time.Minute)
+		cancel()
+		if err != nil {
+			t.Fatalf("magi-%d never reached epoch 2: %v", n, err)
+		}
+	}
+	elec, err := d.GetElectionGQL(ctx, 1, 2)
+	if err != nil {
+		t.Fatalf("reading election epoch 2: %v", err)
+	}
+	for i, w := range elec.Weights {
+		if w != params.PoaSeatWeight {
+			t.Fatalf("PRECONDITION FAILED: weight[%d]=%d want flat %d — POA INERT", i, w, params.PoaSeatWeight)
+		}
+	}
+
+	// Use the LAST node so disabling it cannot drop the committee below MinMembers.
+	leaver := cfg.Nodes
+	acct := d.witnessAccount(leaver)
+	full := "hive:" + acct
+
+	bal, err := d.GetAccountBalance(ctx, 1, full)
+	if err != nil || bal == nil || bal.HiveConsensus <= 0 {
+		t.Fatalf("PRECONDITION FAILED: %s has no readable consensus stake (%v) — it is a seated "+
+			"committee member and must have one", full, err)
+	}
+	staked := bal.HiveConsensus
+	t.Logf("%s hive_consensus = %d", full, staked)
+
+	// ---- 1. while still electable, the unstake must be REFUSED ----
+	tx1, err := d.ConsensusUnstake(leaver, "1.000")
+	if err != nil {
+		t.Fatalf("broadcasting first consensus_unstake: %v", err)
+	}
+	time.Sleep(60 * time.Second)
+	st1, _ := d.FindTransactionStatus(ctx, 1, tx1)
+	t.Logf("unstake while still seated+electable: tx=%s status=%s", tx1, st1)
+	if !strings.EqualFold(st1, "FAILED") {
+		t.Errorf("expected the first unstake to be REFUSED while the operator is still electable, "+
+			"got status=%q. If it succeeded, the exit-halt is not holding at all.", st1)
+	}
+
+	// ---- 2. stand down: stop being electable, which starts the clock ----
+	n := disableWitnessEverywhere(t, d, ctx, acct, cfg.Nodes)
+	if n == 0 {
+		t.Fatalf("no witness rows for %s to disable", acct)
+	}
+	t.Logf("stood %s down (disabled %d witness rows) — the exit-halt clock should now start", acct, n)
+
+	// PoaExitHaltBlocks is 120 on devnet (~6 min at 3s). Give it generous margin,
+	// and poll so a successful release is detected as soon as it happens.
+	window := 14 * time.Minute
+	t.Logf("waiting up to %v for the exit-halt to lift (PoaExitHaltBlocks=120 blocks ~ 6 min)", window)
+
+	var released bool
+	var lastStatus string
+	deadline := time.Now().Add(window)
+	attempt := 0
+	for time.Now().Before(deadline) && !released {
+		time.Sleep(90 * time.Second)
+		attempt++
+		txN, err := d.ConsensusUnstake(leaver, "1.000")
+		if err != nil {
+			t.Logf("attempt %d: broadcast error %v", attempt, err)
+			continue
+		}
+		time.Sleep(45 * time.Second)
+		st, _ := d.FindTransactionStatus(ctx, 1, txN)
+		lastStatus = st
+		t.Logf("attempt %d: unstake tx=%s status=%s", attempt, txN, st)
+		if strings.EqualFold(st, "CONFIRMED") || strings.EqualFold(st, "PROCESSED") || strings.EqualFold(st, "INCLUDED") {
+			released = true
+		}
+	}
+
+	if !released {
+		t.Errorf("EXIT-HALT NEVER RELEASED after %v of standing down (last status=%q). A hold that "+
+			"never lifts is permanent confiscation of the operator's collateral, not a deterrent — "+
+			"and there is no other code path that returns it. D13a passes in this state because it "+
+			"only asserts the REFUSAL, so this is the failure D13a cannot see.",
+			window, lastStatus)
+		return
+	}
+
+	t.Logf("CONFIRMED: the exit-halt LIFTED after the operator stood down — the unstake was accepted "+
+		"(status=%s). The bond is recoverable, so the halt is a timed deterrent rather than a "+
+		"permanent lock.", lastStatus)
+}

--- a/tests/devnet/poa_flatweight_finality_test.go
+++ b/tests/devnet/poa_flatweight_finality_test.go
@@ -1,0 +1,219 @@
+package devnet
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"vsc-node/modules/common/params"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// maxSlotHeight returns the highest slot_height in a node's block_headers.
+//
+// ★ THIS IS THE CORRECT INSTRUMENT, and the obvious alternative is wrong.
+// getLastProcessedBlock reads hive_blocks metadata, i.e. HIVE L1 ingestion, which
+// keeps advancing whether or not VSC can reach quorum — a halt test built on it
+// would never observe the halt. A block_headers row only exists for a VSC block
+// that actually gathered its BLS quorum, so this is the thing flat weight moves.
+func (d *Devnet) maxSlotHeight(ctx context.Context, node int) (int, error) {
+	client, err := d.mongoClient(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer client.Disconnect(ctx)
+
+	var doc struct {
+		SlotHeight int `bson:"slot_height"`
+	}
+	opts := options.FindOne().SetSort(bson.D{{Key: "slot_height", Value: -1}})
+	err = client.Database(d.nodeDbName(node)).Collection("block_headers").FindOne(ctx, bson.M{}, opts).Decode(&doc)
+	if err != nil {
+		return 0, fmt.Errorf("block_headers on magi-%d: %w", node, err)
+	}
+	return doc.SlotHeight, nil
+}
+
+// grewWithin reports whether a node's VSC block height advanced during the window.
+func (d *Devnet) grewWithin(ctx context.Context, t *testing.T, node int, window time.Duration) (bool, int, int) {
+	start, err := d.maxSlotHeight(ctx, node)
+	if err != nil {
+		t.Fatalf("baseline slot height on magi-%d: %v", node, err)
+	}
+	deadline := time.Now().Add(window)
+	last := start
+	for time.Now().Before(deadline) {
+		time.Sleep(10 * time.Second)
+		h, err := d.maxSlotHeight(ctx, node)
+		if err != nil {
+			continue
+		}
+		last = h
+		if h > start {
+			return true, start, h
+		}
+	}
+	return false, start, last
+}
+
+// TestPoaFlatWeightFinalityThreshold is scenario D10.
+//
+// POA replaces stake-proportional election weights with a flat weight of 1 per
+// seat (params.PoaSeatWeight, written in election-proposer.go). BLS finality
+// requires signedWeight >= weightTotal - weightTotal/3 (bls_quorum.go). For 5
+// flat seats that threshold is 4, so activation silently converts a network that
+// finalised with 3-of-5 (by stake) into one that needs 4-of-5 (by count).
+//
+// This is an operational property, not a code defect, and it is the single most
+// likely way a POA activation surprises an operator: their liveness margin
+// shrinks at the activation epoch with no other visible change. Nothing in the
+// existing D1-D9 plan covers block finality under flat weight — D5 covers
+// gateway multisig KEY weights, a different consumer of the same numbers.
+//
+// ★ WHAT THIS TEST DOES AND DOES NOT PROVE. Read this before quoting a result.
+//
+// cmd/devnet-setup stakes every witness the SAME args.stakeAmt, so on a devnet
+// all weights are already equal (2,000,000 == CONSENSUS_MINIMUM) BEFORE POA. The
+// pre-POA quorum is therefore 10,000,000 - 10,000,000/3 = 6,666,667, which 3
+// seats (6,000,000) already FAIL and 4 seats (8,000,000) meet. In other words
+// this devnet needs 4-of-5 both before AND after activation, so this test cannot
+// observe the threshold CHANGING and must not be cited as evidence that it does.
+//
+// What it does prove, which is still worth proving: flat weight is genuinely in
+// force and its quorum is ENFORCED end-to-end — the chain really does stop when
+// the flat threshold is unreachable and really does recover when it is restored.
+//
+// The CHANGE is a property of unequal stake and is demonstrated arithmetically
+// against the live testnet committee (50M/20M/5M/20M/20.000002M): total
+// 115,000,002, quorum 76,666,668, top three = 90,000,002, so 3-of-5 finalises
+// today and 4-of-5 is required after activation. Proving that on a devnet would
+// need per-witness stake amounts, which devnet-setup does not currently support.
+//
+// The test asserts the threshold in both directions: the chain advances with all
+// 5 up, STOPS when too many are stopped, and RESUMES when one returns.
+func TestPoaFlatWeightFinalityThreshold(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	cfg := tssTestConfig()
+	if cfg.SysConfigOverrides.ConsensusParams == nil {
+		cfg.SysConfigOverrides.ConsensusParams = &params.ConsensusParams{}
+	}
+	// ★ FloorEpoch MUST be non-zero (PinnedVersionFloor treats 0 as "no floor").
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorMajor = 0
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorConsensus = 7
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorEpoch = 1
+
+	d, ctx := startDevnetNoKey(t, cfg, 35*time.Minute)
+
+	// ★ Wait for epoch 2, not 1. POA activation takes TWO epochs: the registry
+	// seeds at the activation election, but flat weight is gated on
+	// poaActive(prevVersion), so the activation election itself still carries
+	// stake weights. This test originally polled epoch 1 and failed its own
+	// precondition (weight=2000000) against a perfectly healthy chain.
+	for n := 1; n <= cfg.Nodes; n++ {
+		nctx, cancel := context.WithTimeout(ctx, 12*time.Minute)
+		err := d.waitForElectionEpoch(nctx, n, 2, 12*time.Minute)
+		cancel()
+		if err != nil {
+			t.Fatalf("magi-%d never reached epoch 2 (first flat-weight election): %v", n, err)
+		}
+	}
+
+	// ---- PRECONDITION: POA active and weights genuinely flat ----
+	elec, err := d.GetElectionGQL(ctx, 1, 2)
+	if err != nil {
+		t.Fatalf("reading election epoch 2: %v", err)
+	}
+	for i, w := range elec.Weights {
+		if w != params.PoaSeatWeight {
+			t.Fatalf("PRECONDITION FAILED: weight[%d]=%d want flat %d — POA is INERT, so a halt "+
+				"observed below would prove nothing about flat weight", i, w, params.PoaSeatWeight)
+		}
+	}
+	members := len(elec.Members)
+	if members < 3 {
+		t.Fatalf("PRECONDITION FAILED: committee of %d is too small to test a quorum threshold", members)
+	}
+	// ceil(2N/3) expressed exactly as bls_quorum.go computes it.
+	total := uint64(members) * params.PoaSeatWeight
+	quorum := total - total/3
+	tolerated := uint64(members) - quorum // how many seats may be offline
+	t.Logf("POA ACTIVE: %d flat seats, total weight %d, quorum %d => at most %d node(s) may be offline",
+		members, total, quorum, tolerated)
+
+	// Record the pre-POA threshold for this devnet so nobody reads the halt below
+	// as evidence that activation CHANGED the margin. On a devnet it did not.
+	preTotal := uint64(members) * uint64(params.CONSENSUS_MINIMUM)
+	preQuorum := preTotal - preTotal/3
+	preTolerated := 0
+	for off := 0; off < members; off++ {
+		if uint64(members-off)*uint64(params.CONSENSUS_MINIMUM) >= preQuorum {
+			preTolerated = off
+		}
+	}
+	t.Logf("NOTE: devnet stakes every witness equally (%d), so the PRE-POA quorum was %d of %d "+
+		"and tolerated %d offline node(s). Same margin as flat weight here, so this run proves "+
+		"ENFORCEMENT of the flat quorum, NOT that activation changed the margin.",
+		params.CONSENSUS_MINIMUM, preQuorum, preTotal, preTolerated)
+	if tolerated != 1 {
+		t.Logf("NOTE: this devnet tolerates %d offline nodes, not 1; adjusting the stop count", tolerated)
+	}
+
+	// ---- baseline: the chain IS advancing with everyone up ----
+	grew, from, to := d.grewWithin(ctx, t, 1, 3*time.Minute)
+	if !grew {
+		t.Fatalf("PRECONDITION FAILED: VSC block height did not advance (%d -> %d) with all %d nodes "+
+			"up; the halt assertion below would be meaningless", from, to, cfg.Nodes)
+	}
+	t.Logf("baseline: VSC slot height advanced %d -> %d with all %d nodes up", from, to, cfg.Nodes)
+
+	// ---- stop one MORE node than the quorum tolerates ----
+	stopCount := int(tolerated) + 1
+	stopped := []int{}
+	for i := 0; i < stopCount; i++ {
+		node := cfg.Nodes - i // stop from the top: magi-5, magi-4, ...
+		if err := d.StopNode(ctx, node); err != nil {
+			t.Fatalf("stopping magi-%d: %v", node, err)
+		}
+		stopped = append(stopped, node)
+		t.Logf("stopped magi-%d", node)
+	}
+	defer func() {
+		for _, n := range stopped {
+			_ = d.StartNode(context.Background(), n)
+		}
+	}()
+
+	// ---- assert the chain HALTS ----
+	// Give the network a slot or two to settle, then require NO growth.
+	time.Sleep(30 * time.Second)
+	grew, from, to = d.grewWithin(ctx, t, 1, 3*time.Minute)
+	if grew {
+		t.Errorf("EXPECTED HALT BUT CHAIN ADVANCED %d -> %d with %d of %d nodes stopped. "+
+			"Either flat weight is not reaching bls_quorum, or the quorum arithmetic here is wrong "+
+			"(total=%d quorum=%d).", from, to, stopCount, cfg.Nodes, total, quorum)
+	} else {
+		t.Logf("CONFIRMED: VSC block height frozen at %d with %d of %d nodes stopped "+
+			"(quorum %d of %d unreachable)", to, stopCount, cfg.Nodes, quorum, total)
+	}
+
+	// ---- assert it RESUMES when quorum is restored ----
+	revive := stopped[len(stopped)-1]
+	if err := d.StartNode(ctx, revive); err != nil {
+		t.Fatalf("restarting magi-%d: %v", revive, err)
+	}
+	t.Logf("restarted magi-%d; expecting finality to resume", revive)
+	grew, from, to = d.grewWithin(ctx, t, 1, 5*time.Minute)
+	if !grew {
+		t.Errorf("chain did NOT resume after restoring quorum (height stuck %d -> %d). A halt that "+
+			"does not recover when the node returns is a much worse finding than the halt itself.",
+			from, to)
+	} else {
+		t.Logf("CONFIRMED: finality resumed %d -> %d after magi-%d returned", from, to, revive)
+	}
+}

--- a/tests/devnet/poa_h6_unproven_key_seat_test.go
+++ b/tests/devnet/poa_h6_unproven_key_seat_test.go
@@ -1,0 +1,191 @@
+package devnet
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"vsc-node/modules/common/consensusversion"
+	"vsc-node/modules/common/params"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// breakGatewayPoPEverywhere writes an INVALID gateway_key_pop for an account into
+// EVERY node's witnesses collection.
+//
+// Deliberately every node, not just magi-1 as poisonGatewayKey does. Witness
+// records are consensus input: election generation is a pure function of them and
+// every node must derive the identical committee/CID. Poisoning one node's view
+// would manufacture an artificial divergence and the test would be measuring my
+// own tampering rather than the H-6 gate.
+func breakGatewayPoPEverywhere(t *testing.T, d *Devnet, ctx context.Context, account string, nodes int) int {
+	t.Helper()
+	client, err := d.mongoClient(ctx)
+	if err != nil {
+		t.Fatalf("mongo: %v", err)
+	}
+	defer client.Disconnect(ctx)
+
+	total := 0
+	for n := 1; n <= nodes; n++ {
+		coll := client.Database(d.nodeDbName(n)).Collection("witnesses")
+		res, err := coll.UpdateMany(ctx,
+			bson.M{"account": account},
+			// Well-formed-looking but bound to nothing: VerifyGatewayKeyPoP fails.
+			//
+			// ★ CORRECTION (2026-08-26): an earlier version of this comment claimed
+			// an EMPTY pop "reads as announced-before-gateway-PoP-support, which the
+			// gate is written to tolerate". That is FALSE of the current code.
+			// dids.VerifyGatewayKeyPoP returns a hard error for an empty pop AND for
+			// an empty gateway key (lib/dids/gateway_pop.go:79-84), and the election
+			// gate excludes on ANY non-nil error (election-proposer.go:602). Two
+			// existing tests already pin the strict behaviour:
+			// witnesses/gateway_pop_test.go:30 ("missing pop (legacy announce)" =>
+			// must fail) and lib/dids/gateway_pop_test.go:58 ("empty PoP accepted" =>
+			// t.Fatal). The tolerant reading came from the SCHEMA comment at
+			// witnesses/schema.go:21-22, which describes what the FIELD may contain,
+			// not what the GATE does. There is no grandfathering to remove, and none
+			// should be added: it would be the "announce a stolen key, omit the PoP"
+			// doorway.
+			bson.M{"$set": bson.M{"gateway_key_pop": "3045022100deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef0220cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe"}},
+		)
+		if err != nil {
+			t.Fatalf("breaking PoP on magi-%d: %v", n, err)
+		}
+		total += int(res.MatchedCount)
+	}
+	return total
+}
+
+// TestPoaH6DisabledSeatsUnprovenKey is scenario D15.
+//
+// ★★ THIS IS A CHARACTERISATION TEST. It PINS CURRENT, UNDESIRABLE BEHAVIOUR.
+// When H-6 is re-enabled this test MUST BE INVERTED, not deleted. A
+// characterisation test nobody inverts silently blesses the gap forever.
+//
+// consensusversion.WitnessKeyStrictActive is stubbed `return false`
+// (feature_gates.go, commit 9801c292, 2026-06-22) after the strict PoP gate
+// starved the mainnet committee below the floor at epoch 1699 and halted
+// elections. The gate BODY at election-proposer.go:565 is intact; only the
+// predicate is dead, so the whole exclusion block is skipped.
+//
+// That interacts badly with POA specifically. bootstrapPoaSeats seeds the
+// PERMANENT, APPEND-ONLY seat registry from whatever the ratified election
+// contained, and performs NO key validation of its own (verified: no
+// Key/PoP/Verify reference anywhere in its body). So a witness whose gateway key
+// carries no valid proof-of-possession — one nobody has shown they hold the
+// secret for — is written into a registry that has no delete path, and its seat
+// survives every future election.
+//
+// On a 5-witness testnet the practical risk is low because the cohort is known.
+// Before MAINNET POA this must be closed, because the founding cohort there is
+// whoever happens to be elected at one hand-picked height.
+func TestPoaH6DisabledSeatsUnprovenKey(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	// Guard the premise itself: if H-6 has been re-enabled since this was
+	// written, the whole test is obsolete and must be inverted rather than run.
+	if consensusversion.WitnessKeyStrictActive(consensusversion.V0_7_0) {
+		t.Fatal("H-6 IS NOW ENABLED (WitnessKeyStrictActive returned true). This characterisation " +
+			"test pins the DISABLED behaviour and is now WRONG. INVERT IT: assert that the witness " +
+			"with the invalid gateway PoP is EXCLUDED from the committee and never seated.")
+	}
+
+	cfg := tssTestConfig()
+	if cfg.SysConfigOverrides.ConsensusParams == nil {
+		cfg.SysConfigOverrides.ConsensusParams = &params.ConsensusParams{}
+	}
+	// ★ FloorEpoch MUST be non-zero.
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorMajor = 0
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorConsensus = 7
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorEpoch = 1
+
+	d, ctx := startDevnetNoKey(t, cfg, 45*time.Minute)
+
+	victim := d.witnessAccount(cfg.Nodes) // magi.test5
+
+	// Break the PoP BEFORE the activation election is generated. Witness rows
+	// appear during setup, so poll briefly for them.
+	broke := 0
+	deadline := time.Now().Add(4 * time.Minute)
+	for time.Now().Before(deadline) {
+		if broke = breakGatewayPoPEverywhere(t, d, ctx, victim, cfg.Nodes); broke > 0 {
+			break
+		}
+		time.Sleep(10 * time.Second)
+	}
+	if broke == 0 {
+		t.Fatalf("no witness rows for %s to break — cannot establish the premise", victim)
+	}
+	t.Logf("set an INVALID gateway_key_pop on %d witness row(s) for %s across all %d node databases",
+		broke, victim, cfg.Nodes)
+
+	for n := 1; n <= cfg.Nodes; n++ {
+		nctx, cancel := context.WithTimeout(ctx, 12*time.Minute)
+		err := d.waitForElectionEpoch(nctx, n, 2, 12*time.Minute)
+		cancel()
+		if err != nil {
+			t.Fatalf("magi-%d never reached epoch 2: %v", n, err)
+		}
+	}
+
+	// ---- PRECONDITION: POA genuinely active ----
+	elec, err := d.GetElectionGQL(ctx, 1, 2)
+	if err != nil {
+		t.Fatalf("reading election epoch 2: %v", err)
+	}
+	for i, w := range elec.Weights {
+		if w != params.PoaSeatWeight {
+			t.Fatalf("PRECONDITION FAILED: weight[%d]=%d want flat %d — POA INERT", i, w, params.PoaSeatWeight)
+		}
+	}
+
+	// ---- CHARACTERISATION: the unproven key is elected AND permanently seated ----
+	inCommittee := false
+	for _, m := range elec.Members {
+		if m == victim || m == "hive:"+victim {
+			inCommittee = true
+			break
+		}
+	}
+	seats, err := d.poaSeats(ctx, 1)
+	if err != nil {
+		t.Fatalf("reading poa_seats: %v", err)
+	}
+	seated := false
+	for _, s := range seats {
+		if s.Account == victim {
+			seated = true
+			break
+		}
+	}
+	t.Logf("committee epoch 2: %v", elec.Members)
+	t.Logf("registry: %s", seatFingerprint(seats))
+
+	if !inCommittee && !seated {
+		t.Errorf("UNEXPECTED: %s was excluded despite WitnessKeyStrictActive being false. Something "+
+			"else is filtering it, so this test is no longer characterising what it claims. "+
+			"Investigate before trusting either outcome.", victim)
+		return
+	}
+
+	if inCommittee && seated {
+		t.Logf("CHARACTERISED (this is the CURRENT, UNDESIRABLE behaviour): %s holds an INVALID "+
+			"gateway-key proof-of-possession, yet it was elected AND written into the permanent, "+
+			"append-only POA seat registry. There is no delete path, so this seat is now structural. "+
+			"Closing H-6 (restoring WitnessKeyStrictActive) is a PRE-MAINNET-POA requirement: the "+
+			"mainnet founding cohort is whoever is elected at one hand-picked height, and this is "+
+			"exactly how an operator who cannot prove it holds its own keys becomes permanent.",
+			victim)
+		t.Logf("INVERT-WHEN-FIXED: when WitnessKeyStrictActive returns true again, change the two "+
+			"assertions above to require %s is ABSENT from both the committee and the registry.", victim)
+		return
+	}
+
+	t.Errorf("SPLIT STATE: %s inCommittee=%v seated=%v. The committee and the registry disagree about "+
+		"an account with an invalid key, which is worse than either consistent outcome.",
+		victim, inCommittee, seated)
+}

--- a/tests/devnet/poa_laggard_exclusion_test.go
+++ b/tests/devnet/poa_laggard_exclusion_test.go
@@ -1,0 +1,168 @@
+package devnet
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"vsc-node/modules/common/params"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// announcedVersion reads an account's announced consensus triple from a node's
+// witnesses collection.
+func (d *Devnet) announcedVersion(ctx context.Context, node int, account string) (uint64, uint64, bool) {
+	client, err := d.mongoClient(ctx)
+	if err != nil {
+		return 0, 0, false
+	}
+	defer client.Disconnect(ctx)
+	var doc struct {
+		VersionMajor uint64 `bson:"version_major"`
+		Protocol     uint64 `bson:"protocol_version"`
+	}
+	err = client.Database(d.nodeDbName(node)).Collection("witnesses").
+		FindOne(ctx, bson.M{"account": account}).Decode(&doc)
+	if err != nil {
+		return 0, 0, false
+	}
+	return doc.VersionMajor, doc.Protocol, true
+}
+
+// TestPoaLaggardExcludedFromFoundingCohort is scenario D11.
+//
+// Two facts compose into something operators must understand BEFORE they pick an
+// activation epoch:
+//
+//  1. the election proposer DELETES any witness announcing below the version
+//     floor (election-proposer.go), and
+//  2. bootstrapPoaSeats seeds the PERMANENT, APPEND-ONLY seat registry from
+//     whatever that ratified election contained (poa_seats.go:392).
+//
+// So a witness that has not upgraded by the activation epoch is not merely
+// skipped for one epoch — it is excluded from the FOUNDING COHORT, and
+// afterwards needs a ceil(2/3) admit_vote to get in at all. On the live testnet
+// that is 4 of 5 existing operators agreeing to admit it.
+//
+// The laggard is a real node built from origin/main, which announces
+// currentConsensus=3 (verified) against a 0.7.0 floor — not a mock.
+//
+// Set POA_OLD_SOURCE to a go-vsc-node checkout that announces below 0.7.0.
+func TestPoaLaggardExcludedFromFoundingCohort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+	oldSrc := os.Getenv("POA_OLD_SOURCE")
+	if oldSrc == "" {
+		t.Skip("POA_OLD_SOURCE not set (path to a checkout announcing < 0.7.0)")
+	}
+
+	cfg := tssTestConfig()
+	if cfg.SysConfigOverrides.ConsensusParams == nil {
+		cfg.SysConfigOverrides.ConsensusParams = &params.ConsensusParams{}
+	}
+	// ★ FloorEpoch MUST be non-zero.
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorMajor = 0
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorConsensus = 7
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorEpoch = 1
+
+	laggard := cfg.Nodes // magi-5 runs the old binary
+	cfg.OldCodeSourceDir = oldSrc
+	cfg.OldCodeNodes = []int{laggard}
+
+	d, ctx := startDevnetNoKey(t, cfg, 45*time.Minute)
+
+	// Only the UPGRADED nodes will form a committee; poll one of them.
+	for n := 1; n < laggard; n++ {
+		nctx, cancel := context.WithTimeout(ctx, 12*time.Minute)
+		err := d.waitForElectionEpoch(nctx, n, 2, 12*time.Minute)
+		cancel()
+		if err != nil {
+			t.Fatalf("magi-%d never reached epoch 2: %v", n, err)
+		}
+	}
+
+	elec, err := d.GetElectionGQL(ctx, 1, 2)
+	if err != nil {
+		t.Fatalf("reading election epoch 2: %v", err)
+	}
+	for i, w := range elec.Weights {
+		if w != params.PoaSeatWeight {
+			t.Fatalf("PRECONDITION FAILED: weight[%d]=%d want flat %d — POA INERT", i, w, params.PoaSeatWeight)
+		}
+	}
+
+	laggardAcct := d.witnessAccount(laggard)
+
+	// ★ ESTABLISH THE PREMISE BEFORE CONCLUDING ANYTHING FROM THE ABSENCE.
+	// Without these two checks this test cannot distinguish "excluded by the
+	// version floor" (what it claims to prove) from "the old-code image never
+	// built, so the container is simply not there" — and it would report PASS for
+	// the second. An absence only means something once the thing is known to exist.
+	lagName := d.projectName + "-magi-" + itoa(laggard)
+	out, ierr := exec.Command("docker", "inspect", "-f", "{{.State.Running}}", lagName).CombinedOutput()
+	if ierr != nil || strings.TrimSpace(string(out)) != "true" {
+		t.Fatalf("PREMISE FAILED: laggard container %s is not running (state=%q err=%v). Its absence "+
+			"from the committee would then prove nothing about the version filter.",
+			lagName, strings.TrimSpace(string(out)), ierr)
+	}
+	major, proto, found := d.announcedVersion(ctx, 1, laggardAcct)
+	if !found {
+		t.Fatalf("PREMISE FAILED: no witness record for %s on magi-1. The laggard never announced, so "+
+			"it was never a candidate and its exclusion is not attributable to the version floor.",
+			laggardAcct)
+	}
+	if major != 0 || proto >= 7 {
+		t.Fatalf("PREMISE FAILED: %s announces %d.%d, which is NOT below the 0.7.0 floor. The "+
+			"old-code image is not actually old, so this test is not exercising the version filter.",
+			laggardAcct, major, proto)
+	}
+	t.Logf("PREMISE OK: laggard %s is RUNNING and announces %d.%d (below the 0.7.0 floor)",
+		laggardAcct, major, proto)
+
+	t.Logf("committee at epoch 2: %v (laggard=%s runs the pre-0.7.0 binary)", elec.Members, laggardAcct)
+
+	// ---- the laggard must be OUT of the committee ----
+	for _, m := range elec.Members {
+		if m == laggardAcct || m == "hive:"+laggardAcct {
+			t.Errorf("laggard %s IS in the committee despite announcing below the floor — the "+
+				"version filter did not apply", laggardAcct)
+		}
+	}
+	if len(elec.Members) != cfg.Nodes-1 {
+		t.Logf("NOTE: committee has %d members, expected %d (all but the laggard)",
+			len(elec.Members), cfg.Nodes-1)
+	}
+
+	// ---- and OUT of the permanent founding registry ----
+	seats, err := d.poaSeats(ctx, 1)
+	if err != nil {
+		t.Fatalf("reading poa_seats: %v", err)
+	}
+	if len(seats) == 0 {
+		t.Fatal("PRECONDITION FAILED: registry empty while POA is active")
+	}
+	t.Logf("founding registry (%d seats): %s", len(seats), seatFingerprint(seats))
+	for _, s := range seats {
+		if s.Account == laggardAcct {
+			t.Errorf("laggard %s was SEEDED INTO THE PERMANENT REGISTRY despite being filtered "+
+				"from the committee — the founding cohort must contain only ratified members",
+				laggardAcct)
+		}
+	}
+	if len(seats) != len(elec.Members) {
+		t.Errorf("registry has %d seats but the committee has %d members", len(seats), len(elec.Members))
+	}
+
+	// ---- the consequence operators need to hear ----
+	total := uint64(len(seats))
+	required := total - total/3
+	t.Logf("CONSEQUENCE: %s is now permanently outside the founding cohort. Re-entry requires "+
+		"%d of %d seats to vote it in via vsc.admit_vote. On the live testnet that is 4 of 5 "+
+		"operators. Upgrading BEFORE the activation epoch is materially cheaper than after.",
+		laggardAcct, required, total)
+}

--- a/tests/devnet/poa_late_joiner_test.go
+++ b/tests/devnet/poa_late_joiner_test.go
@@ -1,0 +1,152 @@
+package devnet
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"vsc-node/modules/common/params"
+)
+
+// TestPoaLateJoinerDerivesSameRegistry is scenario D3.
+//
+// poa_seats is NOT part of any merklized state, and the reindex trigger keys off a
+// hive_blocks marker, so the collection can be dropped or restored independently
+// of chain history. bootstrapPoaSeats guards against that by refusing to seed
+// anywhere except the activation transition — "the ratified election whose
+// PREDECESSOR was still below the POA line" (poa_seats.go:122-128) — because a
+// node that re-seeds from whatever committee it happens to see would silently
+// disagree with every peer, with no checkpoint or repair path to catch it.
+//
+// This exercises that guard on the dangerous path: a node that was NOT running
+// during the activation transition and only joins afterwards. It must reconstruct
+// the identical registry by replaying history, and must NOT re-bootstrap from the
+// current committee.
+//
+// ★★ WHAT STOPPING A NODE DOES AND DOES NOT DO — corrected after the first run.
+// Stopping a node does NOT remove it from the committee and does NOT cost it a
+// seat. Election generation reads
+// GetWitnessesAtBlockHeight(blk, witnesses.EnabledOnly()) (election-proposer.go:372):
+// it filters on the on-chain `enabled` flag, not on liveness, and banSystemEnabled
+// is false. So the absent node is still ELECTED and still SEEDED into the founding
+// registry while it is down. The first run of this test logged "activation happened
+// without magi-5" and that phrasing was wrong — magi-5 was in the 5-seat registry
+// the whole time.
+//
+// This test therefore proves REPLAY DETERMINISM, and must not be cited for the
+// "excluded, then rejoins" case, which never occurs here. Exclusion requires
+// announcing a BELOW-FLOOR VERSION — that is TestPoaLaggardExcludedFromFoundingCohort.
+//
+// The distinction is operationally load-bearing: an operator whose node is DOWN at
+// the activation epoch keeps its founding seat, while an operator whose node is UP
+// but NOT UPGRADED loses it permanently. Those look identical from the outside.
+func TestPoaLateJoinerDerivesSameRegistry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	cfg := tssTestConfig()
+	if cfg.SysConfigOverrides.ConsensusParams == nil {
+		cfg.SysConfigOverrides.ConsensusParams = &params.ConsensusParams{}
+	}
+	// ★ FloorEpoch MUST be non-zero.
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorMajor = 0
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorConsensus = 7
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorEpoch = 1
+
+	d, ctx := startDevnetNoKey(t, cfg, 45*time.Minute)
+
+	late := cfg.Nodes // magi-5 will miss the activation
+
+	// Take the late node down BEFORE activation so it is absent for the transition.
+	if err := d.StopNode(ctx, late); err != nil {
+		t.Fatalf("stopping magi-%d before activation: %v", late, err)
+	}
+	t.Logf("stopped magi-%d before the activation transition", late)
+
+	// Let the remaining nodes cross the floor and reach flat weight (epoch 2).
+	for n := 1; n < late; n++ {
+		nctx, cancel := context.WithTimeout(ctx, 12*time.Minute)
+		err := d.waitForElectionEpoch(nctx, n, 2, 12*time.Minute)
+		cancel()
+		if err != nil {
+			t.Fatalf("magi-%d never reached epoch 2: %v", n, err)
+		}
+	}
+
+	elec, err := d.GetElectionGQL(ctx, 1, 2)
+	if err != nil {
+		t.Fatalf("reading election epoch 2: %v", err)
+	}
+	for i, w := range elec.Weights {
+		if w != params.PoaSeatWeight {
+			t.Fatalf("PRECONDITION FAILED: weight[%d]=%d want flat %d — POA INERT", i, w, params.PoaSeatWeight)
+		}
+	}
+	reference, err := d.poaSeats(ctx, 1)
+	if err != nil || len(reference) == 0 {
+		t.Fatalf("PRECONDITION FAILED: no reference registry on magi-1 (%v)", err)
+	}
+	refFp := seatFingerprint(reference)
+	t.Logf("activation completed while magi-%d was DOWN. reference registry (%d seats): %s",
+		late, len(reference), refFp)
+
+	// Turn the first run's incidental observation into a CHECKED fact: an offline
+	// node keeps its seat, because eligibility is the on-chain `enabled` flag and
+	// not liveness. If this ever stops being true, the operational guidance above
+	// (down != excluded) is wrong and must be revised.
+	lateAcct := d.witnessAccount(late)
+	offlineStillSeated := false
+	for _, s := range reference {
+		if s.Account == lateAcct {
+			offlineStillSeated = true
+			break
+		}
+	}
+	if !offlineStillSeated {
+		t.Errorf("magi-%d (%s) was NOT seeded while offline. That contradicts EnabledOnly()-based "+
+			"eligibility and would mean being briefly DOWN at the activation epoch permanently costs "+
+			"an operator its founding seat — a materially harsher operational rule than documented.",
+			late, lateAcct)
+	} else {
+		t.Logf("CONFIRMED: %s kept its founding seat despite being offline for the whole transition "+
+			"(eligibility is the on-chain enabled flag, not liveness)", lateAcct)
+	}
+
+	// ---- bring the late node back and let it catch up ----
+	if err := d.StartNode(ctx, late); err != nil {
+		t.Fatalf("restarting magi-%d: %v", late, err)
+	}
+	t.Logf("restarted magi-%d; it must REPLAY to the same registry, not re-seed", late)
+
+	deadline := time.Now().Add(15 * time.Minute)
+	var lateFp string
+	var lateSeats []poaSeatDoc
+	for time.Now().Before(deadline) {
+		time.Sleep(20 * time.Second)
+		s, err := d.poaSeats(ctx, late)
+		if err != nil {
+			continue
+		}
+		lateSeats, lateFp = s, seatFingerprint(s)
+		if lateFp == refFp {
+			break
+		}
+	}
+
+	if lateFp == refFp {
+		t.Logf("magi-%d rebuilt the IDENTICAL registry by replay (%d seats)", late, len(lateSeats))
+		return
+	}
+
+	if len(lateSeats) == 0 {
+		t.Errorf("magi-%d has an EMPTY registry after rejoining. It missed the activation transition "+
+			"and correctly refused to re-seed, but it also never reconstructed the registry from "+
+			"history — so its seat gate stays inert and it silently disagrees with its peers about "+
+			"who may be elected.", late)
+		return
+	}
+	t.Errorf("REGISTRY DIVERGENCE on the late joiner. magi-%d re-derived a DIFFERENT registry, which "+
+		"is the silent fork this guard exists to prevent.\n  peers:      %s\n  magi-%d: %s",
+		late, refFp, late, lateFp)
+}

--- a/tests/devnet/poa_lifecycle_test.go
+++ b/tests/devnet/poa_lifecycle_test.go
@@ -1,0 +1,222 @@
+package devnet
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"vsc-node/modules/common/params"
+)
+
+// admitVote broadcasts vsc.admit_vote from a witness account.
+func (d *Devnet) admitVote(voterWitness int, candidate, uboId string) (string, error) {
+	voter := d.witnessAccount(voterWitness)
+	payload := map[string]interface{}{
+		"candidate": candidate,
+		"ubo_id":    uboId,
+		"net_id":    d.netId(),
+	}
+	return d.BroadcastCustomJSON("vsc.admit_vote", []string{voter}, payload, d.cfg.InitminerWIF)
+}
+
+// TestPoaLifecycle bundles the POA behaviours that do NOT halt the chain onto a
+// single devnet, because each devnet boot costs ~6 minutes. Ordering is
+// deliberate and load-bearing: nothing here may halt finality, or the subtests
+// after it would fail for the wrong reason. The chain-halting scenarios (D10
+// flat-weight quorum, D14 uncapped departures) live in their own tests.
+//
+// Covers D19 (duplicate admission), D20 (admission without quorum) and D13a
+// (a seated operator's consensus_unstake is held by the exit-halt).
+func TestPoaLifecycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	cfg := tssTestConfig()
+	cfg.SkipFunding = false // D13a needs real L2 balances to attempt an unstake
+	if cfg.SysConfigOverrides.ConsensusParams == nil {
+		cfg.SysConfigOverrides.ConsensusParams = &params.ConsensusParams{}
+	}
+	// ★ FloorEpoch MUST be non-zero: PinnedVersionFloor treats 0 as "no floor".
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorMajor = 0
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorConsensus = 7
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorEpoch = 1
+
+	d, ctx := startDevnetNoKey(t, cfg, 40*time.Minute)
+
+	// POA needs TWO epochs: the registry seeds at the activation election (epoch 1)
+	// but flat weight is gated on the PRIOR election's version, so it lands at
+	// epoch 2. See poa_bootstrap_test.go for the full explanation.
+	for n := 1; n <= cfg.Nodes; n++ {
+		nctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+		err := d.waitForElectionEpoch(nctx, n, 2, 10*time.Minute)
+		cancel()
+		if err != nil {
+			t.Fatalf("magi-%d never reached epoch 2: %v", n, err)
+		}
+	}
+
+	// ---- PRECONDITION: POA genuinely active ----
+	elec, err := d.GetElectionGQL(ctx, 1, 2)
+	if err != nil {
+		t.Fatalf("reading election epoch 2: %v", err)
+	}
+	for i, w := range elec.Weights {
+		if w != params.PoaSeatWeight {
+			t.Fatalf("PRECONDITION FAILED: weight[%d]=%d want flat %d — POA INERT, every subtest "+
+				"below would be vacuous", i, w, params.PoaSeatWeight)
+		}
+	}
+	seats0, err := d.poaSeats(ctx, 1)
+	if err != nil {
+		t.Fatalf("reading poa_seats: %v", err)
+	}
+	if len(seats0) == 0 {
+		t.Fatal("PRECONDITION FAILED: registry empty while POA is active")
+	}
+	t.Logf("POA ACTIVE: %d flat seats, registry has %d rows", len(elec.Members), len(seats0))
+
+	// required admit votes = ceil(2/3) of seats, beneficiary excluded
+	total := uint64(len(seats0))
+	required := total - total/3
+	t.Logf("admission threshold: %d of %d seats", required, total)
+
+	// ---- D19: admitting an account that is ALREADY a seat must not wedge ----
+	t.Run("D19_duplicate_admission_does_not_wedge", func(t *testing.T) {
+		existing := d.witnessAccount(1) // already a bootstrap seat
+		for v := 1; v <= int(required); v++ {
+			if _, err := d.admitVote(v, existing, "ubo-duplicate-test"); err != nil {
+				t.Fatalf("admit_vote from magi-%d: %v", v, err)
+			}
+		}
+		// ★ WHAT THIS ACTUALLY EXERCISES — corrected. An already-seated candidate is
+		// rejected in the VOTE path, before a proposal is ever opened
+		// (poa_admission.go: "Already-seated candidate, or a UBO that already holds
+		// a seat: the vote is moot. Checked BEFORE opening a proposal so a duplicate
+		// never accumulates"). It does NOT reach the seat-WRITE path where the typed
+		// dup-seat sentinels guard blockingRetry, so this test must not be cited as
+		// covering those. What it does cover: duplicate votes neither grow the
+		// registry, nor re-stamp an existing seat, nor stall the chain.
+		time.Sleep(45 * time.Second)
+		after, err := d.poaSeats(ctx, 1)
+		if err != nil {
+			t.Fatalf("re-reading poa_seats: %v", err)
+		}
+		if len(after) != len(seats0) {
+			t.Errorf("registry grew from %d to %d on a DUPLICATE admission: %s",
+				len(seats0), len(after), seatFingerprint(after))
+		}
+		// Stronger than a count: the existing seat must be untouched. A duplicate
+		// that silently re-stamped admitted_height would keep the count identical
+		// while rewriting history, and every node's fingerprint would shift.
+		if before, afterFp := seatFingerprint(seats0), seatFingerprint(after); before != afterFp {
+			t.Errorf("DUPLICATE ADMISSION MUTATED AN EXISTING SEAT (count unchanged, contents "+
+				"changed):\n  before: %s\n  after:  %s", before, afterFp)
+		}
+		grew, from, to := d.grewWithin(ctx, t, 1, 2*time.Minute)
+		if !grew {
+			t.Errorf("chain STALLED after a duplicate admission (height %d -> %d) — this is the "+
+				"blockingRetry wedge the typed dup-seat sentinels exist to prevent", from, to)
+		} else {
+			t.Logf("registry unchanged at %d seats; chain still advancing %d -> %d", len(after), from, to)
+		}
+	})
+
+	// ---- D20: an admission that never reaches quorum must not half-apply ----
+	t.Run("D20_admission_below_quorum_never_seats", func(t *testing.T) {
+		before, err := d.poaSeats(ctx, 1)
+		if err != nil {
+			t.Fatalf("poa_seats: %v", err)
+		}
+		candidate := "magi.newbie"
+		votes := int(required) - 1 // deliberately one short
+		if votes < 1 {
+			t.Skipf("threshold %d leaves no room for a below-quorum test", required)
+		}
+		for v := 1; v <= votes; v++ {
+			if _, err := d.admitVote(v, candidate, "ubo-newbie-001"); err != nil {
+				t.Fatalf("admit_vote from magi-%d: %v", v, err)
+			}
+		}
+		time.Sleep(45 * time.Second)
+		after, err := d.poaSeats(ctx, 1)
+		if err != nil {
+			t.Fatalf("poa_seats: %v", err)
+		}
+		if len(after) != len(before) {
+			t.Errorf("candidate was SEATED on %d of %d votes (threshold is %d): %s",
+				votes, total, required, seatFingerprint(after))
+		}
+		for _, s := range after {
+			if s.Account == candidate {
+				t.Errorf("candidate %q present in the registry despite being one vote short", candidate)
+			}
+		}
+		t.Logf("candidate not seated on %d/%d votes (threshold %d) — correct", votes, total, required)
+	})
+
+	// ---- D13a: a seated operator's consensus_unstake is HELD by the exit-halt ----
+	t.Run("D13a_seated_unstake_is_held", func(t *testing.T) {
+		acct := "hive:" + d.witnessAccount(2)
+		bal, err := d.GetAccountBalance(ctx, 1, acct)
+		// ★ FAIL, do not SKIP. A skipped subtest is indistinguishable from a
+		// passing one in a summary, and the first run of this test skipped here
+		// silently while the parent reported PASS -- the exit-halt was never
+		// exercised at all. Per feedback_vacuous_pass_is_worse_than_fail, a check
+		// with nothing to inspect must FAIL.
+		if err != nil || bal == nil {
+			t.Fatalf("cannot read balance for %s (err=%v). This account is a SEATED committee "+
+				"member, so it must have a readable ledger balance; not being able to read one is "+
+				"itself the finding.", acct, err)
+		}
+		before := bal.HiveConsensus
+		if before <= 0 {
+			t.Fatalf("%s reports hive_consensus=%d, but it is an ELECTED committee member and "+
+				"therefore must hold at least MinStake. Either the balance read is wrong or the "+
+				"election admitted an unstaked member -- both are findings, neither is a skip.",
+				acct, before)
+		}
+		t.Logf("%s hive_consensus before unstake attempt: %d", acct, before)
+
+		txId, err := d.ConsensusUnstake(2, "1.000")
+		if err != nil {
+			t.Fatalf("broadcasting consensus_unstake: %v", err)
+		}
+		time.Sleep(60 * time.Second)
+
+		// ★ ASSERT THE REASON, NOT JUST THE ABSENCE OF AN EFFECT.
+		// "hive_consensus did not move" is equally consistent with the tx simply
+		// not having been processed yet, so on its own it is not evidence the
+		// exit-halt fired. The refusal is a concrete TxResult
+		// (transactions.go:887-899, Success:false with a message beginning
+		// "consensus bond is locked: POA collateral exit-halt"), so require the
+		// transaction to have actually been PROCESSED and to have failed.
+		status, serr := d.FindTransactionStatus(ctx, 1, txId)
+		if serr != nil {
+			t.Errorf("could not read status for the unstake tx %s (%v). Without it, an unchanged "+
+				"balance does not distinguish 'the exit-halt refused it' from 'it has not been "+
+				"processed yet'.", txId, serr)
+		} else {
+			t.Logf("unstake tx %s status=%s", txId, status)
+			if strings.EqualFold(status, "UNCONFIRMED") || status == "" {
+				t.Errorf("unstake tx %s is still %q after 60s — the balance check below cannot "+
+					"distinguish a working exit-halt from an unprocessed transaction. Treat this "+
+					"run as INCONCLUSIVE rather than a pass.", txId, status)
+			}
+		}
+
+		bal2, err := d.GetAccountBalance(ctx, 1, acct)
+		if err != nil || bal2 == nil {
+			t.Fatalf("re-reading balance: %v", err)
+		}
+		if bal2.HiveConsensus < before {
+			t.Errorf("EXIT-HALT DID NOT HOLD: hive_consensus fell %d -> %d for a SEATED operator. "+
+				"An unstake that drains the bond while the account is still seated is the RG-1 shape: "+
+				"a slash afterwards targets a zero bond and silently no-ops.",
+				before, bal2.HiveConsensus)
+		} else {
+			t.Logf("exit-halt held: hive_consensus unchanged at %d for a seated operator", bal2.HiveConsensus)
+		}
+	})
+}

--- a/tests/devnet/poa_mass_departure_test.go
+++ b/tests/devnet/poa_mass_departure_test.go
@@ -1,0 +1,244 @@
+package devnet
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"vsc-node/modules/common/params"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// nodeLogContains greps a node's container logs for a pattern.
+func (d *Devnet) nodeLogContains(node int, pattern string, tailLines int) (bool, string) {
+	name := d.projectName + "-magi-" + itoa(node)
+	out, err := exec.Command("docker", "logs", "--tail", itoa(tailLines), name).CombinedOutput()
+	if err != nil {
+		return false, ""
+	}
+	var hits []string
+	for _, ln := range strings.Split(string(out), "\n") {
+		if strings.Contains(strings.ToLower(ln), strings.ToLower(pattern)) {
+			hits = append(hits, ln)
+		}
+	}
+	return len(hits) > 0, strings.Join(hits, "\n")
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	if neg {
+		return "-" + string(b)
+	}
+	return string(b)
+}
+
+// disableWitnessEverywhere sets enabled=false on an account's witness rows in
+// EVERY node's database, which is what actually removes it from ELECTION
+// eligibility: election generation reads
+// GetWitnessesAtBlockHeight(blk, witnesses.EnabledOnly()) (election-proposer.go:372).
+// Written to every node because witness records are consensus input and all nodes
+// must derive the identical committee.
+func disableWitnessEverywhere(t *testing.T, d *Devnet, ctx context.Context, account string, nodes int) int {
+	t.Helper()
+	client, err := d.mongoClient(ctx)
+	if err != nil {
+		t.Fatalf("mongo: %v", err)
+	}
+	defer client.Disconnect(ctx)
+	total := 0
+	for n := 1; n <= nodes; n++ {
+		res, err := client.Database(d.nodeDbName(n)).Collection("witnesses").UpdateMany(ctx,
+			bson.M{"account": account}, bson.M{"$set": bson.M{"enabled": false}})
+		if err != nil {
+			t.Fatalf("disabling %s on magi-%d: %v", account, n, err)
+		}
+		total += int(res.MatchedCount)
+	}
+	return total
+}
+
+// TestPoaMassDeparture is scenario D14, REWRITTEN.
+//
+// ★★ THE FIRST VERSION OF THIS TEST HAD A WRONG PREMISE AND PASSED ANYWAY.
+// It stopped 3 of 5 NODES and claimed that drove the committee below MinMembers.
+// It does not. Election generation reads
+// GetWitnessesAtBlockHeight(blk, witnesses.EnabledOnly()) — it filters on the
+// on-chain `enabled` flag, NOT on liveness — and banSystemEnabled is false. A
+// stopped node keeps its witness record and stays ELECTED and SEATED. (Directly
+// corroborated by the late-joiner run, where a node stopped across the entire
+// activation transition was still written into the founding registry.) So the old
+// test only made nodes unreachable, which is D10's territory, and the MinMembers
+// guard was never exercised at all.
+//
+// This version removes witnesses from ELECTION ELIGIBILITY by disabling their
+// records, which is what a witness actually does when it stands down. The nodes
+// stay UP, so the existing committee can still reach quorum and the chain keeps
+// producing — which is exactly what makes the guard observable in isolation
+// rather than tangled up with a liveness halt.
+//
+// What it asserts: the churn cap (PoaMaxNewMembersPerElection) throttles
+// ADMISSIONS only, nothing caps DEPARTURES, so a set can be driven under
+// MinMembers faster than it can refill. The GV4-3 guard must REJECT such an
+// election rather than persist a degenerate committee and divide by zero in
+// consensus.GenerateSchedule — the shape that halted mainnet elections at epoch
+// 1699.
+func TestPoaMassDeparture(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	cfg := tssTestConfig()
+	if cfg.SysConfigOverrides.ConsensusParams == nil {
+		cfg.SysConfigOverrides.ConsensusParams = &params.ConsensusParams{}
+	}
+	// ★ FloorEpoch MUST be non-zero.
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorMajor = 0
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorConsensus = 7
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorEpoch = 1
+
+	d, ctx := startDevnetNoKey(t, cfg, 45*time.Minute)
+
+	for n := 1; n <= cfg.Nodes; n++ {
+		nctx, cancel := context.WithTimeout(ctx, 12*time.Minute)
+		err := d.waitForElectionEpoch(nctx, n, 2, 12*time.Minute)
+		cancel()
+		if err != nil {
+			t.Fatalf("magi-%d never reached epoch 2: %v", n, err)
+		}
+	}
+
+	elec, err := d.GetElectionGQL(ctx, 1, 2)
+	if err != nil {
+		t.Fatalf("reading election epoch 2: %v", err)
+	}
+	for i, w := range elec.Weights {
+		if w != params.PoaSeatWeight {
+			t.Fatalf("PRECONDITION FAILED: weight[%d]=%d want flat %d — POA INERT", i, w, params.PoaSeatWeight)
+		}
+	}
+	minMembers := cfg.SysConfigOverrides.ConsensusParams.MinMembers
+	if minMembers == 0 {
+		minMembers = 3
+	}
+	t.Logf("POA ACTIVE with %d flat seats; MinMembers=%d", len(elec.Members), minMembers)
+
+	// Disable enough witnesses that only (MinMembers-1) remain ELIGIBLE.
+	keep := int(minMembers) - 1
+	disabled := []string{}
+	for node := cfg.Nodes; node > keep; node-- {
+		acct := d.witnessAccount(node)
+		n := disableWitnessEverywhere(t, d, ctx, acct, cfg.Nodes)
+		if n == 0 {
+			t.Fatalf("no witness rows matched %s — cannot establish the premise", acct)
+		}
+		disabled = append(disabled, acct)
+		t.Logf("disabled witness %s (%d rows across all node DBs)", acct, n)
+	}
+	t.Logf("%d of %d witnesses disabled, leaving %d eligible (MinMembers=%d). All nodes remain UP.",
+		len(disabled), cfg.Nodes, keep, minMembers)
+
+	// Give the network several election intervals to try (and refuse) to form one.
+	time.Sleep(5 * time.Minute)
+
+	// ---- 1. no node may crash or panic ----
+	for node := 1; node <= cfg.Nodes; node++ {
+		name := d.projectName + "-magi-" + itoa(node)
+		out, _ := exec.Command("docker", "inspect", "-f", "{{.State.Running}}", name).CombinedOutput()
+		if strings.TrimSpace(string(out)) != "true" {
+			t.Errorf("magi-%d is NOT RUNNING after the eligible set fell below MinMembers. A "+
+				"degenerate committee must be REFUSED, never fatal.", node)
+			continue
+		}
+		if hit, lines := d.nodeLogContains(node, "panic", 3000); hit {
+			t.Errorf("magi-%d PANICKED:\n%s", node, poaTrunc(lines, 1200))
+		}
+		if hit, lines := d.nodeLogContains(node, "divide by zero", 3000); hit {
+			t.Errorf("magi-%d hit DIVIDE-BY-ZERO — the GV4-3 MinMembers guard did not catch the "+
+				"degenerate committee. This is the epoch-1699 mainnet halt shape:\n%s",
+				node, poaTrunc(lines, 800))
+		}
+	}
+
+	// ---- 2. no election below MinMembers may be persisted ----
+	// Walk forward from the last known-good epoch; any election that exists must
+	// still satisfy MinMembers.
+	// ★ COUNT WHAT WAS ACTUALLY INSPECTED. The first version of this loop reported
+	// "smallest committee persisted: 5" when it had inspected ZERO elections -- 5
+	// was merely the initial value of the variable. A loop that finds nothing must
+	// say so and fail, not emit its seed value as though it were an observation
+	// (feedback_vacuous_pass_is_worse_than_fail).
+	worst := -1
+	inspected := 0
+	var seen []uint64
+	for e := uint64(3); e <= 10; e++ {
+		el, err := d.GetElectionGQL(ctx, 1, e)
+		if err != nil {
+			continue
+		}
+		inspected++
+		seen = append(seen, e)
+		t.Logf("epoch %d persisted with %d members: %v", e, len(el.Members), el.Members)
+		if worst < 0 || len(el.Members) < worst {
+			worst = len(el.Members)
+		}
+		if len(el.Members) < int(minMembers) {
+			t.Errorf("DEGENERATE COMMITTEE PERSISTED: epoch %d has %d members, below MinMembers=%d. "+
+				"The GV4-3 guard is supposed to reject this BEFORE it can drive "+
+				"consensus.GenerateSchedule into a divide-by-zero.", e, len(el.Members), minMembers)
+		}
+	}
+	if inspected == 0 {
+		// This is a legitimate and expected outcome -- with the eligible set below
+		// MinMembers no NEW election can form, so the chain keeps the last good
+		// committee -- but it must be stated as an observation, not hidden behind a
+		// seed value. Verify the last known-good election is still the head.
+		t.Logf("NO new election persisted at epochs 3-10. With only %d eligible witnesses and "+
+			"MinMembers=%d this is the expected safe outcome: no degenerate committee can be "+
+			"formed, so the last good committee (epoch 2, %d members) is retained.",
+			keep, minMembers, len(elec.Members))
+		if len(elec.Members) < int(minMembers) {
+			t.Errorf("the RETAINED committee itself is below MinMembers (%d < %d)",
+				len(elec.Members), minMembers)
+		}
+	} else {
+		t.Logf("inspected %d persisted election(s) at epochs %v; smallest committee=%d (MinMembers=%d)",
+			inspected, seen, worst, minMembers)
+	}
+
+	// ---- 3. observability: did the guard say anything? ----
+	spoke := false
+	for node := 1; node <= cfg.Nodes; node++ {
+		if hit, lines := d.nodeLogContains(node, "MinMembers", 3000); hit {
+			spoke = true
+			t.Logf("magi-%d guard log:\n%s", node, poaTrunc(lines, 600))
+			break
+		}
+	}
+	if !spoke {
+		t.Logf("NOTE: no MinMembers log line on any node. The eligible set fell below the floor with " +
+			"no operator-visible message — worth fixing separately; an operator would have no signal " +
+			"that elections had stopped advancing for this reason.")
+	}
+}
+
+func poaTrunc(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…(truncated)"
+}

--- a/tests/devnet/poa_readiness_guard_test.go
+++ b/tests/devnet/poa_readiness_guard_test.go
@@ -1,0 +1,203 @@
+package devnet
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"vsc-node/modules/common/params"
+)
+
+// pendingVersionProposals reads a node's pending consensus-version proposals.
+// Used as the POSITIVE CONTROL for the negative test below: it distinguishes
+// "the guard refused the rise" from "the proposal op never landed at all".
+func (d *Devnet) pendingVersionProposals(ctx context.Context, node int) ([]struct {
+	Target          string `json:"target"`
+	ActivationEpoch uint64 `json:"activation_epoch"`
+	Proposer        string `json:"proposer"`
+}, error) {
+	const q = `{localNodeInfo{consensus_version_proposals{target activation_epoch proposer}}}`
+	var out struct {
+		LocalNodeInfo struct {
+			Proposals []struct {
+				Target          string `json:"target"`
+				ActivationEpoch uint64 `json:"activation_epoch"`
+				Proposer        string `json:"proposer"`
+			} `json:"consensus_version_proposals"`
+		} `json:"localNodeInfo"`
+	}
+	if err := d.gqlQuery(ctx, node, q, nil, &out); err != nil {
+		return nil, err
+	}
+	return out.LocalNodeInfo.Proposals, nil
+}
+
+// TestPoaReadinessGuardRefusesPrematureRise is scenario D12-NEGATIVE, and it is
+// the most important scenario that was still uncovered.
+//
+// TestPoaActivationViaProposal proved the floor RISES when the network is ready.
+// Nothing proved it REFUSES when the network is not — and that refusal is the
+// vault-freeze protection. resolveVersionFloor (election-proposer.go:441-516)
+// requires BOTH:
+//
+//	stakeReady   — >= 4/5 of committee stake announces a version meeting the target
+//	prevReadyAt  — the OUTGOING committee still retains quorum on the target
+//
+// The second exists specifically because advancing past the outgoing committee
+// filters its members out, and that committee holds the live TSS key shares: rise
+// too early and BTC keysign/reshare loses threshold and the vault FREEZES. A
+// config pin (Route A) has no such guard, which is exactly why Route B is the
+// safer activation path and why this refusal must be shown to work.
+//
+// ★★ THIS IS A NEGATIVE TEST, the most dangerous kind to write: "nothing
+// happened" is also what a broken devnet, a dropped transaction, or a typo
+// produces. Three defences make the absence meaningful:
+//
+//  1. PREMISE  — assert readiness is genuinely BELOW threshold (2 of 5 witnesses
+//     really are announcing a below-target version, verified from their records).
+//  2. CONTROL  — assert the proposal was ACCEPTED and is pending on-chain. If the
+//     op never landed, a non-rise proves nothing about the guard.
+//  3. OUTCOME  — assert POA is still inert after several epochs.
+//
+// Without (2) especially, this test would pass against a devnet where the
+// proposal simply failed to broadcast.
+//
+// Set POA_OLD_SOURCE to a checkout announcing below 0.7.0 (origin/main = 0.3.0).
+func TestPoaReadinessGuardRefusesPrematureRise(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+	oldSrc := os.Getenv("POA_OLD_SOURCE")
+	if oldSrc == "" {
+		t.Skip("POA_OLD_SOURCE not set (path to a checkout announcing < 0.7.0)")
+	}
+
+	cfg := tssTestConfig()
+	// NO floor override: POA starts inert and only a proposal could raise it.
+	// Two of five nodes run the old binary, so at most 3/5 = 60% of stake can
+	// announce 0.7.0 — below the 4/5 stakeReady threshold.
+	laggards := []int{cfg.Nodes - 1, cfg.Nodes} // magi-4, magi-5
+	cfg.OldCodeSourceDir = oldSrc
+	cfg.OldCodeNodes = laggards
+
+	d, ctx := startDevnetNoKey(t, cfg, 50*time.Minute)
+
+	upgraded := cfg.Nodes - len(laggards)
+	for n := 1; n <= upgraded; n++ {
+		nctx, cancel := context.WithTimeout(ctx, 12*time.Minute)
+		err := d.waitForElectionEpoch(nctx, n, 1, 12*time.Minute)
+		cancel()
+		if err != nil {
+			t.Fatalf("magi-%d never ingested epoch >= 1: %v", n, err)
+		}
+	}
+
+	// ---- DEFENCE 1: readiness really is below threshold ----
+	belowCount := 0
+	for _, n := range laggards {
+		acct := d.witnessAccount(n)
+		major, proto, found := d.announcedVersion(ctx, 1, acct)
+		if !found {
+			t.Fatalf("PREMISE FAILED: no witness record for laggard %s — cannot establish that "+
+				"readiness is below threshold", acct)
+		}
+		if major != 0 || proto >= 7 {
+			t.Fatalf("PREMISE FAILED: laggard %s announces %d.%d, which MEETS the 0.7.0 target. "+
+				"Readiness would then be 5/5 and a non-rise would be inexplicable rather than "+
+				"attributable to the guard.", acct, major, proto)
+		}
+		belowCount++
+		t.Logf("laggard %s announces %d.%d (below target)", acct, major, proto)
+	}
+	elec1, err := d.GetElectionGQL(ctx, 1, 1)
+	if err != nil {
+		t.Fatalf("reading election epoch 1: %v", err)
+	}
+	readyFrac := float64(len(elec1.Members)-belowCount) / float64(len(elec1.Members))
+	t.Logf("PREMISE OK: %d of %d committee members announce >= 0.7.0 (%.0f%%), below the 4/5 (80%%) "+
+		"stakeReady threshold", len(elec1.Members)-belowCount, len(elec1.Members), readyFrac*100)
+	if readyFrac >= 0.8 {
+		t.Fatalf("PREMISE FAILED: readiness is %.0f%%, at or above the 80%% threshold — the guard "+
+			"SHOULD allow the rise, so refusing to rise would be the bug, not the expected result",
+			readyFrac*100)
+	}
+
+	// POA must be inert to begin with.
+	for _, w := range elec1.Weights {
+		if w == params.PoaSeatWeight && len(elec1.Weights) > 1 {
+			t.Fatalf("PRECONDITION FAILED: weights already flat %v before any proposal", elec1.Weights)
+		}
+	}
+
+	// ---- propose 0.7.0 from the UPGRADED members (a node may only propose a
+	// version it announces, so the laggards cannot propose it at all) ----
+	cur, _ := d.currentEpoch(ctx, 1)
+	target := cur + 2
+	t.Logf("current epoch %d; proposing 0.7.0 for activation at epoch %d from %d upgraded members",
+		cur, target, upgraded)
+	for n := 1; n <= upgraded; n++ {
+		if _, err := d.proposeConsensusVersion(n, 0, 7, target); err != nil {
+			t.Logf("propose from magi-%d failed (continuing): %v", n, err)
+		}
+	}
+
+	// ---- DEFENCE 2 (THE CONTROL): the proposal must actually be pending ----
+	var pending int
+	deadline := time.Now().Add(6 * time.Minute)
+	for time.Now().Before(deadline) {
+		time.Sleep(20 * time.Second)
+		props, err := d.pendingVersionProposals(ctx, 1)
+		if err != nil {
+			continue
+		}
+		if len(props) > 0 {
+			pending = len(props)
+			for _, p := range props {
+				t.Logf("pending proposal recorded on-chain: target=%s activation_epoch=%d proposer=%s",
+					p.Target, p.ActivationEpoch, p.Proposer)
+			}
+			break
+		}
+	}
+	if pending == 0 {
+		t.Fatalf("CONTROL FAILED: no consensus-version proposal is pending after broadcasting from %d "+
+			"members. The absence of an activation below would then be explained by the op never "+
+			"landing, NOT by the readiness guard. Treat this run as INCONCLUSIVE.", upgraded)
+	}
+
+	// ---- DEFENCE 3: and yet POA must NOT activate ----
+	for e := target; e <= target+3; e++ {
+		nctx, cancel := context.WithTimeout(ctx, 8*time.Minute)
+		_ = d.waitForElectionEpoch(nctx, 1, e, 8*time.Minute)
+		cancel()
+		el, err := d.GetElectionGQL(ctx, 1, e)
+		if err != nil || el == nil {
+			continue
+		}
+		flat := len(el.Weights) > 0
+		for _, w := range el.Weights {
+			if w != params.PoaSeatWeight {
+				flat = false
+				break
+			}
+		}
+		t.Logf("epoch %d weights=%v flat=%v members=%d", e, el.Weights, flat, len(el.Members))
+		if flat {
+			t.Fatalf("READINESS GUARD FAILED: POA ACTIVATED at epoch %d with only %.0f%% of stake "+
+				"announcing the target. The guard exists to stop exactly this: advancing the floor "+
+				"past the outgoing committee filters out the members holding the live TSS shares, "+
+				"which freezes the BTC vault. weights=%v", e, readyFrac*100, el.Weights)
+		}
+	}
+
+	seats, _ := d.poaSeats(ctx, 1)
+	if len(seats) != 0 {
+		t.Errorf("READINESS GUARD FAILED: the seat registry was seeded (%d rows) despite the floor "+
+			"never rising: %s", len(seats), seatFingerprint(seats))
+	}
+
+	t.Logf("CONFIRMED: with %.0f%% readiness the proposal was ACCEPTED (%d pending) but the floor did "+
+		"NOT rise and POA stayed inert. The vault-freeze protection works — this is the guard a "+
+		"config-pin activation (Route A) does not have.", readyFrac*100, pending)
+}

--- a/tests/devnet/poa_registry_failure_states_test.go
+++ b/tests/devnet/poa_registry_failure_states_test.go
@@ -1,0 +1,240 @@
+package devnet
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	"vsc-node/modules/common/params"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// wipeRegistry deletes a single node's poa_seats collection, simulating the
+// "this node LOST its registry" case the bootstrap guard is written to detect.
+func wipeRegistry(t *testing.T, d *Devnet, ctx context.Context, node int) int64 {
+	t.Helper()
+	client, err := d.mongoClient(ctx)
+	if err != nil {
+		t.Fatalf("mongo: %v", err)
+	}
+	defer client.Disconnect(ctx)
+	res, err := client.Database(d.nodeDbName(node)).Collection("poa_seats").DeleteMany(ctx, bson.M{})
+	if err != nil {
+		t.Fatalf("wiping poa_seats on magi-%d: %v", node, err)
+	}
+	return res.DeletedCount
+}
+
+// TestPoaLostRegistryFailsClosed is scenario D16.
+//
+// poa_seats is NOT part of any merklized state and the reindex trigger keys off a
+// hive_blocks marker, so the collection can be dropped or restored independently
+// of chain history. The code calls the consequence out explicitly
+// (poa_seats.go:100-127): an empty registry has two very different causes, and
+// conflating them means "a node that loses its registry silently re-seeds from
+// whatever the CURRENT committee happens to be, and then disagrees with every peer
+// that still holds the true one — a divergence with no checkpoint or repair path
+// anywhere to catch it."
+//
+// So the required behaviour on a LOST registry is: refuse to re-seed, stay inert,
+// and say so loudly. This test destroys one node's registry AFTER activation and
+// requires exactly that. A node that silently re-bootstraps here is the worst
+// outcome POA can produce: a permanent, undetectable split over who may be elected.
+func TestPoaLostRegistryFailsClosed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	cfg := tssTestConfig()
+	if cfg.SysConfigOverrides.ConsensusParams == nil {
+		cfg.SysConfigOverrides.ConsensusParams = &params.ConsensusParams{}
+	}
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorMajor = 0
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorConsensus = 7
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorEpoch = 1
+
+	d, ctx := startDevnetNoKey(t, cfg, 50*time.Minute)
+
+	for n := 1; n <= cfg.Nodes; n++ {
+		nctx, cancel := context.WithTimeout(ctx, 12*time.Minute)
+		err := d.waitForElectionEpoch(nctx, n, 2, 12*time.Minute)
+		cancel()
+		if err != nil {
+			t.Fatalf("magi-%d never reached epoch 2: %v", n, err)
+		}
+	}
+	elec, err := d.GetElectionGQL(ctx, 1, 2)
+	if err != nil {
+		t.Fatalf("reading election epoch 2: %v", err)
+	}
+	for i, w := range elec.Weights {
+		if w != params.PoaSeatWeight {
+			t.Fatalf("PRECONDITION FAILED: weight[%d]=%d want flat %d — POA INERT", i, w, params.PoaSeatWeight)
+		}
+	}
+	reference, err := d.poaSeats(ctx, 1)
+	if err != nil || len(reference) == 0 {
+		t.Fatalf("PRECONDITION FAILED: no reference registry (%v)", err)
+	}
+	refFp := seatFingerprint(reference)
+	t.Logf("reference registry (%d seats): %s", len(reference), refFp)
+
+	victim := cfg.Nodes
+	if err := d.StopNode(ctx, victim); err != nil {
+		t.Fatalf("stopping magi-%d: %v", victim, err)
+	}
+	deleted := wipeRegistry(t, d, ctx, victim)
+	if deleted == 0 {
+		t.Fatalf("PREMISE FAILED: magi-%d had no seats to delete, so nothing was lost", victim)
+	}
+	t.Logf("destroyed magi-%d's registry (%d rows deleted) and restarting it", victim, deleted)
+	if err := d.StartNode(ctx, victim); err != nil {
+		t.Fatalf("restarting magi-%d: %v", victim, err)
+	}
+
+	// Let it catch up and process several elections. If it is going to re-seed
+	// incorrectly, this is when it happens.
+	time.Sleep(6 * time.Minute)
+
+	after, err := d.poaSeats(ctx, victim)
+	if err != nil {
+		t.Fatalf("reading magi-%d registry: %v", victim, err)
+	}
+	afterFp := seatFingerprint(after)
+	t.Logf("magi-%d registry after the loss (%d seats): %s", victim, len(after), afterFp)
+
+	switch {
+	case len(after) == 0:
+		t.Logf("ACCEPTABLE (fail-closed): magi-%d refused to re-seed and stayed empty. The seat gate "+
+			"is inert on this node and it does not fabricate a registry. Operator must restore or "+
+			"full-reindex.", victim)
+		if hit, lines := d.nodeLogContains(victim, "not the activation transition", 4000); hit {
+			t.Logf("guard spoke as designed:\n%s", poaTrunc(lines, 700))
+		} else {
+			t.Errorf("magi-%d failed closed but emitted NO 'not the activation transition' message. "+
+				"An operator would have a silently inert node and no way to know why — the guard's "+
+				"own comment says the safe response is to leave it empty AND say so loudly.", victim)
+		}
+	case afterFp == refFp:
+		t.Logf("ACCEPTABLE (recovered): magi-%d rebuilt the IDENTICAL registry, so no divergence.", victim)
+	default:
+		t.Errorf("SILENT REGISTRY DIVERGENCE — the worst outcome POA can produce. magi-%d re-seeded a "+
+			"DIFFERENT registry after losing its own, so it now disagrees with its peers about who may "+
+			"be elected, with no checkpoint or repair path to detect it.\n  peers:   %s\n  magi-%d: %s",
+			victim, refFp, victim, afterFp)
+	}
+
+	// Whatever happened, the node must be alive and must not have panicked.
+	name := d.projectName + "-magi-" + itoa(victim)
+	out, _ := exec.Command("docker", "inspect", "-f", "{{.State.Running}}", name).CombinedOutput()
+	if string(out) == "" || len(out) < 4 {
+		t.Errorf("could not inspect magi-%d", victim)
+	}
+	if hit, lines := d.nodeLogContains(victim, "panic", 4000); hit {
+		t.Errorf("magi-%d PANICKED after losing its registry:\n%s", victim, poaTrunc(lines, 900))
+	}
+}
+
+// TestPoaCrashDuringActivation is scenario D17.
+//
+// bootstrapPoaSeats fires at exactly ONE transition and explicitly refuses to
+// retry (poa_seats.go:420-426). A node that dies while that transition is being
+// processed is therefore the most direct route to a permanently missing or partial
+// registry: it never sees the one moment it was allowed to seed.
+//
+// This SIGKILLs a node (docker kill, not a graceful stop) around the activation
+// transition, restarts it, and requires it to converge on the identical registry.
+func TestPoaCrashDuringActivation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	cfg := tssTestConfig()
+	if cfg.SysConfigOverrides.ConsensusParams == nil {
+		cfg.SysConfigOverrides.ConsensusParams = &params.ConsensusParams{}
+	}
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorMajor = 0
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorConsensus = 7
+	cfg.SysConfigOverrides.ConsensusParams.ConsensusVersionFloorEpoch = 1
+
+	d, ctx := startDevnetNoKey(t, cfg, 50*time.Minute)
+
+	victim := cfg.Nodes
+	name := d.projectName + "-magi-" + itoa(victim)
+
+	// Wait for the activation election to exist, then SIGKILL immediately — the
+	// transition is being processed right around here.
+	nctx, cancel := context.WithTimeout(ctx, 12*time.Minute)
+	if err := d.waitForElectionEpoch(nctx, 1, 1, 12*time.Minute); err != nil {
+		cancel()
+		t.Fatalf("magi-1 never ingested epoch 1: %v", err)
+	}
+	cancel()
+
+	out, err := exec.Command("docker", "kill", name).CombinedOutput()
+	if err != nil {
+		t.Fatalf("SIGKILL magi-%d: %v (%s)", victim, err, out)
+	}
+	t.Logf("SIGKILLed magi-%d at the activation transition (ungraceful, no shutdown hooks)", victim)
+
+	time.Sleep(90 * time.Second)
+	if err := d.StartNode(ctx, victim); err != nil {
+		t.Fatalf("restarting magi-%d: %v", victim, err)
+	}
+	t.Logf("restarted magi-%d", victim)
+
+	// Peers must reach flat weight and a seeded registry.
+	for n := 1; n < victim; n++ {
+		nctx, cancel := context.WithTimeout(ctx, 12*time.Minute)
+		_ = d.waitForElectionEpoch(nctx, n, 2, 12*time.Minute)
+		cancel()
+	}
+	elec, err := d.GetElectionGQL(ctx, 1, 2)
+	if err != nil {
+		t.Fatalf("reading election epoch 2: %v", err)
+	}
+	for i, w := range elec.Weights {
+		if w != params.PoaSeatWeight {
+			t.Fatalf("PRECONDITION FAILED: weight[%d]=%d want flat %d — POA INERT", i, w, params.PoaSeatWeight)
+		}
+	}
+	reference, err := d.poaSeats(ctx, 1)
+	if err != nil || len(reference) == 0 {
+		t.Fatalf("PRECONDITION FAILED: no reference registry (%v)", err)
+	}
+	refFp := seatFingerprint(reference)
+	t.Logf("peer reference registry (%d seats): %s", len(reference), refFp)
+
+	// Give the crashed node time to catch up.
+	var gotFp string
+	var got []poaSeatDoc
+	deadline := time.Now().Add(12 * time.Minute)
+	for time.Now().Before(deadline) {
+		time.Sleep(30 * time.Second)
+		got, err = d.poaSeats(ctx, victim)
+		if err != nil {
+			continue
+		}
+		gotFp = seatFingerprint(got)
+		if gotFp == refFp {
+			break
+		}
+	}
+
+	if gotFp == refFp {
+		t.Logf("CONFIRMED: magi-%d converged on the IDENTICAL registry (%d seats) after being killed "+
+			"across the activation transition.", victim, len(got))
+		return
+	}
+	if len(got) == 0 {
+		t.Errorf("magi-%d has an EMPTY registry after crashing across the activation transition. "+
+			"bootstrap fires exactly once and refuses to retry, so this node has permanently missed "+
+			"its only chance to seed: its seat gate stays inert and it silently disagrees with peers "+
+			"about who may be elected.", victim)
+		return
+	}
+	t.Errorf("REGISTRY DIVERGENCE after a crash across the activation transition — magi-%d holds a "+
+		"DIFFERENT registry from its peers.\n  peers:   %s\n  magi-%d: %s", victim, refFp, victim, gotFp)
+}

--- a/tests/devnet/poa_route_b_activation_test.go
+++ b/tests/devnet/poa_route_b_activation_test.go
@@ -1,0 +1,164 @@
+package devnet
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"vsc-node/modules/common/params"
+)
+
+// proposeConsensusVersion broadcasts vsc.propose_consensus_version from a witness.
+func (d *Devnet) proposeConsensusVersion(witness int, major, consensus, activationEpoch uint64) (string, error) {
+	acct := d.witnessAccount(witness)
+	payload := map[string]interface{}{
+		"net_id":           d.netId(),
+		"major":            major,
+		"consensus":        consensus,
+		"non_consensus":    0,
+		"activation_epoch": activationEpoch,
+	}
+	return d.BroadcastCustomJSON("vsc.propose_consensus_version", []string{acct}, payload, d.cfg.InitminerWIF)
+}
+
+// currentEpoch reads the highest election epoch a node has ingested.
+func (d *Devnet) currentEpoch(ctx context.Context, node int) (uint64, error) {
+	for e := uint64(60); e > 0; e-- {
+		if _, err := d.GetElectionGQL(ctx, node, e); err == nil {
+			return e, nil
+		}
+	}
+	return 0, nil
+}
+
+// TestPoaActivationViaProposal is the Route B scenario, and it is the one that
+// matters most operationally: it is the EXACT procedure we would run on testnet.
+//
+// The July runbook recommended Route A (edit the ConsensusVersionFloor* fields in
+// system-config.go and redeploy). But the live testnet reached 0.5.0 with its
+// config pin still reading epoch 765 / consensus 3, which means 0.4.0 and 0.5.0
+// were rolled out with the ON-CHAIN op, not a config edit. Route B is therefore
+// the established practice here, and unlike a config pin it carries the readiness
+// guard (resolveVersionFloor, election-proposer.go:441-516): the floor only rises
+// once >= 4/5 of committee stake announces the target AND the outgoing committee
+// still holds quorum on it, which is what stops an activation from filtering the
+// TSS share-holders below threshold and freezing the BTC vault.
+//
+// Nothing has ever tested that path. This test deliberately does NOT pin the
+// floor: it leaves the devnet default, confirms POA is inert, then activates it
+// the way a real operator would — by posting the op from a committee member — and
+// asserts the floor actually rises and POA comes up.
+func TestPoaActivationViaProposal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping devnet integration test in short mode")
+	}
+
+	cfg := tssTestConfig()
+	// ★ NO floor override. POA must start INERT so the proposal is what activates it.
+	d, ctx := startDevnetNoKey(t, cfg, 45*time.Minute)
+
+	for n := 1; n <= cfg.Nodes; n++ {
+		nctx, cancel := context.WithTimeout(ctx, 12*time.Minute)
+		err := d.waitForElectionEpoch(nctx, n, 1, 12*time.Minute)
+		cancel()
+		if err != nil {
+			t.Fatalf("magi-%d never ingested epoch >= 1: %v", n, err)
+		}
+	}
+
+	// ---- PRECONDITION (inverted): POA must be INERT before we activate it ----
+	elec1, err := d.GetElectionGQL(ctx, 1, 1)
+	if err != nil {
+		t.Fatalf("reading election epoch 1: %v", err)
+	}
+	allFlat := true
+	for _, w := range elec1.Weights {
+		if w != params.PoaSeatWeight {
+			allFlat = false
+			break
+		}
+	}
+	if allFlat {
+		t.Fatalf("PRECONDITION FAILED: weights are already flat %v at epoch 1 — POA is active before "+
+			"the proposal, so this test would prove nothing about the proposal path", elec1.Weights)
+	}
+	seats0, _ := d.poaSeats(ctx, 1)
+	if len(seats0) != 0 {
+		t.Fatalf("PRECONDITION FAILED: registry already has %d seats before activation", len(seats0))
+	}
+	t.Logf("POA correctly INERT: epoch 1 weights=%v, registry empty", elec1.Weights)
+
+	// ---- activate the way an operator would ----
+	cur, err := d.currentEpoch(ctx, 1)
+	if err != nil || cur == 0 {
+		t.Fatalf("cannot determine current epoch: %v", err)
+	}
+	target := cur + 2 // a couple of epochs of margin, as on testnet
+	t.Logf("current epoch %d; proposing 0.7.0 for activation at epoch %d", cur, target)
+
+	// Every committee member proposes, so stake-readiness is unambiguous. On
+	// testnet ONE member posting is enough; the guard is about ANNOUNCED versions,
+	// not about how many proposed.
+	for n := 1; n <= cfg.Nodes; n++ {
+		if _, err := d.proposeConsensusVersion(n, 0, 7, target); err != nil {
+			t.Logf("propose from magi-%d failed (continuing): %v", n, err)
+		}
+	}
+
+	// ---- the floor must rise and POA must come up ----
+	// Flat weight lands one epoch after the floor is active (see the two-epoch
+	// note in poa_bootstrap_test.go), so allow through target+2.
+	deadline := time.Now().Add(20 * time.Minute)
+	activated := false
+	var seenEpoch uint64
+	var seenWeights []uint64
+	for time.Now().Before(deadline) && !activated {
+		time.Sleep(20 * time.Second)
+		for e := target; e <= target+3; e++ {
+			el, err := d.GetElectionGQL(ctx, 1, e)
+			if err != nil {
+				continue
+			}
+			flat := len(el.Weights) > 0
+			for _, w := range el.Weights {
+				if w != params.PoaSeatWeight {
+					flat = false
+					break
+				}
+			}
+			seenEpoch, seenWeights = e, el.Weights
+			if flat {
+				activated = true
+				break
+			}
+		}
+	}
+	if !activated {
+		t.Fatalf("POA did NOT activate via vsc.propose_consensus_version. Last seen epoch %d "+
+			"weights=%v. This is the exact procedure intended for testnet, so a failure here is a "+
+			"blocker for the testnet rollout, not a test problem.", seenEpoch, seenWeights)
+	}
+	t.Logf("ACTIVATED VIA PROPOSAL: epoch %d carries flat weights %v", seenEpoch, seenWeights)
+
+	// ---- and the registry must be seeded, identically, everywhere ----
+	want := ""
+	for n := 1; n <= cfg.Nodes; n++ {
+		seats, err := d.poaSeats(ctx, n)
+		if err != nil {
+			t.Errorf("magi-%d poa_seats: %v", n, err)
+			continue
+		}
+		if len(seats) == 0 {
+			t.Errorf("magi-%d: registry EMPTY after activation via proposal", n)
+			continue
+		}
+		fp := seatFingerprint(seats)
+		t.Logf("magi-%d registry (%d seats): %s", n, len(seats), fp)
+		if n == 1 {
+			want = fp
+		} else if fp != want {
+			t.Errorf("REGISTRY DIVERGENCE after proposal-driven activation, magi-1 vs magi-%d\n  %s\n  %s",
+				n, want, fp)
+		}
+	}
+}


### PR DESCRIPTION
### Why this exists

POA is code-complete on `develop` but had never been run against a live multi-node network. Pointing a
devnet at it surfaced one product gap and seven defects that only appear under crash, replay or
degraded-DB conditions, which is exactly the set that unit tests do not reach. Every one of them is
either unrecoverable or fund-touching, because the POA seat registry is append-only by design: there is
no Delete, no Revoke, and no vote can remove a seat. Anything wrong that gets written at activation
stays wrong permanently.

None of this is speculative. The devnet suite in the last commit is what found most of it.

### The fixes

| | Fix | What it prevents |
|---|---|---|
| C1 | `ActiveConsensusVersion` fail-stops instead of returning `Version{}` | The old code returned the zero version on ANY read error, which reads as "consensus 0.0.0" and switches off every gate resolved through it. `IsPoaExitHalted` is one of those, and it decides whether a consensus bond payout is HELD. One transient Mongo blip on one node therefore released a bond its peers refused: a silent, one-node, fund-moving ledger divergence with nothing logged. |
| C2 | Bootstrap is replay-complete | The transition test sat inside `if len(seats) == 0`, so bootstrap became unreachable once the registry held one row. That is the state a crash leaves behind: `AdmitSeat` writes one row at a time, the streamer checkpoints only after the block finishes. A node killed midway restarted, replayed, found a non-empty registry, skipped bootstrap forever, and fell into a maintenance loop that can only iterate rows that already exist. Permanently short, permanently divergent, permanently unrepairable. |
| C3, C6 | POA rules bind to the gate outcome, not to a nil check | `poaActive` re-derived its verdict from `poaSeats != nil`, which is true whenever the registry is merely wired. The seat gate has two reachable paths where it declines to filter (empty registry, starvation refusal); on both, the old predicate still claimed POA was in force. The result was candidacy back to "anyone with MinStake" while every such candidate carried a full seat's weight, making committee weight purchasable at MinStake per seat: cheaper than the stake weighting POA replaced, and free of the vetting POA adds. The churn cap now resolves through its own `PoaChurnCapActive` gate, which previously had no functional call site and could drift silently. |
| C4 | Proof-of-possession is verified before a seat is written | With H-6 off, gateway-key PoP is not evaluated during election at all, and bootstrap wrote whatever was elected into the append-only registry. The consequence is not one bad epoch, it is a permanent member of the electorate holding a share of the ceil(2/3) veto over every future admission. Verified live on devnet before this fix (scenario D15). |
| C5 | `OverrideMinimumMemberCount` removed | Go zero-values struct fields, so any caller passing `ElectionOptions{}` without naming the field set the minimum member count to 0, deleting the proposer's only defence against proposing a committee too small to sign, rotate the gateway multisig or hold the TSS shares. Nothing in the repo ever passed it: pure downside, reachable by omission. |
| C7 | H-6 shadow mode | Every plan for re-enabling key-strict admission starts with "count the survivors first", and there was no way to count them short of running the gate, which is what halted mainnet at epoch 1699. The exclusion set is now computed on every election and logged with per-account reasons, while deletions still happen only when the gate is on. One implementation, two consumers, so the number read while the gate is off is exactly the number that drops when it is switched on. |
| C8 | Signability floor observed | `bondCommitteeFloor` is the size below which a committee cannot do its job even though the election is valid: under 8 keys gateway rotation is silently skipped, under ceil(2*prevN/3)+1 outstanding TSS keys strand. Nothing checked it, so a committee in the window between MinMembers and that floor was emitted silently, and the first symptom is a gateway that will not rotate. With the `vsc.dao` owner backstop already removed from the mainnet gateway account, that has no on-chain recovery. Log only, deliberately: see below. |
| | Stale S7 gateway fixture inverted | `TestAuditUnfixed_S7` asserted the OLD vulnerable behaviour of the function it tracked. When the fix landed its fixture began dereferencing a nil `ms`, and an unrecovered panic aborts the whole test binary. That file sorts third of thirteen in `package gateway`, so the ten files after it stopped running: the ceil(2/3) threshold guard, the uint64 stake-sort truncation guard, the gateway-key dedup that prevents a duplicate-`key_auths` rotation wedge, both underflow guards and the FUZZ-1 serializer repro. Ten of thirteen files in the package holding bridge custody were dead, and CI was green because nothing ran. The package now runs 29 tests instead of 6. |

Applied in the order C1, C2, C3/C6, C7, C5, C8, C4. C2 is sequenced before C3 on purpose: a build-map
review blocked C3 on the grounds that it moves a second consensus output onto an unreplicated registry,
but named its own release condition, "a retry-capable transition detector". C2 is that detector.

### Two subtleties worth a reviewer's attention

**C1 keeps `mongo.ErrNoDocuments` unretried, and that exemption is load-bearing.**
`GetElectionByHeight` queries `block_height $lt height`, so before the first election every block
legitimately has no election below it. A blanket fail-stop would wedge every node at genesis, on every
network. Absence returns the zero version, which is the correct pre-genesis answer. Only non-deterministic
errors block and retry. There is a test for the genesis-wedge arm specifically.

**C2 deliberately does NOT fold `prevElection == nil` into the transition test.**
A nil predecessor means "this node cannot see the previous election", which is absence of evidence, not
evidence of a transition. While the row count guarded the block that distinction was harmless. With the
row count gone, folding nil in would make every election with an unreadable predecessor re-seed from
whatever committee is current, quietly admitting accounts that were never voted in. `TestBootstrapHappensOnlyOnce`
caught this during development.

### What is deliberately NOT in this PR

| Item | Why not |
|---|---|
| C9 to C13, C16 (key-strict on 0.8.0 and the admission ladder) | Blocked on the C7 measurement. Enabling the gate before counting survivors is precisely what halted mainnet at epoch 1699. Read the shadow log for several epochs first. |
| C14 (post-advance member-count guard) | Mainnet only: `prevQuorum` at N=5 is 4, which is >= testnet MinMembers 3, so it cannot strand testnet. |
| C15 (signability floor as a hard refusal) | Needs a version gate and a "previous committee already cleared the floor" precondition, so it can only ever refuse to be the election that regresses a healthy network. Refusing today would make the check itself the thing that stalls the epoch, and on a 3-node devnet the floor of 8 exceeds the entire network. |
| Gateway `vsc.dao` backstop | Already irreversible on-chain. Needs an L1 `account_update` signed by the existing 18-key multisig. |

### Proof

**Full-repo suite**, 103 packages, 25m26s: 62 ok, 35 with no test files, 6 failing packages.
The packages this PR touches are green:

- `modules/election-proposer` ok
- `modules/gateway` ok, now running 29 tests rather than 6
- `modules/state-processing` fails only the 4 reds that already ship on the mainnet lineage
  (2 pendulum-oracle, 2 review2). No POA test fails.

**Every one of the 14 suite failures was classified by re-running it at clean `a52e3237`**, not by
reading code or trusting memory. All are pre-existing or environmental. This PR introduces zero
regressions. Two of them are worth flagging to maintainers independently of this work: `modules/p2p`
`Test` times out at both refs, and `TestFuzzAll/RapidSequentialCalls/RapidSetString` fails identically
at both refs, where 100 `setString` writes return `success=false` with an empty error and state reads
back "".

**Devnet**, 5 nodes, `TestPoaBootstrapDeterminism` PASS in 783s on this branch:

- activation epoch 1: 5 members, stake-derived weights `[2000000 x5]`
- epoch 2: POA active, all weights flat = 1, total = 5
- all 5 nodes derive a byte-identical registry, `magi.test1..5@101(bootstrap=true)`
- bootstrap fires exactly once

C4 is confirmed to have actually executed rather than passing silently: it is guarded by
`se.witnessDb != nil` and only logs on failure, so absence of an exclusion log proves nothing on its
own. `cmd/vsc-node/main.go:85` builds `witnessDb` unconditionally and passes it at :215, so the block
ran, and 5 of 5 witnesses proved both their consensus and gateway PoPs.

`go vet ./tests/devnet/` exits 0, which is the check that matters most for C5 since it deleted a
parameter from `HoldElection`'s signature. Every commit in this PR independently builds, test-compiles
and vets clean, so the series is bisect-safe.

### Launch preconditions this work creates

These are operator-facing and need to be understood before the activation epoch, not after.

1. **Every founding operator must announce a valid consensus-key AND gateway-key PoP before the floor
   rises.** C4 refuses to seed otherwise, and the refusal is terminal for POA on that network because
   the transition fires once. Current binaries announce both (`announcements.go:285`); the hazard is an
   operator running a binary that predates 2026-06-10.
2. **Bootstrap gets no grace epoch.** The election gate keys on the PRIOR election's version, which
   deliberately gives witnesses a full epoch to re-announce. Bootstrap fires on the transition election
   itself. Verify announcements BEFORE raising the floor.
3. **Read C7's shadow log for several epochs before considering key-strict.** That is its entire purpose.
4. **Flat seat weight changes finality.** On testnet the threshold moves from 3-of-5 to 4-of-5, so two
   witnesses down halts the chain. Adding a witness is far cheaper before activation than after, since
   afterwards it needs a supermajority of `admit_vote`s.
5. **Being offline does not cost a seat**, but announcing below the floor does. Those two look identical
   from outside and have opposite consequences.

### The devnet suite

Before this PR, `grep -l poa tests/devnet/*.go` returned nothing: the D1 to D9 plan was prose and had
never been executed. The last commit adds 12 files covering 14 scenarios, all run against a real
multi-node devnet: bootstrap determinism, flat-weight quorum enforcement, activation via
`vsc.propose_consensus_version`, laggard exclusion, the readiness guard refusing a premature rise,
exit-halt hold and release, late-joiner replay, admission round-trip, mass departure, registry failure
states, duplicate admission and sub-quorum admission.

`poa_h6_unproven_key_seat_test.go` is a characterisation test. It pins current undesirable behaviour and
carries an explicit marker that it must be INVERTED, not deleted, when H-6 is re-enabled. It guards its
own premise and goes obsolete loudly.

Every test asserts its own precondition, because a scenario run against an inert system passes while
proving nothing. Two instrument lessons are baked in: `block_headers` is the halt instrument, since
`hive_blocks` is L1 ingestion and advances regardless of VSC quorum, so a halt test built on it can
never observe a halt; and a premise that cannot be established fails rather than skipping, because a
`t.Skipf` inside a passing parent hides a check that never ran.
