### PR TITLE
config: whitelist the LASSECASH/HBD pool

### DIFF
--- a/modules/common/system-config/system-config.go
+++ b/modules/common/system-config/system-config.go
@@ -300,6 +300,7 @@ func MainnetConfig() SystemConfig {
 		pendulumPoolWhitelist: []string{
 			"vsc1BoaniA5HW56GuQy6pVdoZfMcVaaDfnC8kp",
 			"vsc1BVb95YKRHAEy24XgRSaW4L6d9vB88AdwjM",
+			"vsc1BrBFAwZ3Mr8L4ijRqT9RPEPvhK9FWDaYSr", // LASSECASH/HBD
 		},
 	}
 	return conf


### PR DESCRIPTION
The LASSECASH/HBD pool is `contracts/dex` unmodified — code CID `bafkreiezp5u4v3ku7acibljcb46v2na4bkrngsoviym22f63cshhnpeydq` — initialised, seeded, and already registered on the router: `pool-hbd-lassecash` resolves to `vsc1BrBFAwZ3Mr8L4ijRqT9RPEPvhK9FWDaYSr` and `lassecash` is in the router's token list.

Swaps abort in the pendulum applier with `contract not whitelisted`, which is the only thing left.

Its state matches the two pools already on the list — `mv=4`, `fee=8`, reserves under `r0`/`r1`, router pointer set. The mapping contract is a standard `magi_token` (`vsc1BUDsVccMPGycTmpc98WsQYSKyTBsZqFq4h`) whose `getInfo` returns symbol `LASSECASH`, decimals 8. Add and remove liquidity already work, since they never reach the fee module.

No urgency at all — merge whenever it suits a release, or close this and add the line yourselves if you'd rather make that change in-house.
